### PR TITLE
feat(LAT-211): auto-fire code-review and plan-review on status transitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,17 +234,15 @@ This is the **planning sub-agent's** job. Spawn a sub-agent whose sole purpose i
 
 **The test:** If you moved to `planned` and the plan file is still empty scaffold, you didn't plan. Every task gets a plan — even trivial tasks get a one-line plan. The CLI enforces this: transitioning to `in_progress` is blocked when the plan is still scaffold.
 
-**Plan review (default: single).** After writing the plan, run `lattice plan-review <task>`. Check the project's mode:
+**Plan review (default: single, fires automatically).** Moving the task to `planned` automatically spawns a detached `lattice plan-review <task>` in the background. The artifact lands when complete; tail progress with `lattice review-status <task>` or follow `.lattice/.daemon/auto-plan-review-<task>.log`. Disable per-call with `--no-auto-review` on `lattice status`, or project-wide with `auto_plan_review_on_transition: false` in `.lattice/config.json`. **If you opt into `plan_review_mode: triple`, every transition into `planned` spends three agent runs plus a merge by default — disable auto-fire or use `--no-auto-review` when cost matters.**
 
-```
-cat .lattice/config.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('plan_review_mode','single'))"
-```
+The mode still controls *how* the review runs:
 
 | `plan_review_mode` value | What the planner does |
 |--------------------------|----------------------|
 | `single` (default) | Spawns one review agent |
 | `triple` | **Trident plan review** — spawns three agents (claude, codex, gemini) in parallel, merges their findings into one artifact |
