### PR TITLE
Fix/wrk 13 utf8 windows

### DIFF
--- a/src/lattice/cli/demo_cmd.py
+++ b/src/lattice/cli/demo_cmd.py
@@ -1208,13 +1208,13 @@ def _seed_demo(target_dir: Path, quiet: bool = False) -> None:
 
     claude_md = target_dir / "CLAUDE.md"
     if not claude_md.exists():
-        claude_md.write_text(f"# The Lighthouse\n{composed_block}")
+        claude_md.write_text(f"# The Lighthouse\n{composed_block}", encoding="utf-8")
         if not quiet:
             click.echo("  CLAUDE.md        Claude Code integration")
 
     agents_md = target_dir / "agents.md"
     if not agents_md.exists():
-        agents_md.write_text(composed_block.lstrip("\n"))
+        agents_md.write_text(composed_block.lstrip("\n"), encoding="utf-8")
         if not quiet:
             click.echo("  agents.md        agent integration instructions")
 

--- a/src/lattice/cli/helpers.py
+++ b/src/lattice/cli/helpers.py
@@ -488,7 +488,7 @@ def check_plan_gate(
         )
 
     try:
-        content = plan_path.read_text()
+        content = plan_path.read_text(encoding="utf-8")
     except OSError:
         return  # Can't read → don't block (filesystem issue, not a planning issue)
 

--- a/src/lattice/cli/main.py
+++ b/src/lattice/cli/main.py
@@ -248,6 +248,13 @@ def _seed_example_tasks(lattice_dir: Path, config: dict) -> None:
 @click.pass_context
 def cli(ctx: click.Context) -> None:
     """Lattice: file-based, agent-native task tracker."""
+    # Windows UTF-8 guard: re-exec with -X utf8 if not already in UTF-8 mode
+    if sys.platform == "win32" and not sys.flags.utf8_mode:
+        import os
+
+        os.environ["PYTHONUTF8"] = "1"
+        os.execv(sys.executable, [sys.executable, "-X", "utf8"] + sys.argv)
+
     from lattice.update_check import maybe_print_update_notice
 
     ctx.call_on_close(maybe_print_update_notice)
@@ -822,16 +829,16 @@ def _create_or_update_agents_md(root: Path) -> None:
 
     try:
         if agents_md.exists():
-            content = agents_md.read_text()
+            content = agents_md.read_text(encoding="utf-8")
             if marker in content:
                 click.echo("  agents.md already has Lattice integration.")
                 return
             # Append to bottom
-            with open(agents_md, "a") as f:
+            with open(agents_md, "a", encoding="utf-8") as f:
                 f.write("\n" + composed_block)
             click.echo("  Updated agents.md with Lattice integration.")
         else:
-            agents_md.write_text(composed_block.lstrip("\n"))
+            agents_md.write_text(composed_block.lstrip("\n"), encoding="utf-8")
             click.echo("  Created agents.md with Lattice integration.")
     except OSError as e:
         click.echo(f"  Warning: could not update agents.md: {e}", err=True)
@@ -881,10 +888,10 @@ def _silent_update_claude_md(root: Path) -> None:
         return
 
     try:
-        content = claude_md.read_text()
+        content = claude_md.read_text(encoding="utf-8")
         if marker in content:
             return  # Already has it
-        with open(claude_md, "a") as f:
+        with open(claude_md, "a", encoding="utf-8") as f:
             f.write(composed_block)
         click.echo("  Updated CLAUDE.md with Lattice integration.")
     except OSError:
@@ -998,7 +1005,7 @@ def _offer_claude_md(root: Path, *, auto_accept: bool = False) -> None:
 
     try:
         if claude_md.exists():
-            content = claude_md.read_text()
+            content = claude_md.read_text(encoding="utf-8")
             if marker in content:
                 click.echo("  CLAUDE.md already has Lattice integration.")
                 return
@@ -1006,7 +1013,7 @@ def _offer_claude_md(root: Path, *, auto_accept: bool = False) -> None:
                 "Found CLAUDE.md \u2014 add Lattice agent integration?",
                 default=True,
             ):
-                with open(claude_md, "a") as f:
+                with open(claude_md, "a", encoding="utf-8") as f:
                     f.write(composed_block)
                 click.echo("  Updated CLAUDE.md with Lattice integration.")
         else:
