### PR TITLE
chore(config): default plan_review_mode to single (LAT-212)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,16 +234,16 @@ This is the **planning sub-agent's** job. Spawn a sub-agent whose sole purpose i
 
 **The test:** If you moved to `planned` and the plan file is still empty scaffold, you didn't plan. Every task gets a plan — even trivial tasks get a one-line plan. The CLI enforces this: transitioning to `in_progress` is blocked when the plan is still scaffold.
 
-**Plan review (default: trident).** After writing the plan, run `lattice plan-review <task>`. Check the project's mode:
+**Plan review (default: single).** After writing the plan, run `lattice plan-review <task>`. Check the project's mode:
 
 ```
-cat .lattice/config.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('plan_review_mode','triple'))"
+cat .lattice/config.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('plan_review_mode','single'))"
 ```
 
 | `plan_review_mode` value | What the planner does |
 |--------------------------|----------------------|
-| `triple` (default) | **Trident plan review** — spawns three agents (claude, codex, gemini) in parallel, merges their findings into one artifact |
-| `single` | Spawns one review agent |
+| `single` (default) | Spawns one review agent |
+| `triple` | **Trident plan review** — spawns three agents (claude, codex, gemini) in parallel, merges their findings into one artifact |
 | `inline` | Reviews the plan in-session (use when codex/gemini aren't available, or for small/throwaway projects) |
 
 When `plan_approval` is `human`, the CLI automatically moves the task to `needs_human` after `lattice plan-review` completes. Wait for human approval before proceeding to `in_progress`.
@@ -343,7 +343,7 @@ Three settings in `.lattice/config.json` control review behavior:
 | Setting | Values | Default | Meaning |
 |---------|--------|---------|---------|
 | `review_mode` | `inline`, `single`, `triple` | `single` | How code review is performed at the review gate |
-| `plan_review_mode` | `inline`, `single`, `triple` | `triple` | How plan review is performed after the plan is written |
+| `plan_review_mode` | `inline`, `single`, `triple` | `single` | How plan review is performed after the plan is written |
 | `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` moves to `needs_human` for approval |
 
 **`inline`** — review happens in the same agent session (no subprocess spawned).

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -215,7 +215,7 @@ def plan_review(
 
     # Resolve mode: CLI flag > config > default
     if mode is None:
-        mode = config.get("plan_review_mode", "inline")
+        mode = config.get("plan_review_mode", "single")
 
     # Read plan content (required regardless of mode)
     plan_path = lattice_dir / "plans" / f"{task_id}.md"

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -574,7 +574,7 @@ def compute_next_steps(
         }
 
     if new_status == "planned":
-        plan_review_mode = config.get("plan_review_mode", "inline")
+        plan_review_mode = config.get("plan_review_mode", "single")
         if plan_review_mode != "inline":
             hint = (
                 f"Next: run 'lattice plan-review {label}' "

--- a/src/lattice/core/config.py
+++ b/src/lattice/core/config.py
@@ -224,7 +224,7 @@ def default_config(preset: str = "classic") -> LatticeConfig:
         "workflow": workflow,
         "workflow_preset": preset,
         "review_mode": "single",
-        "plan_review_mode": "triple",
+        "plan_review_mode": "single",
         "plan_approval": "auto",
         "review_timeout_seconds": 600,
         "done_display": "grouped",

--- a/src/lattice/templates/claude_md_block.py
+++ b/src/lattice/templates/claude_md_block.py
@@ -93,16 +93,16 @@ This is the **planning sub-agent's** job. Spawn a sub-agent whose sole purpose i
 
 **The test:** If you moved to `planned` and the plan file is still empty scaffold, you didn't plan. Every task gets a plan — even trivial tasks get a one-line plan. The CLI enforces this: transitioning to `in_progress` is blocked when the plan is still scaffold.
 
-**Plan review (default: trident).** After writing the plan, run `lattice plan-review <task>`. Check the project's mode:
+**Plan review (default: single).** After writing the plan, run `lattice plan-review <task>`. Check the project's mode:
 
 ```
-cat .lattice/config.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('plan_review_mode','triple'))"
+cat .lattice/config.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('plan_review_mode','single'))"
 ```
 
 | `plan_review_mode` value | What the planner does |
 |--------------------------|----------------------|
-| `triple` (default) | **Trident plan review** — spawns three agents (claude, codex, gemini) in parallel, merges their findings into one artifact |
-| `single` | Spawns one review agent |
+| `single` (default) | Spawns one review agent |
+| `triple` | **Trident plan review** — spawns three agents (claude, codex, gemini) in parallel, merges their findings into one artifact |
 | `inline` | Reviews the plan in-session (use when codex/gemini aren't available, or for small/throwaway projects) |
 
 When `plan_approval` is `human`, the CLI automatically moves the task to `needs_human` after `lattice plan-review` completes. Wait for human approval before proceeding to `in_progress`.
@@ -202,7 +202,7 @@ Three settings in `.lattice/config.json` control review behavior:
 | Setting | Values | Default | Meaning |
 |---------|--------|---------|---------|
 | `review_mode` | `inline`, `single`, `triple` | `single` | How code review is performed at the review gate |
-| `plan_review_mode` | `inline`, `single`, `triple` | `triple` | How plan review is performed after the plan is written |
+| `plan_review_mode` | `inline`, `single`, `triple` | `single` | How plan review is performed after the plan is written |
 | `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` moves to `needs_human` for approval |
 
 **`inline`** — review happens in the same agent session (no subprocess spawned).

--- a/tests/test_cli/test_review_config.py
+++ b/tests/test_cli/test_review_config.py
@@ -20,7 +20,7 @@ class TestConfigDefaults:
         from lattice.core.config import default_config
 
         config = default_config()
-        assert config["plan_review_mode"] == "triple"
+        assert config["plan_review_mode"] == "single"
 
     def test_default_plan_approval(self):
         from lattice.core.config import default_config
@@ -56,7 +56,7 @@ class TestBackwardCompatibility:
         reloaded = json.loads((lattice_dir / "config.json").read_text())
         # Callers should treat missing keys as defaults
         assert reloaded.get("review_mode", "single") == "single"
-        assert reloaded.get("plan_review_mode", "triple") == "triple"
+        assert reloaded.get("plan_review_mode", "single") == "single"
         assert reloaded.get("plan_approval", "auto") == "auto"
 
 
@@ -144,7 +144,7 @@ class TestInitFlags:
         assert result.exit_code == 0, result.output
         config = json.loads((tmp_path / ".lattice" / "config.json").read_text())
         assert config["review_mode"] == "single"
-        assert config["plan_review_mode"] == "triple"
+        assert config["plan_review_mode"] == "single"
         assert config["plan_approval"] == "auto"
 
     def test_init_combined_review_flags(self, cli_runner, tmp_path):
@@ -170,7 +170,7 @@ class TestInitFlags:
         config = json.loads((tmp_path / ".lattice" / "config.json").read_text())
         assert config["review_mode"] == "triple"
         assert config["plan_approval"] == "human"
-        assert config["plan_review_mode"] == "triple"  # default preserved
+        assert config["plan_review_mode"] == "single"  # default preserved
 
     def test_init_scaffolds_templates_dir(self, cli_runner, tmp_path):
         from lattice.cli.main import cli


### PR DESCRIPTION
## Summary

- Change `plan_review_mode` init default from `triple` to `single` in `src/lattice/core/config.py`.
- Align the runtime fallback in `cli/task_cmds.py` and `cli/review_cmds.py` from `inline` to `single` so missing-key behavior matches init-time default.
- Update `CLAUDE.md` and the `lattice setup-claude` template (`claude_md_block.py`) to reflect the new default.

## Why

Triple plan-review (three agents + merger) is too heavy as a default — fine as opt-in for substantial work, but most plans don't need it. Pre-change, the init-time default was `triple` while the runtime fallback was `inline`, so older projects without the key silently ran in inline mode while new projects got triple. Both paths now converge on `single`.

Pairs with LAT-211 (auto-fire reviews on transitions). Once that lands, the new `single` default means the auto-fire spawns one review agent rather than three on every plan transition.

## Test plan

- [x] Full test suite passes (`uv run pytest`): 1730 tests, 0 failures.
- [x] `ruff check src/ tests/` clean.
- [x] Manual `lattice init` in a scratch directory produces `config.json` with `plan_review_mode: "single"`.
- [x] `TestBackwardCompatibility.test_missing_review_mode_uses_default` covers the missing-key fallback path.

Closes LAT-212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)