-| `inline` | Reviews the plan in-session (use when codex/gemini aren't available, or for small/throwaway projects) |
+| `inline` | Reviews the plan in-session (use when codex/gemini aren't available, or for small/throwaway projects). Auto-fire is a no-op for inline mode — there is no subprocess to spawn. |
 
 When `plan_approval` is `human`, the CLI automatically moves the task to `needs_human` after `lattice plan-review` completes. Wait for human approval before proceeding to `in_progress`.
 
@@ -266,6 +264,8 @@ Every finding must be explicitly triaged — no silent drops. If triage produces
 
 Moving to `review` is a commitment to actually review the work.
 
+**The review fires automatically by default.** When you transition the task to `review`, the CLI spawns a detached `lattice code-review <task>` in the background — the orchestrator does not need to remember to run it. Tail progress with `lattice review-status <task>` (covers both manual and auto-fired reviews) or follow `.lattice/.daemon/auto-code-review-<task>.log`. Disable per-call with `--no-auto-review` on `lattice status`, or project-wide with `auto_code_review_on_transition: false` in `.lattice/config.json`. **If `review_mode` is `triple`, every `→ review` transition (including rework cycles) spends three agent runs by default.**
+
 This is the **review sub-agent's** job. Spawn a sub-agent with fresh context — it did NOT write the code and comes in cold.
 
 **Step 1: Check review_mode.** Before reviewing, check the project config:
@@ -276,16 +276,16 @@ cat .lattice/config.json | python3 -c "import sys,json; d=json.load(sys.stdin); 
 
 | `review_mode` value | What the reviewer does |
 |---------------------|----------------------|
-| `inline` | Review the diff yourself in-session. Run `lattice code-review <task> --mode inline` to acknowledge. |
-| `single` (default) | Run `lattice code-review <task>` — spawns one review agent, stores artifact |
-| `triple` | Run `lattice code-review <task>` — spawns three agents + merge, stores artifacts |
+| `inline` | Review the diff yourself in-session. Run `lattice code-review <task> --mode inline` to acknowledge. (Auto-fire is a no-op for inline.) |
+| `single` (default) | Auto-fire on `→ review` spawns one review agent + stores artifact. Same end-state as `lattice code-review <task>` run manually. |
+| `triple` | Auto-fire spawns three agents + merge, stores artifacts. Same end-state as `lattice code-review <task>` run manually. |
 
 **Step 2: Perform the review.** The review sub-agent should:
 1. Read the plan file to understand what was supposed to be built.
 2. Read the git diff to see what was actually built.
 3. Run tests and linting to verify nothing is broken.
 4. Compare the implementation against the plan's acceptance criteria.
-5. Call `lattice code-review <task>` (or review inline if mode is `inline`).
+5. Use the artifact produced by the auto-fired review (or run `lattice code-review <task>` manually if you opted out / are inline).
 
 **When moving to `done`:** If the completion policy blocks you for a missing review artifact, do the review. Do not `--force` past it. `--force --reason` is for genuinely exceptional cases, not a convenience shortcut.
 
@@ -338,17 +338,30 @@ Max cycles:   3 review->rework transitions, then CLI blocks -> needs_human
 
 ### Review Config Reference
 
-Three settings in `.lattice/config.json` control review behavior:
+Five settings in `.lattice/config.json` control review behavior:
 
 | Setting | Values | Default | Meaning |
 |---------|--------|---------|---------|
 | `review_mode` | `inline`, `single`, `triple` | `single` | How code review is performed at the review gate |
 | `plan_review_mode` | `inline`, `single`, `triple` | `single` | How plan review is performed after the plan is written |
 | `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` moves to `needs_human` for approval |
+| `auto_code_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice code-review` when a task transitions to `review` |
+| `auto_plan_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice plan-review` when a task transitions to `planned` |
 
 **`inline`** — review happens in the same agent session (no subprocess spawned).
 **`single`** — one review agent is spawned; result stored as a `review` or `plan-review` artifact.
 **`triple`** — three agents (claude, codex, gemini) run in parallel; individual results stored as `review-individual` artifacts; a merged result stored as `review` or `plan-review`.
+
+### Auto-fire Conventions (LAT-211)
+
+When a task transitions to `review` or `planned`, `lattice status` automatically spawns a detached `lattice code-review` / `plan-review` subprocess in a new session. The transition itself never blocks on the spawn — if discovery or `Popen` fails, the status change still lands and a warning is logged.
+
+- **Coordination** lives in `.lattice/review_state/<task_id>.json`. The schema gains optional `started_by_pid` (the PID currently responsible for the in-flight review) and `auto_fired` (true when the auto-fire path created the record). First-writer-wins; existing readers ignore unknown fields. The audit-trail signal that "this review was auto-fired" lives in the `auto_review_spawned` event, not in `review_state` (which is transient).
+- **Logs** land at `.lattice/.daemon/auto-{code,plan}-review-<task_id>.log`. One file per task per gate type; **overwritten on each new spawn**, so when a task cycles through `→ review` more than once, only the latest attempt is on disk. The header line records the spawn timestamp.
+- **Monitor** with `lattice review-status <task_id>` (covers both manual and auto-fired reviews) or by tailing the log file.
+- **Audit** via the `auto_review_spawned` event in the per-task event log. Includes `review_type`, `mode`, `log_path`, `spawned_at`, `pid` (debug aid only — short-lived), and `trigger_status_event_id`. The event is emitted only when a spawn actually succeeded; skip reasons (inline / disabled / opted-out / already in flight) surface in CLI output and `--json` instead.
+- **Per-call opt-out**: `lattice status <task> review --no-auto-review`. Useful when you want to step in manually for a specific transition without changing config.
+- **Project-wide opt-out**: set `auto_code_review_on_transition: false` and/or `auto_plan_review_on_transition: false` in `.lattice/config.json`. The status command falls back to today's hint-only output.
 
 ### When You're Stuck
 

--- a/Decisions.md
+++ b/Decisions.md
@@ -752,6 +752,34 @@ Additionally, `lattice advance N` processed multiple tasks in a single context w
 
 ---
 
+## 45. Reviews fire automatically on status transitions (LAT-211)
+
+**Date:** 2026-05-06
+**Status:** Accepted
+
+**Context:** Review discipline depended on the orchestrator agent remembering to run `lattice code-review <task>` (or `lattice plan-review`) at the right moment. In practice agents skipped the step on rework loops, after multi-pane handoffs, or when an interrupted session resumed mid-cycle. The review gate became a convention rather than a structural property of the workflow.
+
+**Decision:** `lattice status <id> review` and `lattice status <id> planned` now automatically spawn a detached `lattice code-review` / `plan-review` subprocess in a new session. Two new config keys gate the behavior — `auto_code_review_on_transition` and `auto_plan_review_on_transition`, both default `true`. Per-call opt-out via `--no-auto-review` on `lattice status`.
+
+**Implementation notes:**
+- **Module split.** Pure gating (`should_auto_fire`, `format_skip_reason`, constants) lives in `core/auto_review.py`; the side-effecting bits (executable discovery, `Popen`, log file open, `review_state` claim) live in `cli/auto_review.py`. This honors the project's `core/` (no filesystem) vs `cli/` (wires Click + side effects) layer convention.
+- **Coordination via `review_state`.** The existing `core.review.review_state` primitive is the single source of truth for "is a review in flight?". Schema gains optional `started_by_pid` and `auto_fired` fields; existing readers ignore unknown fields, so the change is forward-compatible. Synchronous parent-side claim before `Popen` closes the original "lockfile race" down to microseconds. The audit-trail signal that "this review was auto-fired" lives in the `auto_review_spawned` event, not in `review_state` (transient coordination state).
+- **`agent_spawn` is the wrong abstraction.** `core.agent_spawn` (LAT-205) is the primitive for spawning AI agent CLIs (`claude`/`codex`/`gemini`); for spawning the `lattice` CLI itself as a detached background process the right primitive is direct `subprocess.Popen` with `start_new_session=True` (mirrors the dashboard launcher at `cli/main.py:983-994`). The spawned `lattice code-review` uses `agent_spawn` internally, so the ticket's intent (no new agent-spawning plumbing) is preserved transitively.
+- **`auto_review_spawned` event** registered in `BUILTIN_EVENT_TYPES` and `_NOOP_EVENT_TYPES` (it logs the audit trail; the eventual review artifact, not this event, mutates the snapshot). Emitted only when a spawn actually succeeded — skip reasons surface in CLI output / `--json` instead.
+- **Logs at `.lattice/.daemon/auto-{code,plan}-review-<task_id>.log`**, overwritten per spawn. Bounded disk usage; latest-only is sufficient for debugging.
+
+**Cost-of-ownership:** With `triple` review modes (the default for `plan_review_mode`), every transition into `review` or `planned` now spends three agent runs by default plus a merge run. Operators on cost-sensitive projects should disable per-project or use `--no-auto-review`. This is surfaced in `CLAUDE.md`, `templates/claude_md_block.py`, and `docs/user-guide.md` so it's the first thing operators see.
+
+**Consequences:**
+- New `.lattice/.daemon/` directory for per-task log files (created lazily on first spawn, never garbage-collected).
+- New built-in event `auto_review_spawned` (per-task; not lifecycle).
+- `review_state` schema gains `started_by_pid` and `auto_fired` fields (forward-compatible).
+- `lattice review-status <id>` now displays `auto_fired` and `started_by_pid` when present, covering manual and auto-fired reviews uniformly.
+- Manual `lattice code-review` / `plan-review` commands now claim `review_state` at entry — refusing with a friendly "review already in flight" message when a different live PID holds the slot.
+- Multi-machine semantics deferred to LAT-209 (cross-machine `review_state` coordination requires the LAT-209 sync layer to mediate).
+
+---
+
 ## Note: This file is append-only
 
 `Decisions.md` is an append-only log. Entries are never edited or deleted after recording. Superseded decisions are noted inline with a reference to the superseding entry. Cross-cutting architectural decisions go here; task-scoped design decisions belong in the plan file (`.lattice/plans/<task_id>.md`).

--- a/docs/integration-claude-code.md
+++ b/docs/integration-claude-code.md
@@ -111,7 +111,7 @@ That's it. One command teaches the agent the full lifecycle. Here's what happens
 3. The agent does the work — writes code, runs tests, iterates
 4. The agent commits the changes
 5. The agent leaves a comment explaining what it did and why
-6. The agent moves the task to `review` (or `needs_human` if it hit a decision point)
+6. The agent moves the task to `review` — Lattice automatically spawns the review subprocess in the background; the agent does not need to remember to run `lattice code-review` itself. Tail with `lattice review-status <task>` or follow the artifact when it lands. (Or moves to `needs_human` if it hit a decision point.)
 7. The agent reports back to you with a summary
 
 ### Step 3: Come back to a sorted inbox

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -202,6 +202,31 @@ this is. asynchronous collaboration. across species. and it works.
 
 ---
 
+## reviews fire themselves
+
+when an agent moves a task to `planned` or `review`, Lattice does not wait for someone to remember to run the review — it spawns the right review subprocess in the background, immediately and detached. by the time the agent reads the next instruction the review is already in flight.
+
+the rules are simple:
+
+- `planned` → spawns `lattice plan-review <task>` (default mode: `triple` — three agents in parallel + a merge)
+- `review` → spawns `lattice code-review <task>` (default mode: `single`)
+
+monitor any in-flight review with `lattice review-status <task>`. logs land at `.lattice/.daemon/auto-{plan,code}-review-<task>.log` (one file per task per gate, overwritten on each new spawn). every spawn appends an `auto_review_spawned` event to the task's event log so the audit trail stays complete.
+
+opt out for a single transition with `--no-auto-review`:
+
+```bash
+lattice status TASK review --actor agent:me --no-auto-review
+```
+
+opt out project-wide by setting `auto_code_review_on_transition: false` and/or `auto_plan_review_on_transition: false` in `.lattice/config.json`. both default to `true`.
+
+**cost-of-ownership note.** auto-fire on `triple` mode multiplies API spend: every transition into `review` (or `planned`, where `triple` is the default) spends three agent runs plus a merge run. for a project that cycles through review more than once per ticket, this can add up quickly. if cost matters, disable per-project or use `--no-auto-review` for surgical transitions.
+
+if the spawn fails (no `lattice` on PATH, OS kill the fork, etc.), the status transition still succeeds — auto-fire is enhancement, never gating. a warning is logged and the CLI prints a skip-reason note like `auto-review skipped (executable not found on PATH)`.
+
+---
+
 ## how it works under the hood
 
 you don't need to understand this to use Lattice. but knowing the shape of the machine helps you trust it. and trust. is everything.

--- a/docs/user-reference.md
+++ b/docs/user-reference.md
@@ -209,6 +209,28 @@ High-stakes changes get multiple perspectives. Launch review agents from differe
 
 Three models surface issues no single model catches alone. The synthesis separates high-confidence findings (flagged by multiple reviewers) from observations that need your judgment.
 
+### Auto-fire on status transitions
+
+Transitioning a task to `review` or `planned` automatically spawns the matching review subprocess in the background:
+
+| Transition | What fires | Default mode |
+|------------|------------|--------------|
+| `→ review` | `lattice code-review <task>` (detached) | `review_mode` (default `single`) |
+| `→ planned` | `lattice plan-review <task>` (detached) | `plan_review_mode` (default `triple`) |
+
+Both default to enabled. Disable via:
+
+- `--no-auto-review` on `lattice status` (per-call opt-out).
+- `auto_code_review_on_transition: false` and/or `auto_plan_review_on_transition: false` in `.lattice/config.json` (project-wide).
+
+Coordination piggybacks on the existing `review_state/<task_id>.json` primitive — first-writer-wins. If a review is already in flight from a manual `lattice code-review` (or another auto-fire on a different machine), the second auto-fire is a no-op and reports `auto-review skipped (review already in flight, pid …)`.
+
+Logs land at `.lattice/.daemon/auto-{code,plan}-review-<task_id>.log` (overwritten per spawn). Every successful spawn appends an `auto_review_spawned` event to the task's event log with the review type, mode, log path, spawned-at timestamp, child PID (debug aid only), and the triggering `status_changed` event ID.
+
+Spawn failures (no `lattice` on PATH, OS forbids fork) never block the status transition — the change still lands and a warning is logged. Auto-fire is enhancement, never gating.
+
+**Cost-of-ownership.** With `triple` mode (the default for `plan_review_mode`), every transition into `planned` or `review` spends three agent runs plus a merge run. For projects where API spend matters, set the config keys to `false` or use `--no-auto-review` for surgical transitions.
+
 ### The taste-to-code pipeline
 
 Human taste compounds when captured structurally:

--- a/src/lattice/cli/auto_review.py
+++ b/src/lattice/cli/auto_review.py
@@ -1,0 +1,236 @@
+"""Side-effect layer for auto-firing reviews on status transitions (LAT-211).
+
+This module owns everything the pure :mod:`lattice.core.auto_review` does
+*not*: locating the ``lattice`` executable, claiming the in-flight review
+slot via :func:`lattice.core.review.claim_review_state`, opening the log
+file, and spawning the detached subprocess. It is callable from the Click
+``status_cmd`` and returns a result dict describing what happened — never
+raises so the cardinal property of ``status_cmd`` is preserved (auto-fire
+must never block a status transition).
+
+See LAT-211 plan §4 (wiring) and §5 (coordination) for the design.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from lattice.core.auto_review import (
+    AUTO_REVIEW_ACTOR,
+    DAEMON_DIR_NAME,
+    resolve_mode,
+    review_type_for_status,
+    should_auto_fire,
+)
+from lattice.core.review import claim_review_state
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Executable discovery
+# ---------------------------------------------------------------------------
+
+
+def find_lattice_executable() -> str | None:
+    """Return the absolute path to the ``lattice`` CLI binary, or None.
+
+    Prefers ``$PATH`` (``shutil.which``).  Falls back to the directory
+    containing the current Python interpreter (covers the common
+    ``uv tool install`` layout where ``lattice`` lives next to ``python``).
+    Mirrors the discovery code at :func:`lattice.cli.main.open_in_browser`
+    so behavior stays consistent with the existing dashboard launcher.
+    """
+    found = shutil.which("lattice")
+    if found:
+        return found
+    candidate = Path(sys.executable).parent / "lattice"
+    if candidate.exists():
+        return str(candidate)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Log path
+# ---------------------------------------------------------------------------
+
+
+def log_path_for(lattice_dir: Path, review_type: str, task_id: str) -> Path:
+    """Return the per-task log path for an auto-fired review.
+
+    Path shape: ``.lattice/.daemon/auto-{review_type}-{task_id}.log``.
+    Overwritten per spawn — debug aid only, not an audit trail.
+    """
+    return lattice_dir / DAEMON_DIR_NAME / f"auto-{review_type}-{task_id}.log"
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def auto_fire_review(
+    lattice_dir: Path,
+    task_id: str,
+    new_status: str,
+    *,
+    status_event_id: str,
+    config: dict,
+    no_auto_review_flag: bool,
+) -> dict:
+    """Spawn a detached ``lattice {code,plan}-review`` if gating allows.
+
+    The function is structured to swallow all errors internally and return
+    a result dict.  Callers (``status_cmd``) wrap it in a defensive
+    ``try/except`` regardless, but in practice this returns rather than
+    raising on every code path.
+
+    Result dict shapes:
+
+    * On success::
+
+        {
+            "fired": True,
+            "review_type": "code-review" | "plan-review",
+            "mode": "single" | "triple",
+            "log_path": "<absolute path>",
+            "pid": <child PID>,
+            "spawned_at": "<RFC3339 UTC>",
+        }
+
+    * On skip / failure::
+
+        {
+            "fired": False,
+            "reason": "<stable code>",
+            # plus optional details: holder_pid, holder_auto_fired, etc.
+        }
+    """
+    fire, skip_reason = should_auto_fire(
+        config,
+        new_status,
+        no_auto_review_flag=no_auto_review_flag,
+    )
+    if not fire:
+        assert skip_reason is not None
+        return {"fired": False, "reason": skip_reason}
+
+    review_type = review_type_for_status(new_status)
+    if review_type is None:
+        # ``should_auto_fire`` already excludes non-gate statuses; this
+        # branch is defensive — keeps the type-checker happy and guards
+        # against future drift.
+        return {"fired": False, "reason": "not_a_review_gate"}
+
+    mode = resolve_mode(config, new_status)
+
+    # Synchronous parent-side claim — see LAT-211 §5.
+    claimed, existing = claim_review_state(
+        lattice_dir,
+        task_id,
+        mode=mode,
+        review_type=review_type,
+        started_by_pid=os.getpid(),
+        auto_fired=True,
+    )
+    if not claimed:
+        result: dict = {
+            "fired": False,
+            "reason": "review_in_flight",
+        }
+        if isinstance(existing, dict):
+            holder = existing.get("started_by_pid")
+            if isinstance(holder, int):
+                result["holder_pid"] = holder
+            holder_auto = existing.get("auto_fired")
+            if isinstance(holder_auto, bool):
+                result["holder_auto_fired"] = holder_auto
+        return result
+
+    lattice_bin = find_lattice_executable()
+    if lattice_bin is None:
+        # Release the claim so a manual retry isn't blocked by our
+        # phantom record.  Best effort — failures here are silently
+        # ignored because we're already on the failure path.
+        try:
+            from lattice.core.review import clear_review_state
+
+            clear_review_state(lattice_dir, task_id)
+        except Exception:  # noqa: BLE001 — best effort cleanup
+            logger.debug("clear_review_state failed during executable lookup miss", exc_info=True)
+        return {"fired": False, "reason": "executable_not_found"}
+
+    log_path = log_path_for(lattice_dir, review_type, task_id)
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        try:
+            from lattice.core.review import clear_review_state
+
+            clear_review_state(lattice_dir, task_id)
+        except Exception:  # noqa: BLE001
+            logger.debug("clear_review_state failed during mkdir failure", exc_info=True)
+        return {"fired": False, "reason": f"spawn_failed:{exc}"}
+
+    spawned_at = _now_iso()
+    cmd = [
+        lattice_bin,
+        review_type,
+        task_id,
+        "--actor",
+        AUTO_REVIEW_ACTOR,
+        "--triggered-by",
+        status_event_id,
+    ]
+
+    log_fh = None
+    try:
+        log_fh = open(log_path, "w", encoding="utf-8")
+        log_fh.write(f"# auto-{review_type} for {task_id} started {spawned_at}\n")
+        log_fh.flush()
+
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(lattice_dir.parent),
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as exc:  # noqa: BLE001 — return the failure cleanly
+        try:
+            from lattice.core.review import clear_review_state
+
+            clear_review_state(lattice_dir, task_id)
+        except Exception:  # noqa: BLE001
+            logger.debug("clear_review_state failed during Popen failure", exc_info=True)
+        return {"fired": False, "reason": f"spawn_failed:{exc}"}
+    finally:
+        # The child holds its own dup of the log fd.  Close the parent's
+        # copy immediately to avoid a leaked descriptor — important if
+        # this helper ever runs from a longer-lived caller (the daemon
+        # path or plugins).
+        if log_fh is not None:
+            try:
+                log_fh.close()
+            except OSError:
+                logger.debug("log fd close raised", exc_info=True)
+
+    return {
+        "fired": True,
+        "review_type": review_type,
+        "mode": mode,
+        "log_path": str(log_path),
+        "pid": proc.pid,
+        "spawned_at": spawned_at,
+    }
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/src/lattice/cli/auto_review.py
+++ b/src/lattice/cli/auto_review.py
@@ -28,7 +28,7 @@ from lattice.core.auto_review import (
     review_type_for_status,
     should_auto_fire,
 )
-from lattice.core.review import claim_review_state
+from lattice.core.review import claim_review_state, clear_review_state
 
 logger = logging.getLogger(__name__)
 
@@ -159,8 +159,6 @@ def auto_fire_review(
         # phantom record.  Best effort — failures here are silently
         # ignored because we're already on the failure path.
         try:
-            from lattice.core.review import clear_review_state
-
             clear_review_state(lattice_dir, task_id)
         except Exception:  # noqa: BLE001 — best effort cleanup
             logger.debug("clear_review_state failed during executable lookup miss", exc_info=True)
@@ -171,8 +169,6 @@ def auto_fire_review(
         log_path.parent.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
         try:
-            from lattice.core.review import clear_review_state
-
             clear_review_state(lattice_dir, task_id)
         except Exception:  # noqa: BLE001
             logger.debug("clear_review_state failed during mkdir failure", exc_info=True)
@@ -205,11 +201,16 @@ def auto_fire_review(
         )
     except Exception as exc:  # noqa: BLE001 — return the failure cleanly
         try:
-            from lattice.core.review import clear_review_state
-
             clear_review_state(lattice_dir, task_id)
         except Exception:  # noqa: BLE001
             logger.debug("clear_review_state failed during Popen failure", exc_info=True)
+        # An empty header file may have been written before Popen raised;
+        # remove it so future debug spelunkers don't read it as "a review
+        # spawned and produced nothing."
+        try:
+            log_path.unlink(missing_ok=True)
+        except OSError:
+            logger.debug("log_path.unlink failed during Popen failure", exc_info=True)
         return {"fired": False, "reason": f"spawn_failed:{exc}"}
     finally:
         # The child holds its own dup of the log fd.  Close the parent's

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import tempfile
 from datetime import datetime, timezone
@@ -22,14 +23,98 @@ from lattice.cli.helpers import (
 )
 from lattice.cli.main import cli
 from lattice.core.review import (
+    claim_review_state,
     cleanup_temp_files,
     read_review_state,
     run_merge_agent,
     run_single_review,
     run_triple_review,
     resolve_diff,
+    write_review_state,
 )
 from lattice.templates import load_review_template
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _claim_or_refuse(
+    lattice_dir: Path,
+    task_id: str,
+    *,
+    mode: str,
+    review_type: str,
+    triggered_by: str | None,
+    is_json: bool,
+) -> None:
+    """Claim ``review_state`` for this review subprocess, or exit with a clear error.
+
+    Implements the LAT-211 plan-review finding 3 ordering: read existing
+    state *before* calling :func:`claim_review_state`. If the existing
+    record names a parent that auto-fired this review (``auto_fired=True``
+    AND ``started_by_pid == os.getppid()``) and ``--triggered-by`` was
+    set, write a new record directly with ``auto_fired=True`` and our PID
+    — bypassing the live-other-PID refusal that would otherwise fire,
+    because the "other" PID is our spawning parent.
+
+    Otherwise call ``claim_review_state(..., auto_fired=False)``: the
+    standard stale-PID reclaim handles the typical case (parent exited
+    before child reached this point), and the live-other-PID refusal
+    handles real contention.
+
+    Logs the friendly "review already in flight" message and exits 1
+    (or returns the structured error for ``--json``) on contention.
+    """
+    existing = read_review_state(lattice_dir, task_id)
+    if (
+        triggered_by is not None
+        and isinstance(existing, dict)
+        and existing.get("auto_fired") is True
+        and isinstance(existing.get("started_by_pid"), int)
+        and existing["started_by_pid"] == os.getppid()
+    ):
+        adopted: dict[str, Any] = {
+            "task_id": task_id,
+            "mode": mode,
+            "review_type": review_type,
+            "started_at": _now_iso(),
+            "started_by_pid": os.getpid(),
+            "auto_fired": True,
+            "agents": [],
+        }
+        write_review_state(lattice_dir, adopted)
+        return
+
+    claimed, holder = claim_review_state(
+        lattice_dir,
+        task_id,
+        mode=mode,
+        review_type=review_type,
+        started_by_pid=os.getpid(),
+        auto_fired=False,
+    )
+    if claimed:
+        return
+
+    holder = holder or {}
+    holder_pid = holder.get("started_by_pid")
+    holder_started = holder.get("started_at")
+    holder_auto = holder.get("auto_fired")
+    holder_review_type = holder.get("review_type") or review_type
+    log_hint = ""
+    daemon_log = lattice_dir / ".daemon" / f"auto-{holder_review_type}-{task_id}.log"
+    if daemon_log.exists():
+        log_hint = f"\n  log: {daemon_log}"
+    msg = (
+        f"A review is already in flight for this task "
+        f"(pid {holder_pid}, started {holder_started}, "
+        f"auto_fired={holder_auto}).  "
+        f"Use 'lattice review-status {task_id}' to monitor, "
+        f"or wait for it to complete."
+        f"{log_hint}"
+    )
+    output_error(msg, "REVIEW_IN_FLIGHT", is_json)
 
 
 # ---------------------------------------------------------------------------
@@ -86,7 +171,29 @@ def code_review(
     if mode is None:
         mode = config.get("review_mode", "single")
 
+    # Inline-mode contention check: even though inline never claims, refuse
+    # if a non-inline review is in flight so the operator doesn't run two
+    # reviews in parallel by accident.
     if mode == "inline":
+        existing = read_review_state(lattice_dir, task_id)
+        if isinstance(existing, dict):
+            from lattice.core.review import _pid_alive
+
+            holder_pid = existing.get("started_by_pid")
+            if (
+                isinstance(holder_pid, int)
+                and holder_pid != os.getpid()
+                and _pid_alive(holder_pid)
+            ):
+                output_error(
+                    (
+                        "A review is already in flight for this task "
+                        f"(pid {holder_pid}, started {existing.get('started_at')}, "
+                        f"auto_fired={existing.get('auto_fired')})."
+                    ),
+                    "REVIEW_IN_FLIGHT",
+                    is_json,
+                )
         display_id = snapshot.get("short_id") or task_id
         msg = (
             f"[code-review] Mode is 'inline' — review is happening in-session.\n"
@@ -101,6 +208,17 @@ def code_review(
         return
 
     actor = require_actor(is_json)
+
+    # Claim the in-flight slot (or adopt the parent's claim when this is
+    # an auto-fired child invoked with --triggered-by).
+    _claim_or_refuse(
+        lattice_dir,
+        task_id,
+        mode=mode,
+        review_type="code-review",
+        triggered_by=triggered_by,
+        is_json=is_json,
+    )
 
     # Resolve diff
     success, diff_or_err = resolve_diff(lattice_dir, task_id, snapshot, base=base)
@@ -228,6 +346,25 @@ def plan_review(
     plan_content = plan_path.read_text(encoding="utf-8")
 
     if mode == "inline":
+        existing = read_review_state(lattice_dir, task_id)
+        if isinstance(existing, dict):
+            from lattice.core.review import _pid_alive
+
+            holder_pid = existing.get("started_by_pid")
+            if (
+                isinstance(holder_pid, int)
+                and holder_pid != os.getpid()
+                and _pid_alive(holder_pid)
+            ):
+                output_error(
+                    (
+                        "A review is already in flight for this task "
+                        f"(pid {holder_pid}, started {existing.get('started_at')}, "
+                        f"auto_fired={existing.get('auto_fired')})."
+                    ),
+                    "REVIEW_IN_FLIGHT",
+                    is_json,
+                )
         display_id = snapshot.get("short_id") or task_id
         msg = (
             f"[plan-review] Mode is 'inline' — review is happening in-session.\n"
@@ -242,6 +379,15 @@ def plan_review(
         return
 
     actor = require_actor(is_json)
+
+    _claim_or_refuse(
+        lattice_dir,
+        task_id,
+        mode=mode,
+        review_type="plan-review",
+        triggered_by=triggered_by,
+        is_json=is_json,
+    )
 
     # Load and fill plan review template
     template = load_review_template(lattice_dir, "plan-review")
@@ -349,6 +495,15 @@ def review_status(task_id: str, output_json: bool) -> None:
     click.echo(f"  review_type:  {state.get('review_type', '?')}")
     click.echo(f"  started_at:   {state.get('started_at', '?')}")
     click.echo(f"  elapsed:      {overall_elapsed}")
+    if "auto_fired" in state:
+        pid_part = (
+            f" (started_by_pid {state['started_by_pid']})"
+            if isinstance(state.get("started_by_pid"), int)
+            else ""
+        )
+        click.echo(f"  auto_fired:   {state['auto_fired']}{pid_part}")
+    elif isinstance(state.get("started_by_pid"), int):
+        click.echo(f"  started_by_pid: {state['started_by_pid']}")
     agents = state.get("agents", [])
     if agents:
         click.echo("  agents:")

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -554,13 +554,20 @@ def compute_next_steps(
     lattice_dir: object,  # Path
     *,
     display_id: str | None = None,
+    auto_review_result: dict | None = None,
 ) -> tuple[str | None, dict | None]:
     """Return (human_hint, structured_dict) for the given status transition.
 
     Both may be ``None`` when no hint applies.  *display_id* is the short ID
     (e.g. ``LAT-42``) used in human-readable hints; falls back to *task_id*.
+    *auto_review_result*, when present, is the dict returned by
+    :func:`lattice.cli.auto_review.auto_fire_review`; the hint shifts to
+    "auto-firing" when ``fired=True`` and appends a skip-reason note when
+    ``fired=False``.
     """
     from pathlib import Path
+
+    from lattice.core.auto_review import format_skip_reason
 
     lattice_dir = Path(lattice_dir)
     label = display_id or task_id
@@ -575,11 +582,33 @@ def compute_next_steps(
 
     if new_status == "planned":
         plan_review_mode = config.get("plan_review_mode", "single")
+        if auto_review_result and auto_review_result.get("fired"):
+            hint = (
+                f"Auto-firing plan-review (pid {auto_review_result['pid']}, "
+                f"plan_review_mode: {auto_review_result['mode']}). "
+                f"Tail: lattice review-status {label}."
+            )
+            return hint, {
+                "action": "plan_review_auto_fired",
+                "pid": auto_review_result["pid"],
+                "mode": auto_review_result["mode"],
+                "log_path": auto_review_result["log_path"],
+                "then": "in_progress",
+            }
         if plan_review_mode != "inline":
             hint = (
                 f"Next: run 'lattice plan-review {label}' "
                 f"(plan_review_mode: {plan_review_mode}) before moving to in_progress."
             )
+            if auto_review_result and not auto_review_result.get("fired"):
+                hint += (
+                    " ("
+                    + format_skip_reason(
+                        auto_review_result.get("reason", "unknown"),
+                        holder_pid=auto_review_result.get("holder_pid"),
+                    )
+                    + ")"
+                )
             return hint, {
                 "action": "plan_review",
                 "command": f"lattice plan-review {label}",
@@ -594,10 +623,32 @@ def compute_next_steps(
 
     if new_status == "review":
         review_mode = config.get("review_mode", "single")
+        if auto_review_result and auto_review_result.get("fired"):
+            hint = (
+                f"Auto-firing code-review (pid {auto_review_result['pid']}, "
+                f"review_mode: {auto_review_result['mode']}). "
+                f"Tail: lattice review-status {label}."
+            )
+            return hint, {
+                "action": "code_review_auto_fired",
+                "pid": auto_review_result["pid"],
+                "mode": auto_review_result["mode"],
+                "log_path": auto_review_result["log_path"],
+                "then": "done",
+            }
         hint = (
             f"Next: run 'lattice code-review {label}' "
             f"(review_mode: {review_mode}) before opening the PR."
         )
+        if auto_review_result and not auto_review_result.get("fired"):
+            hint += (
+                " ("
+                + format_skip_reason(
+                    auto_review_result.get("reason", "unknown"),
+                    holder_pid=auto_review_result.get("holder_pid"),
+                )
+                + ")"
+            )
         return hint, {
             "action": "code_review",
             "command": f"lattice code-review {label}",
@@ -680,11 +731,20 @@ def _append_plan_reset_section(
 @click.argument("task_id")
 @click.argument("new_status")
 @click.option("--force", is_flag=True, help="Force an invalid transition.")
+@click.option(
+    "--no-auto-review",
+    is_flag=True,
+    help=(
+        "Skip auto-firing code-review/plan-review on transitions to "
+        "review/planned (per-invocation opt-out)."
+    ),
+)
 @common_options
 def status_cmd(
     task_id: str,
     new_status: str,
     force: bool,
+    no_auto_review: bool,
     model: str | None,
     session: str | None,
     output_json: bool,
@@ -875,6 +935,68 @@ def status_cmd(
     if cmux_available():
         on_status_changed(updated_snapshot, current_status, new_status)
 
+    # Auto-fire review/plan-review on transitions to review/planned (LAT-211).
+    # Wrapped defensively: a spawn failure must NEVER block the status
+    # transition. The status_changed event is already durable above.
+    auto_review_result: dict | None = None
+    if new_status in ("review", "planned"):
+        try:
+            from lattice.cli.auto_review import auto_fire_review
+
+            auto_review_result = auto_fire_review(
+                lattice_dir,
+                task_id,
+                new_status,
+                status_event_id=event["id"],
+                config=config,
+                no_auto_review_flag=no_auto_review,
+            )
+        except Exception as exc:  # noqa: BLE001 — never fail the transition
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "auto-review spawn raised: %s",
+                exc,
+                exc_info=True,
+            )
+
+        # Emit the auto_review_spawned audit event when (and only when)
+        # we actually spawned. Skip reasons surface in CLI output instead.
+        if auto_review_result and auto_review_result.get("fired"):
+            try:
+                from lattice.core.auto_review import AUTO_REVIEW_ACTOR
+
+                auto_event = create_event(
+                    type="auto_review_spawned",
+                    task_id=task_id,
+                    actor=AUTO_REVIEW_ACTOR,
+                    data={
+                        "review_type": auto_review_result["review_type"],
+                        "mode": auto_review_result["mode"],
+                        "log_path": auto_review_result["log_path"],
+                        "spawned_at": auto_review_result["spawned_at"],
+                        # PIDs are short-lived debug aids; the durable signal is
+                        # ``log_path`` plus the eventual review artifact.
+                        "pid": auto_review_result["pid"],
+                        "trigger_status_event_id": event["id"],
+                    },
+                )
+                write_task_event(
+                    lattice_dir,
+                    task_id,
+                    [auto_event],
+                    updated_snapshot,
+                    config,
+                )
+            except Exception as exc:  # noqa: BLE001
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "auto_review_spawned event write failed: %s",
+                    exc,
+                    exc_info=True,
+                )
+
     display_id = updated_snapshot.get("short_id") or task_id
 
     # Compute next-step hints (LAT-197)
@@ -884,12 +1006,15 @@ def status_cmd(
         task_id,
         lattice_dir,
         display_id=display_id,
+        auto_review_result=auto_review_result,
     )
 
     # Build JSON data with optional next_steps
     json_data = dict(updated_snapshot)
     if next_steps_data is not None:
         json_data["next_steps"] = next_steps_data
+    if auto_review_result is not None:
+        json_data["auto_review"] = auto_review_result
 
     assign_msg = f"  (auto-assigned to {actor})" if auto_assigned else ""
     human_msg = f"Status: {current_status} -> {new_status} ({display_id}){assign_msg}"

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import click
 
@@ -47,6 +48,8 @@ from lattice.core.ids import generate_task_id, validate_actor, validate_id
 from lattice.core.tasks import apply_event_to_snapshot, is_backward_status_transition
 from lattice.storage.readers import read_task_events
 from lattice.storage.short_ids import allocate_short_id
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -952,9 +955,7 @@ def status_cmd(
                 no_auto_review_flag=no_auto_review,
             )
         except Exception as exc:  # noqa: BLE001 — never fail the transition
-            import logging
-
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "auto-review spawn raised: %s",
                 exc,
                 exc_info=True,
@@ -989,9 +990,7 @@ def status_cmd(
                     config,
                 )
             except Exception as exc:  # noqa: BLE001
-                import logging
-
-                logging.getLogger(__name__).warning(
+                logger.warning(
                     "auto_review_spawned event write failed: %s",
                     exc,
                     exc_info=True,

--- a/src/lattice/core/auto_review.py
+++ b/src/lattice/core/auto_review.py
@@ -46,8 +46,15 @@ _STATUS_TO_MODE_KEY: dict[str, str] = {
     "planned": "plan_review_mode",
 }
 
-#: Default mode per gate.  Matches the existing CLI defaults so an unset
-#: config behaves identically before and after this ticket.
+#: Conservative fallback mode per gate when the config key is absent.
+#:
+#: Note: this DIFFERS from :func:`lattice.core.config.default_config`,
+#: which seeds ``review_mode = "single"`` and ``plan_review_mode = "triple"``.
+#: Real configs always have these keys, so the fallback is exercised only
+#: by sparse configs (mostly tests).  We deliberately fall back to
+#: ``inline`` for the planned gate so a key-less config skips auto-fire
+#: rather than silently triggering an expensive triple-agent spawn.  The
+#: ``review`` gate keeps ``single`` because that's the cheap, common path.
 _STATUS_TO_DEFAULT_MODE: dict[str, str] = {
     "review": "single",
     "planned": "inline",

--- a/src/lattice/core/auto_review.py
+++ b/src/lattice/core/auto_review.py
@@ -1,0 +1,165 @@
+"""Pure gating logic for auto-firing review subprocesses on status transitions.
+
+This module is deliberately filesystem-free (it lives in ``core/``). The
+side-effecting bits — locating the ``lattice`` binary, claiming
+``review_state``, opening the log file, and spawning the detached subprocess
+— live in :mod:`lattice.cli.auto_review`. See LAT-211 for the layer-boundary
+rationale: ``core/`` holds pure logic, ``cli/`` wires it via Click and owns
+the side effects.
+"""
+
+from __future__ import annotations
+
+
+# ---------------------------------------------------------------------------
+# Constants shared between the gating helper and the spawn helper
+# ---------------------------------------------------------------------------
+
+#: Subdirectory of ``.lattice/`` where auto-fire log files live.  Created
+#: lazily on first spawn.  Never garbage-collected — logs are overwritten
+#: per spawn so disk usage is bounded.
+DAEMON_DIR_NAME = ".daemon"
+
+#: Actor string written on auto-fired review CLI invocations and on the
+#: ``auto_review_spawned`` event.  Distinguishes auto-fired runs from manual
+#: ones in the audit trail.
+AUTO_REVIEW_ACTOR = "agent:lattice-auto-review"
+
+#: Status slugs that gate auto-fire behavior.  Mapping from status to the
+#: review subcommand we'd spawn.
+_STATUS_TO_REVIEW_TYPE: dict[str, str] = {
+    "review": "code-review",
+    "planned": "plan-review",
+}
+
+#: Per-gate config key that enables/disables auto-fire.  Both default to
+#: ``True``; readers always pass ``True`` as the default to ``dict.get``.
+_STATUS_TO_CONFIG_KEY: dict[str, str] = {
+    "review": "auto_code_review_on_transition",
+    "planned": "auto_plan_review_on_transition",
+}
+
+#: Per-gate config key that selects the review mode.  When the resolved
+#: mode is ``inline`` the gate is a no-op (nothing to spawn).
+_STATUS_TO_MODE_KEY: dict[str, str] = {
+    "review": "review_mode",
+    "planned": "plan_review_mode",
+}
+
+#: Default mode per gate.  Matches the existing CLI defaults so an unset
+#: config behaves identically before and after this ticket.
+_STATUS_TO_DEFAULT_MODE: dict[str, str] = {
+    "review": "single",
+    "planned": "inline",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public mapping helpers
+# ---------------------------------------------------------------------------
+
+
+def review_type_for_status(new_status: str) -> str | None:
+    """Return ``"code-review"`` or ``"plan-review"`` for review-gate statuses.
+
+    Returns ``None`` for any other status — those are not auto-fire gates.
+    """
+    return _STATUS_TO_REVIEW_TYPE.get(new_status)
+
+
+def resolve_mode(config: dict, new_status: str) -> str:
+    """Resolve the effective review mode for ``new_status`` from config.
+
+    Falls back to the per-gate default when the config key is unset.  Pure
+    function — never reads from disk.
+    """
+    key = _STATUS_TO_MODE_KEY.get(new_status)
+    if key is None:
+        return _STATUS_TO_DEFAULT_MODE.get(new_status, "single")
+    default = _STATUS_TO_DEFAULT_MODE.get(new_status, "single")
+    return config.get(key, default)
+
+
+# ---------------------------------------------------------------------------
+# Gating predicate
+# ---------------------------------------------------------------------------
+
+
+def should_auto_fire(
+    config: dict,
+    new_status: str,
+    *,
+    no_auto_review_flag: bool,
+) -> tuple[bool, str | None]:
+    """Decide whether the auto-fire path should run for this transition.
+
+    Returns ``(True, None)`` when all of the following hold:
+
+    1. ``new_status`` is one of the auto-fire gates (``review`` or
+       ``planned``).
+    2. The corresponding config key is truthy (default ``True``).
+    3. The corresponding mode is **not** ``inline`` (inline = "review
+       in-session" — there is no subprocess to spawn).
+    4. ``--no-auto-review`` was not passed on the ``lattice status``
+       invocation.
+
+    Returns ``(False, reason)`` otherwise, where ``reason`` is a stable
+    machine-readable code:
+
+    * ``"not_a_review_gate"`` — transition target is not a review/plan gate.
+    * ``"disabled_in_config"`` — the corresponding config key is falsy.
+    * ``"inline_mode"`` — review_mode / plan_review_mode is ``inline``.
+    * ``"no_auto_review_flag"`` — operator passed ``--no-auto-review``.
+
+    Pure function — no filesystem, no review_state read.  The "is a review
+    already in flight?" check happens in the side-effect layer (
+    :mod:`lattice.cli.auto_review`) after this returns ``True``.
+    """
+    if new_status not in _STATUS_TO_REVIEW_TYPE:
+        return False, "not_a_review_gate"
+
+    if no_auto_review_flag:
+        return False, "no_auto_review_flag"
+
+    config_key = _STATUS_TO_CONFIG_KEY[new_status]
+    if not config.get(config_key, True):
+        return False, "disabled_in_config"
+
+    mode = resolve_mode(config, new_status)
+    if mode == "inline":
+        return False, "inline_mode"
+
+    return True, None
+
+
+# ---------------------------------------------------------------------------
+# Skip-reason rendering
+# ---------------------------------------------------------------------------
+
+
+def format_skip_reason(reason: str, *, holder_pid: int | None = None) -> str:
+    """Return a human-readable one-liner explaining why auto-fire skipped.
+
+    Used by ``status_cmd`` to surface the skip in its end-of-command output
+    so an operator can tell at a glance whether the review fired and, if
+    not, why.  The returned string is suitable for appending to the
+    existing next-step hint.
+    """
+    if reason == "inline_mode":
+        return "auto-review skipped (inline mode)"
+    if reason == "disabled_in_config":
+        return "auto-review skipped (disabled in config)"
+    if reason == "no_auto_review_flag":
+        return "auto-review skipped (--no-auto-review)"
+    if reason == "not_a_review_gate":
+        return "auto-review skipped (not a review gate)"
+    if reason == "executable_not_found":
+        return "auto-review skipped (lattice executable not found on PATH)"
+    if reason == "review_in_flight":
+        if holder_pid is not None:
+            return f"auto-review skipped (review already in flight, pid {holder_pid})"
+        return "auto-review skipped (review already in flight)"
+    if reason.startswith("spawn_failed:"):
+        detail = reason.split(":", 1)[1]
+        return f"auto-review skipped (spawn failed: {detail})"
+    return f"auto-review skipped ({reason})"

--- a/src/lattice/core/config.py
+++ b/src/lattice/core/config.py
@@ -148,6 +148,8 @@ class LatticeConfig(TypedDict, total=False):
     plan_review_mode: Literal["inline", "single", "triple"]
     plan_approval: Literal["auto", "human"]
     review_timeout_seconds: int
+    auto_code_review_on_transition: bool
+    auto_plan_review_on_transition: bool
     done_display: Literal["all", "recent", "grouped"]
     project_type: Literal["standard", "structure"]
 
@@ -247,6 +249,8 @@ def default_config(preset: str = "classic") -> LatticeConfig:
         "plan_review_mode": "single",
         "plan_approval": "auto",
         "review_timeout_seconds": 600,
+        "auto_code_review_on_transition": True,
+        "auto_plan_review_on_transition": True,
         "done_display": "grouped",
     }
 

--- a/src/lattice/core/events.py
+++ b/src/lattice/core/events.py
@@ -39,6 +39,7 @@ BUILTIN_EVENT_TYPES: frozenset[str] = frozenset(
         "resource_heartbeat",
         "resource_expired",
         "resource_updated",
+        "auto_review_spawned",
     }
 )
 

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -77,6 +77,51 @@ def cleanup_prompt_dirs(lattice_dir: Path) -> int:
 # ---------------------------------------------------------------------------
 # In-flight state helpers
 # ---------------------------------------------------------------------------
+#
+# ``review_state`` lifecycle for the auto-fire path (LAT-211).
+#
+# The ``review_state/<task_id>.json`` record is the single source of truth for
+# "is a review in flight for this task?". For the auto-fire workflow it is
+# written and re-written at three sites; understanding the order matters
+# because ``auto_fired`` (and ``started_by_pid``) shifts at each step.
+#
+# 1. **Parent (``status_cmd`` → ``cli.auto_review.auto_fire_review``).**  When
+#    the operator runs ``lattice status <id> review`` (or ``planned``), the
+#    parent process synchronously calls ``claim_review_state`` *before* it
+#    spawns the detached ``lattice code-review`` / ``plan-review`` subprocess.
+#    On success the record carries ``auto_fired=True`` and
+#    ``started_by_pid=<parent pid>``. The parent then ``Popen``s the child and
+#    exits.
+#
+# 2. **Child CLI body (``code_review`` / ``plan_review``).**  The detached
+#    review subprocess starts and reads the existing record. Two paths:
+#
+#    * **Adoption (parent-still-alive edge).**  If ``--triggered-by`` was
+#      passed AND the existing record has ``auto_fired=True`` AND
+#      ``started_by_pid == os.getppid()`` (the parent is still alive on the
+#      same machine), the child writes a new record directly with
+#      ``auto_fired=True`` and ``started_by_pid=os.getpid()``. This bypasses
+#      ``claim_review_state``'s live-PID refusal — the child is taking over
+#      the parent's claim, not contending with a stranger.
+#
+#    * **Normal claim.**  Otherwise (no record, stale parent PID, or no
+#      ``--triggered-by``) the child calls
+#      ``claim_review_state(..., auto_fired=False)``. The standard stale-PID
+#      reclaim path overwrites the parent's dead record with the child's
+#      live PID. ``auto_fired=False`` here is intentional: ``review_state``
+#      is transient coordination state; the durable "this review was
+#      auto-fired" signal lives in the ``auto_review_spawned`` event in the
+#      task's event log.
+#
+# 3. **``run_single_review`` / ``run_triple_review``.**  Once inside the
+#    review orchestrator the existing in-place ``write_review_state`` calls
+#    update ``agents[*].status`` and timestamps as agents progress, then
+#    ``clear_review_state`` removes the record on exit. These calls preserve
+#    whatever ``started_by_pid`` and ``auto_fired`` the CLI body wrote in
+#    step 2 — they never recompute them.
+#
+# Manual ``lattice code-review`` / ``plan-review`` invocations follow the
+# normal-claim path with ``auto_fired=False`` from the start.
 
 
 def _state_path(lattice_dir: Path, task_id: str) -> Path:
@@ -108,6 +153,73 @@ def clear_review_state(lattice_dir: Path, task_id: str) -> None:
     """Remove in-flight review state after completion."""
     path = _state_path(lattice_dir, task_id)
     path.unlink(missing_ok=True)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True if ``pid`` refers to a live process on this machine.
+
+    Uses ``os.kill(pid, 0)`` (signal 0) which performs the kernel's existence
+    check without delivering a signal. ``PermissionError`` is treated as
+    "alive" — the process exists but we lack permission to signal it
+    (different uid, sandbox boundary). Non-positive PIDs are never alive.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def claim_review_state(
+    lattice_dir: Path,
+    task_id: str,
+    *,
+    mode: str,
+    review_type: str,
+    started_by_pid: int,
+    auto_fired: bool,
+) -> tuple[bool, dict | None]:
+    """Best-effort claim of the in-flight review slot for ``task_id``.
+
+    Reads the existing record. If it carries a different live ``started_by_pid``
+    the claim is refused and the existing record is returned unchanged. If
+    no record exists, the holder PID is dead, or the holder is the caller
+    itself, the slot is reclaimed: a fresh record is written with the supplied
+    ``mode``, ``review_type``, ``started_by_pid``, and ``auto_fired`` values
+    (and an empty ``agents`` list — the orchestrator fills it in later).
+
+    Returns ``(True, written_state)`` on success or ``(False, existing_state)``
+    on contention.
+
+    Note: this is *not* a true compare-and-swap. ``write_review_state`` does
+    an atomic temp-file replace, but the read-decide-write window is not
+    locked. Two callers passing the read check within microseconds will both
+    write — last writer wins. The realistic race is handled in §5 of the
+    LAT-211 plan (see module-level docstring); the residual race spawns
+    duplicate work but never corrupts state.
+    """
+    existing = read_review_state(lattice_dir, task_id)
+    if existing is not None:
+        holder = existing.get("started_by_pid")
+        if isinstance(holder, int) and holder != started_by_pid and _pid_alive(holder):
+            return False, existing
+        # Otherwise: stale (no PID field, dead PID, or our own PID) — reclaim.
+
+    new_state: dict[str, Any] = {
+        "task_id": task_id,
+        "mode": mode,
+        "review_type": review_type,
+        "started_at": _now_iso(),
+        "started_by_pid": started_by_pid,
+        "auto_fired": auto_fired,
+        "agents": [],
+    }
+    write_review_state(lattice_dir, new_state)
+    return True, new_state
 
 
 # ---------------------------------------------------------------------------
@@ -517,11 +629,17 @@ def run_single_review(
     selection behavior.
     """
     started_at = _now_iso()
+    # Preserve fields written by an earlier ``claim_review_state`` call (e.g.
+    # by the CLI body — see module docstring). If no record exists or the
+    # caller never went through ``claim_review_state``, fall back to defaults.
+    existing = read_review_state(lattice_dir, task_id) or {}
     state: dict[str, Any] = {
         "task_id": task_id,
         "mode": "single",
         "review_type": review_type,
         "started_at": started_at,
+        "started_by_pid": existing.get("started_by_pid", os.getpid()),
+        "auto_fired": existing.get("auto_fired", False),
         "agents": [
             {"name": "claude", "status": "running", "started_at": started_at, "artifact_id": None}
         ],
@@ -586,11 +704,14 @@ def run_triple_review(
     """
     agents = ["claude", "codex", "gemini"]
     overall_started = _now_iso()
+    existing = read_review_state(lattice_dir, task_id) or {}
     state: dict[str, Any] = {
         "task_id": task_id,
         "mode": "triple",
         "review_type": review_type,
         "started_at": overall_started,
+        "started_by_pid": existing.get("started_by_pid", os.getpid()),
+        "auto_fired": existing.get("auto_fired", False),
         "agents": [
             {"name": a, "status": "running", "started_at": overall_started, "artifact_id": None}
             for a in agents

--- a/src/lattice/core/tasks.py
+++ b/src/lattice/core/tasks.py
@@ -209,6 +209,10 @@ _NOOP_EVENT_TYPES: frozenset[str] = frozenset(
         "git_event",
         "task_archived",
         "task_unarchived",
+        # Auto-fire (LAT-211): logged for the audit trail (which review
+        # was auto-spawned, when, by which transition) but does not
+        # mutate the task snapshot — the eventual review artifact does.
+        "auto_review_spawned",
     }
 )
 

--- a/src/lattice/templates/claude_md_block.py
+++ b/src/lattice/templates/claude_md_block.py
@@ -93,17 +93,15 @@ This is the **planning sub-agent's** job. Spawn a sub-agent whose sole purpose i
 
 **The test:** If you moved to `planned` and the plan file is still empty scaffold, you didn't plan. Every task gets a plan — even trivial tasks get a one-line plan. The CLI enforces this: transitioning to `in_progress` is blocked when the plan is still scaffold.
 
-**Plan review (default: single).** After writing the plan, run `lattice plan-review <task>`. Check the project's mode:
+**Plan review (default: single, fires automatically).** Moving the task to `planned` automatically spawns a detached `lattice plan-review <task>` in the background. Tail progress with `lattice review-status <task>` or `.lattice/.daemon/auto-plan-review-<task>.log`. Disable per-call with `--no-auto-review` on `lattice status`, or project-wide with `auto_plan_review_on_transition: false`. **If you opt into `plan_review_mode: triple`, every transition into `planned` spends three agent runs plus a merge — disable auto-fire or use `--no-auto-review` when cost matters.**
 
-```
-cat .lattice/config.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('plan_review_mode','single'))"
-```
+The mode controls *how* the review runs:
 
 | `plan_review_mode` value | What the planner does |
 |--------------------------|----------------------|
 | `single` (default) | Spawns one review agent |
 | `triple` | **Trident plan review** — spawns three agents (claude, codex, gemini) in parallel, merges their findings into one artifact |
-| `inline` | Reviews the plan in-session (use when codex/gemini aren't available, or for small/throwaway projects) |
+| `inline` | Reviews the plan in-session (use when codex/gemini aren't available, or for small/throwaway projects). Auto-fire is a no-op for inline. |
 
 When `plan_approval` is `human`, the CLI automatically moves the task to `needs_human` after `lattice plan-review` completes. Wait for human approval before proceeding to `in_progress`.
 
@@ -125,6 +123,8 @@ Every finding must be explicitly triaged — no silent drops. If triage produces
 
 Moving to `review` is a commitment to actually review the work.
 
+**The review fires automatically by default.** When you transition the task to `review`, the CLI spawns a detached `lattice code-review <task>` in the background — the orchestrator does not need to remember to run it. Tail with `lattice review-status <task>` (covers both manual and auto-fired reviews) or `.lattice/.daemon/auto-code-review-<task>.log`. Disable per-call with `--no-auto-review`, or project-wide with `auto_code_review_on_transition: false`. **If `review_mode` is `triple`, every `→ review` transition (including rework cycles) spends three agent runs by default.**
+
 This is the **review sub-agent's** job. Spawn a sub-agent with fresh context — it did NOT write the code and comes in cold.
 
 **Step 1: Check review_mode.** Before reviewing, check the project config:
@@ -135,16 +135,16 @@ cat .lattice/config.json | python3 -c "import sys,json; d=json.load(sys.stdin); 
 
 | `review_mode` value | What the reviewer does |
 |---------------------|----------------------|
-| `inline` | Review the diff yourself in-session. Run `lattice code-review <task> --mode inline` to acknowledge. |
-| `single` (default) | Run `lattice code-review <task>` — spawns one review agent, stores artifact |
-| `triple` | Run `lattice code-review <task>` — spawns three agents + merge, stores artifacts |
+| `inline` | Review the diff yourself in-session. Run `lattice code-review <task> --mode inline` to acknowledge. (Auto-fire is a no-op for inline.) |
+| `single` (default) | Auto-fire on `→ review` spawns one review agent + stores artifact. Manual fallback: `lattice code-review <task>`. |
+| `triple` | Auto-fire spawns three agents + merge, stores artifacts. Manual fallback: `lattice code-review <task>`. |
 
 **Step 2: Perform the review.** The review sub-agent should:
 1. Read the plan file to understand what was supposed to be built.
 2. Read the git diff to see what was actually built.
 3. Run tests and linting to verify nothing is broken.
 4. Compare the implementation against the plan's acceptance criteria.
-5. Call `lattice code-review <task>` (or review inline if mode is `inline`).
+5. Use the artifact produced by the auto-fired review (or run `lattice code-review <task>` manually if you opted out / are inline).
 
 **When moving to `done`:** If the completion policy blocks you for a missing review artifact, do the review. Do not `--force` past it. `--force --reason` is for genuinely exceptional cases, not a convenience shortcut.
 
@@ -197,17 +197,30 @@ Max cycles:   3 review->rework transitions, then CLI blocks -> needs_human
 
 ### Review Config Reference
 
-Three settings in `.lattice/config.json` control review behavior:
+Five settings in `.lattice/config.json` control review behavior:
 
 | Setting | Values | Default | Meaning |
 |---------|--------|---------|---------|
 | `review_mode` | `inline`, `single`, `triple` | `single` | How code review is performed at the review gate |
 | `plan_review_mode` | `inline`, `single`, `triple` | `single` | How plan review is performed after the plan is written |
 | `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` moves to `needs_human` for approval |
+| `auto_code_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice code-review` when a task transitions to `review` |
+| `auto_plan_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice plan-review` when a task transitions to `planned` |
 
 **`inline`** — review happens in the same agent session (no subprocess spawned).
 **`single`** — one review agent is spawned; result stored as a `review` or `plan-review` artifact.
 **`triple`** — three agents (claude, codex, gemini) run in parallel; individual results stored as `review-individual` artifacts; a merged result stored as `review` or `plan-review`.
+
+### Auto-fire Conventions
+
+When a task transitions to `review` or `planned`, `lattice status` automatically spawns a detached `lattice code-review` / `plan-review` subprocess. The transition itself never blocks on the spawn.
+
+- **Coordination** lives in `.lattice/review_state/<task_id>.json` (extended with `started_by_pid` and `auto_fired` fields). First-writer-wins.
+- **Logs** at `.lattice/.daemon/auto-{code,plan}-review-<task_id>.log`, overwritten per spawn. Header records the spawn timestamp.
+- **Monitor** with `lattice review-status <task_id>` (covers both manual and auto-fired reviews).
+- **Audit** via the `auto_review_spawned` event in the per-task event log.
+- **Per-call opt-out**: `--no-auto-review` on `lattice status`.
+- **Project-wide opt-out**: `auto_code_review_on_transition: false` and/or `auto_plan_review_on_transition: false`.
 
 ### When You're Stuck
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,13 +17,22 @@ def lattice_root(tmp_path: Path) -> Path:
 
 @pytest.fixture()
 def initialized_root(lattice_root: Path) -> Path:
-    """Return a temporary directory with .lattice/ already initialized."""
+    """Return a temporary directory with .lattice/ already initialized.
+
+    Auto-fire of code-review/plan-review on status transitions (LAT-211) is
+    *disabled* in the test fixture so that ``lattice status <id> review``
+    in tests does not actually fork a ``lattice code-review`` subprocess.
+    Tests that exercise the auto-fire path enable it explicitly.
+    """
     from lattice.core.config import default_config, serialize_config
     from lattice.storage.fs import LATTICE_DIR, atomic_write, ensure_lattice_dirs
 
     ensure_lattice_dirs(lattice_root)
     lattice_dir = lattice_root / LATTICE_DIR
-    atomic_write(lattice_dir / "config.json", serialize_config(default_config()))
+    cfg = default_config()
+    cfg["auto_code_review_on_transition"] = False
+    cfg["auto_plan_review_on_transition"] = False
+    atomic_write(lattice_dir / "config.json", serialize_config(cfg))
     (lattice_dir / "events" / "_lifecycle.jsonl").touch()
     return lattice_root
 

--- a/tests/test_cli/test_auto_fire_status.py
+++ b/tests/test_cli/test_auto_fire_status.py
@@ -1,0 +1,430 @@
+"""Tests for auto-fire wiring in ``lattice status`` (LAT-211).
+
+``subprocess.Popen`` is patched everywhere so no actual review subprocess
+is spawned.  Each test enables auto-fire explicitly via ``config_overrides``
+because the conftest disables it by default.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from lattice.cli import auto_review as cli_auto_review
+from lattice.cli.main import cli
+from lattice.core.auto_review import AUTO_REVIEW_ACTOR
+from lattice.core.config import default_config, serialize_config
+from lattice.core.review import write_review_state
+from lattice.storage.fs import LATTICE_DIR, atomic_write, ensure_lattice_dirs
+from lattice.storage.readers import read_task_events
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_board(tmp_path: Path, **overrides: object) -> Path:
+    ensure_lattice_dirs(tmp_path)
+    lattice_dir = tmp_path / LATTICE_DIR
+    config = default_config()
+    # Auto-fire is on by default in production; explicit per-test overrides
+    # let us pin a known config without inheriting the conftest's
+    # disabled-for-tests defaults.
+    config["auto_code_review_on_transition"] = True
+    config["auto_plan_review_on_transition"] = True
+    for k, v in overrides.items():
+        config[k] = v
+    atomic_write(lattice_dir / "config.json", serialize_config(config))
+    (lattice_dir / "events" / "_lifecycle.jsonl").touch()
+    return tmp_path
+
+
+def _create_task(runner: CliRunner, root: Path, title: str = "Test") -> str:
+    res = runner.invoke(
+        cli,
+        ["create", title, "--actor", "agent:test", "--quiet"],
+        env={"LATTICE_ROOT": str(root)},
+        catch_exceptions=False,
+    )
+    assert res.exit_code == 0, res.output
+    return res.output.strip()
+
+
+def _fill_plan(root: Path, task_id: str, title: str = "Test") -> None:
+    plan_path = root / LATTICE_DIR / "plans" / f"{task_id}.md"
+    plan_path.write_text(f"# {title}\n\n## Approach\n\n- Implement the feature.\n")
+
+
+def _walk_to_in_progress(runner: CliRunner, root: Path, task_id: str) -> None:
+    runner.invoke(
+        cli,
+        ["status", task_id, "in_planning", "--actor", "agent:test"],
+        env={"LATTICE_ROOT": str(root)},
+        catch_exceptions=False,
+    )
+    _fill_plan(root, task_id)
+    runner.invoke(
+        cli,
+        ["status", task_id, "planned", "--actor", "agent:test", "--no-auto-review"],
+        env={"LATTICE_ROOT": str(root)},
+        catch_exceptions=False,
+    )
+    runner.invoke(
+        cli,
+        ["status", task_id, "in_progress", "--actor", "agent:test"],
+        env={"LATTICE_ROOT": str(root)},
+        catch_exceptions=False,
+    )
+
+
+class _FakeProc:
+    def __init__(self, pid: int = 12345) -> None:
+        self.pid = pid
+
+
+def _patch_executable(path: str = "/usr/local/bin/lattice"):
+    return patch.object(cli_auto_review, "find_lattice_executable", return_value=path)
+
+
+# ---------------------------------------------------------------------------
+# Auto-fire success paths
+# ---------------------------------------------------------------------------
+
+
+class TestAutoFireSuccessPaths:
+    def test_status_to_review_spawns_code_review(self, tmp_path: Path) -> None:
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        _walk_to_in_progress(runner, root, task_id)
+
+        with (
+            patch.object(
+                cli_auto_review.subprocess, "Popen", return_value=_FakeProc(54321)
+            ) as popen,
+            _patch_executable(),
+        ):
+            res = runner.invoke(
+                cli,
+                ["status", task_id, "review", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+        assert res.exit_code == 0
+        assert "Auto-firing code-review" in res.output
+        popen.assert_called_once()
+        argv = popen.call_args.args[0]
+        # argv ends with the auto-actor + --triggered-by linking back to the
+        # status_changed event.
+        assert argv[1] == "code-review"
+        assert argv[2] == task_id
+        assert argv[3:5] == ["--actor", AUTO_REVIEW_ACTOR]
+        assert argv[5] == "--triggered-by"
+        # event id is a non-empty ULID-shaped string
+        assert argv[6].startswith("ev_")
+
+    def test_status_to_planned_spawns_plan_review(self, tmp_path: Path) -> None:
+        root = _make_board(tmp_path, plan_review_mode="triple")
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        runner.invoke(
+            cli,
+            ["status", task_id, "in_planning", "--actor", "agent:test"],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+        _fill_plan(root, task_id)
+
+        with (
+            patch.object(
+                cli_auto_review.subprocess, "Popen", return_value=_FakeProc(7777)
+            ) as popen,
+            _patch_executable(),
+        ):
+            res = runner.invoke(
+                cli,
+                ["status", task_id, "planned", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+        assert res.exit_code == 0
+        assert "Auto-firing plan-review" in res.output
+        popen.assert_called_once()
+        argv = popen.call_args.args[0]
+        assert argv[1] == "plan-review"
+
+
+# ---------------------------------------------------------------------------
+# Auto-fire skip paths
+# ---------------------------------------------------------------------------
+
+
+class TestAutoFireSkipPaths:
+    def test_in_progress_does_not_spawn(self, tmp_path: Path) -> None:
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        runner.invoke(
+            cli,
+            ["status", task_id, "in_planning", "--actor", "agent:test"],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+        _fill_plan(root, task_id)
+        runner.invoke(
+            cli,
+            ["status", task_id, "planned", "--actor", "agent:test", "--no-auto-review"],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen") as popen,
+            _patch_executable(),
+        ):
+            res = runner.invoke(
+                cli,
+                ["status", task_id, "in_progress", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+        assert res.exit_code == 0
+        popen.assert_not_called()
+
+    def test_no_auto_review_flag_skips_spawn(self, tmp_path: Path) -> None:
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        _walk_to_in_progress(runner, root, task_id)
+
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen") as popen,
+            _patch_executable(),
+        ):
+            res = runner.invoke(
+                cli,
+                ["status", task_id, "review", "--actor", "agent:test", "--no-auto-review"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+        assert res.exit_code == 0
+        popen.assert_not_called()
+        assert "auto-review skipped (--no-auto-review)" in res.output
+
+    def test_disabled_in_config_skips_spawn(self, tmp_path: Path) -> None:
+        root = _make_board(tmp_path, auto_code_review_on_transition=False)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        _walk_to_in_progress(runner, root, task_id)
+
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen") as popen,
+            _patch_executable(),
+        ):
+            res = runner.invoke(
+                cli,
+                ["status", task_id, "review", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+        assert res.exit_code == 0
+        popen.assert_not_called()
+        assert "auto-review skipped (disabled in config)" in res.output
+
+    def test_inline_review_mode_skips_spawn(self, tmp_path: Path) -> None:
+        root = _make_board(tmp_path, review_mode="inline")
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        _walk_to_in_progress(runner, root, task_id)
+
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen") as popen,
+            _patch_executable(),
+        ):
+            res = runner.invoke(
+                cli,
+                ["status", task_id, "review", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+        assert res.exit_code == 0
+        popen.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Failure resilience + audit-trail event
+# ---------------------------------------------------------------------------
+
+
+class TestAutoFireResilience:
+    def test_spawn_failure_does_not_fail_transition(self, tmp_path: Path) -> None:
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        _walk_to_in_progress(runner, root, task_id)
+
+        with (
+            _patch_executable(),
+            patch.object(
+                cli_auto_review.subprocess,
+                "Popen",
+                side_effect=OSError("no fork"),
+            ),
+        ):
+            res = runner.invoke(
+                cli,
+                ["status", task_id, "review", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+        # Status transition still succeeds.
+        assert res.exit_code == 0
+        # And the snapshot is at the new status.
+        snapshot = json.loads((root / LATTICE_DIR / "tasks" / f"{task_id}.json").read_text())
+        assert snapshot["status"] == "review"
+
+    def test_review_in_flight_skips_with_holder_pid(self, tmp_path: Path) -> None:
+        import os
+
+        ppid = os.getppid()
+        if ppid == os.getpid() or ppid <= 1:
+            import pytest
+
+            pytest.skip("Need a usable parent pid to seed a live holder.")
+
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        _walk_to_in_progress(runner, root, task_id)
+
+        # Seed a record held by a live other PID.
+        write_review_state(
+            root / LATTICE_DIR,
+            {
+                "task_id": task_id,
+                "mode": "single",
+                "review_type": "code-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "started_by_pid": ppid,
+                "auto_fired": False,
+                "agents": [],
+            },
+        )
+
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen") as popen,
+            _patch_executable(),
+        ):
+            res = runner.invoke(
+                cli,
+                ["status", task_id, "review", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+        assert res.exit_code == 0
+        popen.assert_not_called()
+        assert "already in flight" in res.output
+        assert f"pid {ppid}" in res.output
+
+    def test_auto_review_spawned_event_appended_on_success(self, tmp_path: Path) -> None:
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        _walk_to_in_progress(runner, root, task_id)
+
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc(31337)),
+            _patch_executable(),
+        ):
+            runner.invoke(
+                cli,
+                ["status", task_id, "review", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+
+        events = read_task_events(root / LATTICE_DIR, task_id)
+        spawn_events = [e for e in events if e["type"] == "auto_review_spawned"]
+        assert len(spawn_events) == 1
+        ev = spawn_events[0]
+        assert ev["actor"] == AUTO_REVIEW_ACTOR
+        data = ev["data"]
+        assert data["review_type"] == "code-review"
+        assert data["mode"] == "single"
+        assert data["pid"] == 31337
+        assert data["log_path"].endswith("/.daemon/auto-code-review-" + task_id + ".log")
+        assert "spawned_at" in data
+        assert "trigger_status_event_id" in data
+        # No ``fired`` field — the event itself signals fired=true.
+        assert "fired" not in data
+        # No ``lock_path`` field — coordination lives in review_state, not lockfiles.
+        assert "lock_path" not in data
+
+    def test_auto_review_spawned_event_not_appended_on_skip(self, tmp_path: Path) -> None:
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        _walk_to_in_progress(runner, root, task_id)
+
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen") as popen,
+            _patch_executable(),
+        ):
+            runner.invoke(
+                cli,
+                ["status", task_id, "review", "--actor", "agent:test", "--no-auto-review"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+        popen.assert_not_called()
+        events = read_task_events(root / LATTICE_DIR, task_id)
+        assert not [e for e in events if e["type"] == "auto_review_spawned"]
+
+
+# ---------------------------------------------------------------------------
+# JSON output surface
+# ---------------------------------------------------------------------------
+
+
+def test_status_json_output_includes_auto_review_block(tmp_path: Path) -> None:
+    root = _make_board(tmp_path)
+    runner = CliRunner()
+    task_id = _create_task(runner, root)
+    _walk_to_in_progress(runner, root, task_id)
+
+    with (
+        patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc(99)),
+        _patch_executable(),
+    ):
+        res = runner.invoke(
+            cli,
+            ["status", task_id, "review", "--actor", "agent:test", "--json"],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+    assert res.exit_code == 0
+    parsed = json.loads(res.output)["data"]
+    assert "auto_review" in parsed
+    assert parsed["auto_review"]["fired"] is True
+    assert parsed["auto_review"]["pid"] == 99
+
+
+def test_status_json_skip_payload(tmp_path: Path) -> None:
+    root = _make_board(tmp_path)
+    runner = CliRunner()
+    task_id = _create_task(runner, root)
+    _walk_to_in_progress(runner, root, task_id)
+
+    res = runner.invoke(
+        cli,
+        ["status", task_id, "review", "--actor", "agent:test", "--no-auto-review", "--json"],
+        env={"LATTICE_ROOT": str(root)},
+        catch_exceptions=False,
+    )
+    assert res.exit_code == 0
+    parsed = json.loads(res.output)["data"]
+    assert parsed["auto_review"] == {"fired": False, "reason": "no_auto_review_flag"}

--- a/tests/test_cli/test_auto_review.py
+++ b/tests/test_cli/test_auto_review.py
@@ -1,0 +1,363 @@
+"""Tests for the CLI-side auto-fire helper (LAT-211).
+
+``subprocess.Popen`` is patched throughout — no actual subprocess is
+forked.  We verify argv composition, log-file lifecycle, claim
+interaction, and the result-dict surface for every skip reason.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from lattice.cli import auto_review as cli_auto_review
+from lattice.cli.auto_review import auto_fire_review, log_path_for
+from lattice.core.auto_review import AUTO_REVIEW_ACTOR
+from lattice.core.review import (
+    claim_review_state,
+    read_review_state,
+    write_review_state,
+)
+
+
+@pytest.fixture
+def lattice_dir(tmp_path: Path) -> Path:
+    """Return a minimal .lattice directory for tests."""
+    ld = tmp_path / ".lattice"
+    ld.mkdir()
+    return ld
+
+
+class _FakeProc:
+    def __init__(self, pid: int = 99999) -> None:
+        self.pid = pid
+
+
+# ---------------------------------------------------------------------------
+# log_path_for
+# ---------------------------------------------------------------------------
+
+
+def test_log_path_for_uses_daemon_subdir(lattice_dir: Path) -> None:
+    path = log_path_for(lattice_dir, "code-review", "task_abc")
+    assert path == lattice_dir / ".daemon" / "auto-code-review-task_abc.log"
+
+
+def test_log_path_for_plan_review(lattice_dir: Path) -> None:
+    path = log_path_for(lattice_dir, "plan-review", "task_abc")
+    assert path == lattice_dir / ".daemon" / "auto-plan-review-task_abc.log"
+
+
+# ---------------------------------------------------------------------------
+# auto_fire_review — happy path
+# ---------------------------------------------------------------------------
+
+
+def _patch_executable(path: str = "/usr/local/bin/lattice"):
+    return patch.object(cli_auto_review, "find_lattice_executable", return_value=path)
+
+
+class TestAutoFireReviewHappyPath:
+    def test_fires_for_review_with_default_config(self, lattice_dir: Path) -> None:
+        with (
+            patch.object(
+                cli_auto_review.subprocess, "Popen", return_value=_FakeProc(12345)
+            ) as popen,
+            _patch_executable("/usr/local/bin/lattice"),
+        ):
+            result = auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "review",
+                status_event_id="evt_xyz",
+                config={},
+                no_auto_review_flag=False,
+            )
+
+        assert result["fired"] is True
+        assert result["review_type"] == "code-review"
+        assert result["mode"] == "single"
+        assert result["pid"] == 12345
+        assert result["log_path"].endswith("/.daemon/auto-code-review-task_abc.log")
+        assert "spawned_at" in result
+
+        # argv composition
+        popen.assert_called_once()
+        argv = popen.call_args.args[0]
+        assert argv == [
+            "/usr/local/bin/lattice",
+            "code-review",
+            "task_abc",
+            "--actor",
+            AUTO_REVIEW_ACTOR,
+            "--triggered-by",
+            "evt_xyz",
+        ]
+        # detached and clean fds
+        assert popen.call_args.kwargs["start_new_session"] is True
+        assert popen.call_args.kwargs["close_fds"] is True
+        # log file written with header + claim record landed on disk
+        log = log_path_for(lattice_dir, "code-review", "task_abc")
+        assert log.exists()
+        header = log.read_text()
+        assert header.startswith("# auto-code-review for task_abc started ")
+
+        state = read_review_state(lattice_dir, "task_abc")
+        assert state is not None
+        assert state["auto_fired"] is True
+        assert state["started_by_pid"] == os.getpid()
+        assert state["mode"] == "single"
+        assert state["review_type"] == "code-review"
+
+    def test_fires_for_planned_with_triple_mode(self, lattice_dir: Path) -> None:
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc(7777)),
+            _patch_executable(),
+        ):
+            result = auto_fire_review(
+                lattice_dir,
+                "task_def",
+                "planned",
+                status_event_id="evt_p",
+                config={"plan_review_mode": "triple"},
+                no_auto_review_flag=False,
+            )
+        assert result["fired"] is True
+        assert result["review_type"] == "plan-review"
+        assert result["mode"] == "triple"
+
+    def test_log_fh_is_closed_in_parent(self, lattice_dir: Path) -> None:
+        # Patch ``open`` for the auto_review module so we can assert close().
+        opened_handles: list = []
+        real_open = open
+
+        def _spy_open(path, mode="r", *args, **kwargs):  # noqa: ANN001, ANN202
+            fh = real_open(path, mode, *args, **kwargs)
+            opened_handles.append(fh)
+            return fh
+
+        with (
+            patch.object(cli_auto_review, "open", _spy_open, create=True),
+            patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc()),
+            _patch_executable(),
+        ):
+            auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "review",
+                status_event_id="evt_xyz",
+                config={},
+                no_auto_review_flag=False,
+            )
+
+        assert opened_handles, "open was not called"
+        log_fh = opened_handles[0]
+        assert log_fh.closed is True
+
+
+# ---------------------------------------------------------------------------
+# auto_fire_review — gating skip paths
+# ---------------------------------------------------------------------------
+
+
+class TestAutoFireReviewSkipPaths:
+    def test_inline_mode_skip(self, lattice_dir: Path) -> None:
+        with patch.object(cli_auto_review.subprocess, "Popen") as popen:
+            result = auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "review",
+                status_event_id="evt_xyz",
+                config={"review_mode": "inline"},
+                no_auto_review_flag=False,
+            )
+        assert result == {"fired": False, "reason": "inline_mode"}
+        popen.assert_not_called()
+        # No claim was made.
+        assert read_review_state(lattice_dir, "task_abc") is None
+
+    def test_disabled_in_config_skip(self, lattice_dir: Path) -> None:
+        with patch.object(cli_auto_review.subprocess, "Popen") as popen:
+            result = auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "review",
+                status_event_id="evt_xyz",
+                config={"auto_code_review_on_transition": False},
+                no_auto_review_flag=False,
+            )
+        assert result == {"fired": False, "reason": "disabled_in_config"}
+        popen.assert_not_called()
+
+    def test_no_auto_review_flag_skip(self, lattice_dir: Path) -> None:
+        with patch.object(cli_auto_review.subprocess, "Popen") as popen:
+            result = auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "review",
+                status_event_id="evt_xyz",
+                config={},
+                no_auto_review_flag=True,
+            )
+        assert result == {"fired": False, "reason": "no_auto_review_flag"}
+        popen.assert_not_called()
+
+    def test_not_a_review_gate_skip(self, lattice_dir: Path) -> None:
+        with patch.object(cli_auto_review.subprocess, "Popen") as popen:
+            result = auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "in_progress",
+                status_event_id="evt_xyz",
+                config={},
+                no_auto_review_flag=False,
+            )
+        assert result == {"fired": False, "reason": "not_a_review_gate"}
+        popen.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# auto_fire_review — coordination + failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestAutoFireReviewCoordination:
+    def test_review_in_flight_when_live_other_pid_holds(self, lattice_dir: Path) -> None:
+        ppid = os.getppid()
+        if ppid == os.getpid() or ppid <= 1:
+            pytest.skip("Need a usable parent pid to seed a live holder.")
+        # Seed a pre-existing record whose holder is alive (test parent
+        # process) — auto_fire_review must refuse.
+        write_review_state(
+            lattice_dir,
+            {
+                "task_id": "task_abc",
+                "mode": "single",
+                "review_type": "code-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "started_by_pid": ppid,
+                "auto_fired": False,
+                "agents": [],
+            },
+        )
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen") as popen,
+            _patch_executable(),
+        ):
+            result = auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "review",
+                status_event_id="evt_xyz",
+                config={},
+                no_auto_review_flag=False,
+            )
+        assert result["fired"] is False
+        assert result["reason"] == "review_in_flight"
+        assert result["holder_pid"] == ppid
+        assert result["holder_auto_fired"] is False
+        popen.assert_not_called()
+        # Existing record untouched.
+        state = read_review_state(lattice_dir, "task_abc")
+        assert state is not None
+        assert state["started_by_pid"] == ppid
+
+    def test_executable_not_found(self, lattice_dir: Path) -> None:
+        with (
+            patch.object(cli_auto_review, "find_lattice_executable", return_value=None),
+            patch.object(cli_auto_review.subprocess, "Popen") as popen,
+        ):
+            result = auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "review",
+                status_event_id="evt_xyz",
+                config={},
+                no_auto_review_flag=False,
+            )
+        assert result == {"fired": False, "reason": "executable_not_found"}
+        popen.assert_not_called()
+        # Phantom claim was released.
+        assert read_review_state(lattice_dir, "task_abc") is None
+
+    def test_popen_failure_releases_claim(self, lattice_dir: Path) -> None:
+        with (
+            _patch_executable(),
+            patch.object(
+                cli_auto_review.subprocess,
+                "Popen",
+                side_effect=OSError("no fork for you"),
+            ),
+        ):
+            result = auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "review",
+                status_event_id="evt_xyz",
+                config={},
+                no_auto_review_flag=False,
+            )
+        assert result["fired"] is False
+        assert result["reason"].startswith("spawn_failed:")
+        assert "no fork" in result["reason"]
+        # Claim released so a retry isn't blocked.
+        assert read_review_state(lattice_dir, "task_abc") is None
+
+    def test_claim_records_survive_after_fire(self, lattice_dir: Path) -> None:
+        # Sanity — after a successful fire the claim is left in place
+        # for the spawned child to adopt.
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc(42)),
+            _patch_executable(),
+        ):
+            auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "review",
+                status_event_id="evt_xyz",
+                config={},
+                no_auto_review_flag=False,
+            )
+        state = read_review_state(lattice_dir, "task_abc")
+        assert state is not None
+        assert state["auto_fired"] is True
+        assert state["started_by_pid"] == os.getpid()
+        # JSON is valid (no leftover serialization quirks).
+        assert json.dumps(state)
+
+
+# ---------------------------------------------------------------------------
+# Sanity: claim_review_state is what's actually being called
+# ---------------------------------------------------------------------------
+
+
+def test_uses_claim_review_state_under_the_hood(lattice_dir: Path) -> None:
+    # Defensive — if someone bypasses the helper, this test catches it.
+    seen: list = []
+    real_claim = claim_review_state
+
+    def _spy(*args, **kwargs):  # noqa: ANN001, ANN202
+        seen.append((args, kwargs))
+        return real_claim(*args, **kwargs)
+
+    with (
+        patch.object(cli_auto_review, "claim_review_state", _spy),
+        patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc()),
+        _patch_executable(),
+    ):
+        auto_fire_review(
+            lattice_dir,
+            "task_abc",
+            "review",
+            status_event_id="evt_xyz",
+            config={},
+            no_auto_review_flag=False,
+        )
+    assert seen, "claim_review_state was not invoked"
+    _, kwargs = seen[0]
+    assert kwargs["auto_fired"] is True
+    assert kwargs["started_by_pid"] == os.getpid()

--- a/tests/test_cli/test_review_cmds.py
+++ b/tests/test_cli/test_review_cmds.py
@@ -470,6 +470,217 @@ class TestCodeReviewTriple:
 # ---------------------------------------------------------------------------
 
 
+class TestReviewClaimAndDisplay:
+    """Coordination tests for the review_state claim path (LAT-211)."""
+
+    def test_review_status_displays_auto_fired_field(self, tmp_path: Path) -> None:
+        from lattice.core.review import write_review_state
+
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        write_review_state(
+            root / LATTICE_DIR,
+            {
+                "task_id": task_id,
+                "mode": "triple",
+                "review_type": "code-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "started_by_pid": 4242,
+                "auto_fired": True,
+                "agents": [],
+            },
+        )
+        result = runner.invoke(
+            cli,
+            ["review-status", task_id],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "auto_fired:" in result.output
+        assert "True" in result.output
+        assert "started_by_pid 4242" in result.output
+
+    def test_review_status_json_round_trips_new_fields(self, tmp_path: Path) -> None:
+        from lattice.core.review import write_review_state
+
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        write_review_state(
+            root / LATTICE_DIR,
+            {
+                "task_id": task_id,
+                "mode": "single",
+                "review_type": "code-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "started_by_pid": 9999,
+                "auto_fired": False,
+                "agents": [],
+            },
+        )
+        result = runner.invoke(
+            cli,
+            ["review-status", task_id, "--json"],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)["data"]
+        assert data["auto_fired"] is False
+        assert data["started_by_pid"] == 9999
+
+    def test_code_review_refuses_when_live_other_pid_holds(self, tmp_path: Path) -> None:
+        import os
+
+        from lattice.core.review import write_review_state
+
+        ppid = os.getppid()
+        if ppid == os.getpid() or ppid <= 1:
+            import pytest
+
+            pytest.skip("Need a usable parent pid for this test.")
+
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        # Seed a record held by an external live PID (test parent process).
+        write_review_state(
+            root / LATTICE_DIR,
+            {
+                "task_id": task_id,
+                "mode": "single",
+                "review_type": "code-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "started_by_pid": ppid,
+                "auto_fired": False,
+                "agents": [],
+            },
+        )
+
+        result = runner.invoke(
+            cli,
+            ["code-review", task_id, "--mode", "single", "--actor", "agent:test"],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+        assert "already in flight" in result.output
+        assert f"pid {ppid}" in result.output
+
+    def test_inline_review_refuses_when_other_pid_holds(self, tmp_path: Path) -> None:
+        import os
+
+        from lattice.core.review import write_review_state
+
+        ppid = os.getppid()
+        if ppid == os.getpid() or ppid <= 1:
+            import pytest
+
+            pytest.skip("Need a usable parent pid for this test.")
+
+        root = _make_board(tmp_path, {"review_mode": "inline"})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        write_review_state(
+            root / LATTICE_DIR,
+            {
+                "task_id": task_id,
+                "mode": "single",
+                "review_type": "code-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "started_by_pid": ppid,
+                "auto_fired": False,
+                "agents": [],
+            },
+        )
+        result = runner.invoke(
+            cli,
+            ["code-review", task_id, "--actor", "agent:test"],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+        assert "already in flight" in result.output
+
+    def test_code_review_with_triggered_by_adopts_parent_state(self, tmp_path: Path) -> None:
+        # Simulate the rare parent-still-alive edge: parent's pid is alive
+        # AND ``--triggered-by`` flags this child as the auto-fired adopter.
+        # The CLI body must overwrite started_by_pid → ours, leaving
+        # ``auto_fired=True``.  We only run up to the claim step (mocked
+        # ``resolve_diff`` & friends) to avoid spawning real agents.
+        import os
+
+        from lattice.core.review import read_review_state, write_review_state
+
+        ppid = os.getppid()
+        if ppid == os.getpid() or ppid <= 1:
+            import pytest
+
+            pytest.skip("Need a usable parent pid for this test.")
+
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        # Give the task a minimal plan + diff context.
+        _write_plan(root, task_id, "# Test\n\nApproach: implement.\n")
+        write_review_state(
+            root / LATTICE_DIR,
+            {
+                "task_id": task_id,
+                "mode": "single",
+                "review_type": "code-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "started_by_pid": ppid,  # alive — would normally refuse
+                "auto_fired": True,
+                "agents": [],
+            },
+        )
+
+        with (
+            patch(
+                "lattice.cli.review_cmds.resolve_diff",
+                return_value=(True, "diff --git a/x.py b/x.py\n"),
+            ),
+            patch(
+                "lattice.cli.review_cmds.run_single_review",
+                return_value=(True, "ok", "PASS"),
+            ),
+            patch(
+                "lattice.cli.review_cmds._attach_review_artifact",
+                return_value="art_fake",
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "code-review",
+                    task_id,
+                    "--mode",
+                    "single",
+                    "--actor",
+                    "agent:test",
+                    "--triggered-by",
+                    "ev_fake",
+                ],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+        # Most importantly: the command did NOT exit with REVIEW_IN_FLIGHT.
+        assert "already in flight" not in result.output
+        # After the adoption path the on-disk record holds *our* PID
+        # (mocked ``run_single_review`` doesn't run ``clear_review_state``,
+        # so the adoption write is what we observe).  ``auto_fired`` stays
+        # True — the audit-trail signal is preserved through the handoff.
+        state_after = read_review_state(root / LATTICE_DIR, task_id)
+        assert state_after is not None
+        assert state_after["started_by_pid"] == os.getpid()
+        assert state_after["auto_fired"] is True
+
+
 class TestReviewState:
     def test_write_read_clear(self, tmp_path):
         from lattice.core.review import clear_review_state, read_review_state, write_review_state

--- a/tests/test_cli/test_review_cmds.py
+++ b/tests/test_cli/test_review_cmds.py
@@ -19,10 +19,18 @@ from lattice.storage.fs import LATTICE_DIR, ensure_lattice_dirs, atomic_write
 
 
 def _make_board(tmp_path: Path, config_overrides: dict | None = None) -> Path:
-    """Initialize a .lattice/ directory and return root."""
+    """Initialize a .lattice/ directory and return root.
+
+    Auto-fire of code-review/plan-review on status transitions (LAT-211) is
+    disabled by default so tests that just walk through statuses do not
+    actually fork a ``lattice code-review`` subprocess. Tests that exercise
+    the auto-fire path override the relevant key via ``config_overrides``.
+    """
     ensure_lattice_dirs(tmp_path)
     lattice_dir = tmp_path / LATTICE_DIR
     config = default_config()
+    config["auto_code_review_on_transition"] = False
+    config["auto_plan_review_on_transition"] = False
     if config_overrides:
         config.update(config_overrides)
     atomic_write(lattice_dir / "config.json", serialize_config(config))

--- a/tests/test_core/test_auto_review.py
+++ b/tests/test_core/test_auto_review.py
@@ -1,0 +1,211 @@
+"""Tests for the pure auto-review gating logic (LAT-211)."""
+
+from __future__ import annotations
+
+import pytest
+
+from lattice.core.auto_review import (
+    AUTO_REVIEW_ACTOR,
+    DAEMON_DIR_NAME,
+    format_skip_reason,
+    resolve_mode,
+    review_type_for_status,
+    should_auto_fire,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_constants_have_expected_values() -> None:
+    assert DAEMON_DIR_NAME == ".daemon"
+    assert AUTO_REVIEW_ACTOR == "agent:lattice-auto-review"
+
+
+# ---------------------------------------------------------------------------
+# review_type_for_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("review", "code-review"),
+        ("planned", "plan-review"),
+        ("in_progress", None),
+        ("done", None),
+        ("backlog", None),
+        ("needs_human", None),
+    ],
+)
+def test_review_type_for_status(status: str, expected: str | None) -> None:
+    assert review_type_for_status(status) == expected
+
+
+# ---------------------------------------------------------------------------
+# resolve_mode
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_mode_review_default_is_single() -> None:
+    assert resolve_mode({}, "review") == "single"
+
+
+def test_resolve_mode_planned_default_is_inline() -> None:
+    assert resolve_mode({}, "planned") == "inline"
+
+
+def test_resolve_mode_review_reads_review_mode() -> None:
+    assert resolve_mode({"review_mode": "triple"}, "review") == "triple"
+    assert resolve_mode({"review_mode": "inline"}, "review") == "inline"
+
+
+def test_resolve_mode_planned_reads_plan_review_mode() -> None:
+    assert resolve_mode({"plan_review_mode": "triple"}, "planned") == "triple"
+    assert resolve_mode({"plan_review_mode": "single"}, "planned") == "single"
+
+
+# ---------------------------------------------------------------------------
+# should_auto_fire — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestShouldAutoFireHappyPaths:
+    def test_review_default_config_fires(self) -> None:
+        ok, reason = should_auto_fire({}, "review", no_auto_review_flag=False)
+        assert ok is True
+        assert reason is None
+
+    def test_planned_with_triple_mode_fires(self) -> None:
+        # plan_review_mode defaults to inline, which would skip; explicit
+        # triple unblocks the planned gate.
+        ok, reason = should_auto_fire(
+            {"plan_review_mode": "triple"},
+            "planned",
+            no_auto_review_flag=False,
+        )
+        assert ok is True
+        assert reason is None
+
+    def test_review_explicit_triple_fires(self) -> None:
+        ok, reason = should_auto_fire(
+            {"review_mode": "triple"},
+            "review",
+            no_auto_review_flag=False,
+        )
+        assert ok is True
+        assert reason is None
+
+
+# ---------------------------------------------------------------------------
+# should_auto_fire — skip paths
+# ---------------------------------------------------------------------------
+
+
+class TestShouldAutoFireSkipPaths:
+    def test_skip_irrelevant_status(self) -> None:
+        ok, reason = should_auto_fire({}, "in_progress", no_auto_review_flag=False)
+        assert ok is False
+        assert reason == "not_a_review_gate"
+
+    def test_skip_when_no_auto_review_flag_set(self) -> None:
+        ok, reason = should_auto_fire({}, "review", no_auto_review_flag=True)
+        assert ok is False
+        assert reason == "no_auto_review_flag"
+
+    def test_no_auto_review_flag_takes_priority_over_config(self) -> None:
+        # Even if config disables, the flag-skip wins so the message can
+        # tell the operator their flag was honored rather than redundant.
+        ok, reason = should_auto_fire(
+            {"auto_code_review_on_transition": False},
+            "review",
+            no_auto_review_flag=True,
+        )
+        assert ok is False
+        assert reason == "no_auto_review_flag"
+
+    def test_skip_disabled_code_review_in_config(self) -> None:
+        ok, reason = should_auto_fire(
+            {"auto_code_review_on_transition": False},
+            "review",
+            no_auto_review_flag=False,
+        )
+        assert ok is False
+        assert reason == "disabled_in_config"
+
+    def test_skip_disabled_plan_review_in_config(self) -> None:
+        ok, reason = should_auto_fire(
+            {
+                "plan_review_mode": "triple",  # would otherwise fire
+                "auto_plan_review_on_transition": False,
+            },
+            "planned",
+            no_auto_review_flag=False,
+        )
+        assert ok is False
+        assert reason == "disabled_in_config"
+
+    def test_disabled_only_affects_matching_gate(self) -> None:
+        # Disabling code-review must not affect planned, and vice versa.
+        ok, reason = should_auto_fire(
+            {
+                "auto_code_review_on_transition": False,
+                "plan_review_mode": "triple",
+            },
+            "planned",
+            no_auto_review_flag=False,
+        )
+        assert ok is True
+        assert reason is None
+
+    def test_skip_inline_review_mode(self) -> None:
+        ok, reason = should_auto_fire(
+            {"review_mode": "inline"},
+            "review",
+            no_auto_review_flag=False,
+        )
+        assert ok is False
+        assert reason == "inline_mode"
+
+    def test_skip_inline_plan_review_mode(self) -> None:
+        # plan_review_mode default is inline, so this also exercises the
+        # default-skip path for the planned gate.
+        ok, reason = should_auto_fire({}, "planned", no_auto_review_flag=False)
+        assert ok is False
+        assert reason == "inline_mode"
+
+
+# ---------------------------------------------------------------------------
+# format_skip_reason
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("reason", "fragment"),
+    [
+        ("inline_mode", "inline mode"),
+        ("disabled_in_config", "disabled in config"),
+        ("no_auto_review_flag", "--no-auto-review"),
+        ("not_a_review_gate", "not a review gate"),
+        ("executable_not_found", "executable not found"),
+        ("review_in_flight", "already in flight"),
+        ("spawn_failed:OSError boom", "spawn failed: OSError boom"),
+    ],
+)
+def test_format_skip_reason_strings(reason: str, fragment: str) -> None:
+    rendered = format_skip_reason(reason)
+    assert "auto-review skipped" in rendered
+    assert fragment in rendered
+
+
+def test_format_skip_reason_includes_holder_pid() -> None:
+    rendered = format_skip_reason("review_in_flight", holder_pid=4242)
+    assert "pid 4242" in rendered
+
+
+def test_format_skip_reason_unknown_falls_through() -> None:
+    rendered = format_skip_reason("custom_reason")
+    assert "auto-review skipped" in rendered
+    assert "custom_reason" in rendered

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -120,6 +120,11 @@ class TestDefaultConfig:
         opinionated = default_config("opinionated")
         assert classic["workflow"]["descriptions"] == opinionated["workflow"]["descriptions"]
 
+    def test_auto_review_keys_default_true(self) -> None:
+        config = default_config()
+        assert config["auto_code_review_on_transition"] is True
+        assert config["auto_plan_review_on_transition"] is True
+
 
 class TestSerializeConfig:
     """serialize_config() produces deterministic canonical JSON."""

--- a/tests/test_core/test_events.py
+++ b/tests/test_core/test_events.py
@@ -50,6 +50,7 @@ class TestBuiltinEventTypes:
             "resource_heartbeat",
             "resource_expired",
             "resource_updated",
+            "auto_review_spawned",
         }
     )
 
@@ -60,7 +61,11 @@ class TestBuiltinEventTypes:
         assert isinstance(BUILTIN_EVENT_TYPES, frozenset)
 
     def test_count(self) -> None:
-        assert len(BUILTIN_EVENT_TYPES) == 26
+        assert len(BUILTIN_EVENT_TYPES) == 27
+
+    def test_auto_review_spawned_is_not_lifecycle(self) -> None:
+        # ``auto_review_spawned`` is a per-task event, not a lifecycle one.
+        assert "auto_review_spawned" not in LIFECYCLE_EVENT_TYPES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 from pathlib import Path
 
@@ -12,6 +13,8 @@ from lattice.core.review import (
     DEFAULT_AGENT_TIMEOUT,
     FAILURE_THRESHOLD,
     _extract_actor_str,
+    _pid_alive,
+    claim_review_state,
     cleanup_temp_files,
     clear_review_state,
     count_agent_failures,
@@ -52,6 +55,166 @@ class TestReviewState:
     def test_clear_nonexistent(self, lattice_dir: Path) -> None:
         # Should not raise
         clear_review_state(lattice_dir, "nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# PID liveness check (LAT-211)
+# ---------------------------------------------------------------------------
+
+
+class TestPidAlive:
+    def test_self_pid_is_alive(self) -> None:
+        assert _pid_alive(os.getpid()) is True
+
+    def test_known_dead_pid_is_not_alive(self) -> None:
+        # 2**31-1 is far above typical PID range; never live in practice.
+        assert _pid_alive(2**31 - 1) is False
+
+    def test_zero_pid_is_not_alive(self) -> None:
+        assert _pid_alive(0) is False
+
+    def test_negative_pid_is_not_alive(self) -> None:
+        assert _pid_alive(-1) is False
+
+
+# ---------------------------------------------------------------------------
+# claim_review_state (LAT-211)
+# ---------------------------------------------------------------------------
+
+
+class TestClaimReviewState:
+    def test_claims_when_no_existing_state(self, lattice_dir: Path) -> None:
+        ok, state = claim_review_state(
+            lattice_dir,
+            "t1",
+            mode="single",
+            review_type="code-review",
+            started_by_pid=os.getpid(),
+            auto_fired=False,
+        )
+        assert ok is True
+        assert state is not None
+        assert state["task_id"] == "t1"
+        assert state["started_by_pid"] == os.getpid()
+        assert state["auto_fired"] is False
+        # Round-trip through disk.
+        loaded = read_review_state(lattice_dir, "t1")
+        assert loaded is not None
+        assert loaded["started_by_pid"] == os.getpid()
+        assert loaded["auto_fired"] is False
+        assert loaded["agents"] == []
+
+    def test_refuses_when_live_other_pid_holds(self, lattice_dir: Path) -> None:
+        # Seed a record held by a different live pid (parent of test process).
+        ppid = os.getppid()
+        if ppid == os.getpid() or ppid <= 1:
+            pytest.skip("Cannot exercise live-other-pid path: no usable parent pid.")
+        write_review_state(
+            lattice_dir,
+            {
+                "task_id": "t1",
+                "mode": "single",
+                "review_type": "code-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "started_by_pid": ppid,
+                "auto_fired": False,
+                "agents": [],
+            },
+        )
+        ok, existing = claim_review_state(
+            lattice_dir,
+            "t1",
+            mode="single",
+            review_type="code-review",
+            started_by_pid=os.getpid(),
+            auto_fired=False,
+        )
+        assert ok is False
+        assert existing is not None
+        assert existing["started_by_pid"] == ppid
+        # On-disk record still belongs to the live holder.
+        loaded = read_review_state(lattice_dir, "t1")
+        assert loaded is not None
+        assert loaded["started_by_pid"] == ppid
+
+    def test_reclaims_when_holder_pid_is_dead(self, lattice_dir: Path) -> None:
+        write_review_state(
+            lattice_dir,
+            {
+                "task_id": "t1",
+                "mode": "single",
+                "review_type": "code-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "started_by_pid": 2**31 - 1,
+                "auto_fired": True,
+                "agents": [{"name": "claude", "status": "running"}],
+            },
+        )
+        ok, state = claim_review_state(
+            lattice_dir,
+            "t1",
+            mode="single",
+            review_type="code-review",
+            started_by_pid=os.getpid(),
+            auto_fired=False,
+        )
+        assert ok is True
+        assert state is not None
+        assert state["started_by_pid"] == os.getpid()
+        assert state["auto_fired"] is False
+        # ``agents`` is reset to an empty list — orchestrator fills in.
+        assert state["agents"] == []
+
+    def test_reclaims_when_existing_state_has_no_pid(self, lattice_dir: Path) -> None:
+        # Legacy/manual state without ``started_by_pid``.
+        write_review_state(
+            lattice_dir,
+            {
+                "task_id": "t1",
+                "mode": "single",
+                "review_type": "code-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "agents": [],
+            },
+        )
+        ok, state = claim_review_state(
+            lattice_dir,
+            "t1",
+            mode="single",
+            review_type="code-review",
+            started_by_pid=os.getpid(),
+            auto_fired=False,
+        )
+        assert ok is True
+        assert state is not None
+        assert state["started_by_pid"] == os.getpid()
+
+    def test_claim_passes_when_holder_is_self(self, lattice_dir: Path) -> None:
+        # Same-PID re-claim is a no-op-ish overwrite (defensive).
+        write_review_state(
+            lattice_dir,
+            {
+                "task_id": "t1",
+                "mode": "single",
+                "review_type": "code-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "started_by_pid": os.getpid(),
+                "auto_fired": True,
+                "agents": [],
+            },
+        )
+        ok, state = claim_review_state(
+            lattice_dir,
+            "t1",
+            mode="single",
+            review_type="code-review",
+            started_by_pid=os.getpid(),
+            auto_fired=True,
+        )
+        assert ok is True
+        assert state is not None
+        assert state["started_by_pid"] == os.getpid()
+        assert state["auto_fired"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Make code-review and plan-review fire automatically when a task transitions to `review` or `planned`. Today the CLI prints a hint and depends on the agent remembering to run the command — this change makes review discipline a structural property of the workflow.

- **Wiring**: `lattice status <id> review` spawns a detached `lattice code-review <id>` (and same shape for `→ planned` / `plan-review`). Status transition returns immediately; the review runs asynchronously; the artifact lands in `.lattice/artifacts/<id>/` when complete.
- **Coordination**: extended the existing `core.review.review_state` primitive (`started_by_pid`, `auto_fired` fields + `claim_review_state` helper) rather than adding a parallel lockfile. Manual and auto-fired reviews share one in-flight record. `lattice review-status <id>` covers both.
- **Layer-boundary discipline**: `core/auto_review.py` is pure gating (no filesystem); `cli/auto_review.py` owns Popen, log open, claim/release. Honors the project's documented core/cli split.
- **Cardinal invariant preserved**: spawn failure never blocks the status transition (`try/except` + `logger.warning`).
- **Operator escape hatches**: `auto_code_review_on_transition` / `auto_plan_review_on_transition` config keys (default true), `--no-auto-review` per-invocation flag, `inline` mode skips auto-fire entirely.
- **Cost-of-ownership note** for `triple` mode added to CLAUDE.md, `templates/claude_md_block.py`, and `docs/user-guide.md` so operators see the API-spend implication before they hit a bill.

## Lifecycle
- 7 commits on `feat/LAT-211-auto-fire-reviews`.
- 1804 tests pass (36 new across `test_core/test_auto_review.py`, `test_cli/test_auto_review.py`, `test_cli/test_auto_fire_status.py`, `test_core/test_review.py::TestClaimReviewState`, `test_cli/test_review_cmds.py::TestReviewClaimAndDisplay`).
- ruff clean across modified files.

## Plan / review trail
- Plan: `.lattice/plans/task_01KQXNE7EPTCES362H7YYW6Q0Q.md` — 11 sections, all 5 ticket open-questions resolved, acceptance criteria mapped row-by-row.
- Plan-review v1 → FAIL (plan-level): factual error about `agent_spawn` + parallel-lockfile redundancy. Rework absorbed both.
- Plan-review v2 → PASS with 3 majors flagged for impl absorption (layer-boundary placement, `auto_fired` lifecycle clarity, `os.getppid()` ordering bug). All addressed in the implementation.
- Code-review → PASS with 7 minors. 4 absorbed in the final commit (`80f5fc5`); 3 deferred with documented justification (concurrent-writer race window, `_pid_alive` naming style, inline-mode contention duplication — refactor scope, not a bug).

## Test plan
- [ ] On a Lattice instance with `auto_code_review_on_transition: true`, run `lattice status <task> review`. Confirm a detached `lattice code-review <task>` is spawned (visible via `ps`), the status transition returns immediately, the log lands at `.lattice/.daemon/auto-code-review-<task>.log`, and the review artifact attaches when the spawn completes.
- [ ] Same for `→ planned` and plan-review.
- [ ] `lattice status <task> review --no-auto-review` does NOT spawn.
- [ ] `auto_code_review_on_transition: false` in config disables auto-fire (CLI falls back to today's hint).
- [ ] `review_mode: inline` skips auto-fire.
- [ ] Concurrent / duplicate spawns are blocked via `review_state` claim — the second invocation surfaces a friendly "review in flight" error.
- [ ] Spawn failure (e.g. `lattice` binary missing from PATH) does not fail the status transition itself.
- [ ] `lattice review-status <task>` displays the new `auto_fired` / `started_by_pid` fields.
- [ ] Existing manual `lattice code-review <task>` and `lattice plan-review <task>` paths behave identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)