@@ -1014,7 +1021,7 @@ def _offer_claude_md(root: Path, *, auto_accept: bool = False) -> None:
                 "Create CLAUDE.md with Lattice agent integration?",
                 default=True,
             ):
-                claude_md.write_text(f"# {root.name}\n{composed_block}")
+                claude_md.write_text(f"# {root.name}\n{composed_block}", encoding="utf-8")
                 click.echo("  Created CLAUDE.md with Lattice integration.")
     except (click.Abort, EOFError):
         # Non-interactive mode — skip CLAUDE.md prompt silently.
@@ -1137,7 +1144,7 @@ def setup_claude(target_path: str, force: bool) -> None:
     claude_md = root / "CLAUDE.md"
 
     if claude_md.exists():
-        content = claude_md.read_text()
+        content = claude_md.read_text(encoding="utf-8")
         if marker in content:
             if not force:
                 click.echo("CLAUDE.md already has Lattice integration. Use --force to replace.")
@@ -1164,14 +1171,14 @@ def setup_claude(target_path: str, force: bool) -> None:
                     new_lines.append(line)
             content = "\n".join(new_lines).rstrip("\n") + "\n"
             content += composed_block
-            claude_md.write_text(content)
+            claude_md.write_text(content, encoding="utf-8")
             click.echo("Updated Lattice integration in CLAUDE.md.")
         else:
-            with open(claude_md, "a") as f:
+            with open(claude_md, "a", encoding="utf-8") as f:
                 f.write(composed_block)
             click.echo("Added Lattice integration to CLAUDE.md.")
     else:
-        claude_md.write_text(f"# {root.name}\n{composed_block}")
+        claude_md.write_text(f"# {root.name}\n{composed_block}", encoding="utf-8")
         click.echo("Created CLAUDE.md with Lattice integration.")
 
 
@@ -1370,7 +1377,7 @@ def setup_prompt(use_claude_md: bool) -> None:
         skill_file = skill_src / "SKILL.md"
         if not skill_file.exists():
             raise click.ClickException("Bundled SKILL.md not found.")
-        click.echo(skill_file.read_text().strip())
+        click.echo(skill_file.read_text(encoding="utf-8").strip())
 
 
 # ---------------------------------------------------------------------------

--- a/src/lattice/cli/main.py
+++ b/src/lattice/cli/main.py
@@ -248,12 +248,15 @@ def _seed_example_tasks(lattice_dir: Path, config: dict) -> None:
 @click.pass_context
 def cli(ctx: click.Context) -> None:
     """Lattice: file-based, agent-native task tracker."""
-    # Windows UTF-8 guard: re-exec with -X utf8 if not already in UTF-8 mode
+    # Windows UTF-8 guard: re-exec with -X utf8 if not already in UTF-8 mode.
+    # os.execv is broken on Windows (spawns background process, loses exit code),
+    # so we use subprocess.call instead.
     if sys.platform == "win32" and not sys.flags.utf8_mode:
         import os
+        import subprocess
 
         os.environ["PYTHONUTF8"] = "1"
-        os.execv(sys.executable, [sys.executable, "-X", "utf8"] + sys.argv)
+        sys.exit(subprocess.call([sys.executable, "-X", "utf8"] + sys.argv))
 
     from lattice.update_check import maybe_print_update_notice
 

--- a/src/lattice/cli/query_cmds.py
+++ b/src/lattice/cli/query_cmds.py
@@ -626,7 +626,7 @@ def _read_plan_content_for_next(lattice_dir: Path, task_id: str) -> str | None:
     if not plan_path.exists():
         return None
     try:
-        content = plan_path.read_text()
+        content = plan_path.read_text(encoding="utf-8")
     except OSError:
         return None
     if _is_scaffold_plan_content(content):

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -841,7 +841,7 @@ def comment(
     if file_path is not None:
         from pathlib import Path
 
-        text = Path(file_path).read_text()
+        text = Path(file_path).read_text(encoding="utf-8")
 
     lattice_dir = require_root(is_json)
     config = load_project_config(lattice_dir)

--- a/src/lattice/mcp/resources.py
+++ b/src/lattice/mcp/resources.py
@@ -140,12 +140,12 @@ def resource_notes(task_id: str) -> str:
 
     notes_path = lattice_dir / "notes" / f"{task_id}.md"
     if notes_path.exists():
-        return notes_path.read_text()
+        return notes_path.read_text(encoding="utf-8")
 
     # Check archive
     archive_notes = lattice_dir / "archive" / "notes" / f"{task_id}.md"
     if archive_notes.exists():
-        return archive_notes.read_text()
+        return archive_notes.read_text(encoding="utf-8")
 
     raise ValueError(f"No notes file found for task {task_id}.")
 
@@ -158,11 +158,11 @@ def resource_plans(task_id: str) -> str:
 
     plan_path = lattice_dir / "plans" / f"{task_id}.md"
     if plan_path.exists():
-        return plan_path.read_text()
+        return plan_path.read_text(encoding="utf-8")
 
     # Check archive
     archive_plans = lattice_dir / "archive" / "plans" / f"{task_id}.md"
     if archive_plans.exists():
-        return archive_plans.read_text()
+        return archive_plans.read_text(encoding="utf-8")
 
     raise ValueError(f"No plan file found for task {task_id}.")

--- a/src/lattice/mcp/server.py
+++ b/src/lattice/mcp/server.py
@@ -17,6 +17,15 @@ import lattice.mcp.tools as _tools  # noqa: F401, E402
 
 def main() -> None:
     """Run the Lattice MCP server over stdio transport."""
+    import sys
+
+    # Windows UTF-8 guard: re-exec with -X utf8 if not already in UTF-8 mode
+    if sys.platform == "win32" and not sys.flags.utf8_mode:
+        import os
+
+        os.environ["PYTHONUTF8"] = "1"
+        os.execv(sys.executable, [sys.executable, "-X", "utf8"] + sys.argv)
+
     mcp.run(transport="stdio")
 
 

--- a/src/lattice/mcp/server.py
+++ b/src/lattice/mcp/server.py
@@ -19,12 +19,15 @@ def main() -> None:
     """Run the Lattice MCP server over stdio transport."""
     import sys
 
-    # Windows UTF-8 guard: re-exec with -X utf8 if not already in UTF-8 mode
+    # Windows UTF-8 guard: re-exec with -X utf8 if not already in UTF-8 mode.
+    # os.execv is broken on Windows (spawns background process, loses exit code),
+    # so we use subprocess.call instead.
     if sys.platform == "win32" and not sys.flags.utf8_mode:
         import os
+        import subprocess
 
         os.environ["PYTHONUTF8"] = "1"
-        os.execv(sys.executable, [sys.executable, "-X", "utf8"] + sys.argv)
+        sys.exit(subprocess.call([sys.executable, "-X", "utf8"] + sys.argv))
 
     mcp.run(transport="stdio")
 

--- a/src/lattice/storage/readers.py
+++ b/src/lattice/storage/readers.py
@@ -19,7 +19,7 @@ def read_task_events(lattice_dir: Path, task_id: str, *, is_archived: bool = Fal
     events: list[dict] = []
     if event_path.exists():
         try:
-            for line in event_path.read_text().splitlines():
+            for line in event_path.read_text(encoding="utf-8").splitlines():
                 line = line.strip()
                 if line:
                     try:


### PR DESCRIPTION
#6 Fixing this issue.

claude:
```
windows defaults to cp1252, Path.write_text() without explicit encoding crashes on → and friends. the defensive encoding="utf-8" additions are spot-on and uncontroversial.

  the entry point guard has a bug: os.execv on windows does NOT work like unix. windows can't replace the process image — instead it spawns a background child and exits the parent with code 0. this means:
  - exit codes are silently lost
  - the re-exec'd process runs in the BACKGROUND
  - control returns to the shell before lattice finishes

  the fix is to use subprocess.call on windows instead of os.execv:

  if sys.platform == "win32" and not sys.flags.utf8_mode:
      import os, subprocess
      os.environ["PYTHONUTF8"] = "1"
      sys.exit(subprocess.call([sys.executable, "-X", "utf8"] + sys.argv))

  the defensive encoding="utf-8" additions are actually the more important prong. they work unconditionally, no re-exec needed. the entry point guard is nice-to-have ergonomics for covering any callsites we missed.

  json calls are genuinely safe — json.dumps() defaults to ensure_ascii=True, so output is pure ascii. skipping those was correct.

  this whole issue goes away with python 3.15 (PEP 686 makes utf-8 the default), but that's ~2 version cycles away.
```


Hmm, I should reconsider whether the defensive encodings are really necessary. We'd need to document this decision. I'm going to make a note to remove that soon.