### PR TITLE
feat(workflow): convert needs_human/blocked to alerts mechanism (LAT-210)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ lattice create "<title>" --actor agent:<your-id>
 
 When in doubt, create the task. A small task costs nothing. Lost visibility costs everything.
 
-**Recurring observations become tasks.** If you observe the same issue in 2+ consecutive sessions or advances (e.g., a failing test, a lint warning, a flaky behavior), create a task for it. Agents are disciplined about tracking assigned work but not discovered work — this convention closes that gap. Create discovered issues at `needs_human` if they need scoping, or `backlog` if they're well-understood.
+**Recurring observations become tasks.** If you observe the same issue in 2+ consecutive sessions or advances (e.g., a failing test, a lint warning, a flaky behavior), create a task for it. Agents are disciplined about tracking assigned work but not discovered work — this convention closes that gap. Create discovered issues at `backlog` if they're well-understood; if they need human scoping, raise a `needs_human` alert via `lattice raise <task> needs_human --short "..."`.
 
 ### Descriptions Carry Context
 
@@ -186,10 +186,23 @@ lattice status <task> <status> --actor agent:<your-id>
 ```
 
 ```
-backlog → in_planning → planned → in_progress → review → done
-                                       ↕            ↕
-                                    blocked      needs_human
+backlog → in_planning → planned → in_progress → review → pr_open → done
+                                                   ↘ cancelled
 ```
+
+**Alerts are orthogonal to status (LAT-210).** When work needs human input or is
+blocked on something external, you raise an *alert* on the card — it stays in
+its current lifecycle position, and the alert decorates it.
+
+```
+lattice raise <task> needs_human --short "Decide approach" --actor agent:<id>
+lattice raise <task> blocked     --short "CI down"           --actor agent:<id>
+lattice clear <task> needs_human --answer "REST"             --actor human:<id>
+```
+
+Alerts auto-exclude a task from `lattice next`. The dashboard renders an alert
+border + strip on the card. `lattice list --alerted` and `--alert <name>`
+surface the queue.
 
 **Transition discipline:**
 - `in_planning` — before you open the first file to read. Then write the plan.
@@ -246,7 +259,7 @@ cat .lattice/config.json | python3 -c "import sys,json; d=json.load(sys.stdin); 
 | `single` | Spawns one review agent |
 | `inline` | Reviews the plan in-session (use when codex/gemini aren't available, or for small/throwaway projects) |
 
-When `plan_approval` is `human`, the CLI automatically moves the task to `needs_human` after `lattice plan-review` completes. Wait for human approval before proceeding to `in_progress`.
+When `plan_approval` is `human`, the CLI automatically raises a `needs_human` alert on the task after `lattice plan-review` completes (LAT-210; the task stays in its current status). Wait for the human to clear the alert (`lattice clear <task> needs_human --answer "approved"`) before proceeding to `in_progress`.
 
 ### Plan Review Triage
 
@@ -256,7 +269,7 @@ When the plan review returns (trident or otherwise), the orchestrator sorts ever
 |--------|--------------------|----------------|
 | **Obvious** | Missing acceptance criteria, contradictions, plan bugs, trivial clarifications, concrete omissions | Fix directly — amend the plan file, record a short `lattice comment` noting what was resolved. |
 | **Evolutionary** | Speculative additions, "while we're at it" scope creep, refactor suggestions not tied to the ticket's goal, nice-to-haves | Be skeptical. Default to skip. If worth tracking, create a new Lattice task (`lattice create ...`) and link it — do not fold into this ticket. Record a comment explaining why it was deferred. |
-| **Complex** | Genuine design decisions, ambiguity the agent can't resolve alone, trade-offs with real stakes, requirement questions | Bring to the human. Move to `needs_human` with a short comment stating the open question(s). |
+| **Complex** | Genuine design decisions, ambiguity the agent can't resolve alone, trade-offs with real stakes, requirement questions | Bring to the human. Raise a `needs_human` alert (`lattice raise <task> needs_human --short "..."`) and pause until it is cleared. |
 
 Every finding must be explicitly triaged — no silent drops. If triage produces no complex questions, advance to `in_progress`. Otherwise, wait for the human answer, fold it into the plan, then advance.
 
@@ -324,7 +337,7 @@ When a review agent evaluates work, it produces one of three outcomes:
 | Route to in_progress vs in_planning | Orchestrator | Follows review agent's recommendation |
 | Whether to spawn fresh sub-agent | Orchestrator | Encouraged by convention, not enforced |
 
-**3-cycle safety valve:** After 3 review-to-rework transitions (any combination of `review -> in_progress` and `review -> in_planning`), the CLI blocks the 4th attempt. The error message instructs the agent to move the task to `needs_human` with a comment explaining the situation. The limit is configurable via `review_cycle_limit` in the workflow config (default: 3). Override with `--force --reason` for genuinely exceptional cases.
+**3-cycle safety valve:** After 3 review-to-rework transitions (any combination of `review -> in_progress` and `review -> in_planning`), the CLI blocks the 4th attempt. The error message instructs the agent to raise a `needs_human` alert with a comment explaining the situation. The limit is configurable via `review_cycle_limit` in the workflow config (default: 3). Override with `--force --reason` for genuinely exceptional cases.
 
 **Allowed lifecycle paths:**
 
@@ -333,7 +346,7 @@ Normal:       in_progress -> review -> done
 Minor fix:    in_progress -> review -> (fix inline) -> done
 1 impl rework: in_progress -> review -> in_progress -> review -> done
 1 plan rework: in_progress -> review -> in_planning -> planned -> in_progress -> review -> done
-Max cycles:   3 review->rework transitions, then CLI blocks -> needs_human
+Max cycles:   3 review->rework transitions, then CLI blocks -> raise needs_human alert
 ```
 
 ### Review Config Reference
@@ -344,22 +357,28 @@ Three settings in `.lattice/config.json` control review behavior:
 |---------|--------|---------|---------|
 | `review_mode` | `inline`, `single`, `triple` | `single` | How code review is performed at the review gate |
 | `plan_review_mode` | `inline`, `single`, `triple` | `triple` | How plan review is performed after the plan is written |
-| `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` moves to `needs_human` for approval |
+| `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` raises a `needs_human` alert and waits for the human to clear it |
 
 **`inline`** — review happens in the same agent session (no subprocess spawned).
 **`single`** — one review agent is spawned; result stored as a `review` or `plan-review` artifact.
 **`triple`** — three agents (claude, codex, gemini) run in parallel; individual results stored as `review-individual` artifacts; a merged result stored as `review` or `plan-review`.
 
-### When You're Stuck
+### When You're Stuck (Alerts — LAT-210)
 
-Use `needs_human` when you need human decision, approval, or input **right now**. This is distinct from `blocked` (generic external dependency) — it creates a scannable queue. **`needs_human` means actionable NOW** — future checkpoints (quality gates, review gates, approval milestones) stay at `planned` or `backlog` until the preceding work is complete. The orchestrator flips them to `needs_human` at the moment they become actionable.
+Alerts are **orthogonal to status**. The card stays in its current lifecycle column; the alert is a "needs attention right now" decoration. Two alerts ship by default:
+
+- `needs_human` — you need a human decision, approval, or input. Highest urgency. The card surfaces in `lattice list --alerted` and is excluded from `lattice next`. The c11 sidebar gets a yellow pill, optional flash, optional OS notification.
+- `blocked` — work cannot proceed due to an external dependency. Same exclusion from `lattice next`, but no flash by default.
 
 ```
-lattice status <task> needs_human --actor agent:<your-id>
-lattice comment <task> "Need: <what you need, in one line>" --actor agent:<your-id>
+lattice raise <task> needs_human --short "Decide REST or GraphQL?" --actor agent:<id>
+lattice raise <task> blocked --short "CI on shared runner is down" --actor agent:<id>
+lattice clear <task> needs_human --answer "REST. Client simplicity wins." --actor human:<id>
 ```
 
-Use for: design decisions requiring human judgment, missing access/credentials, ambiguous requirements, approval gates. The comment is mandatory — explain what you need in seconds, not minutes. The human's queue should be scannable.
+The `--short` text is mandatory and shows on the card; `--long`, `--prompt`, and `--evidence-ref` are optional. Clearing a not-raised alert is a no-op success (idempotent). Use `lattice show <task>` to see active alerts, raised-by, raised-at, and the suggested clear command.
+
+Use for: design decisions requiring human judgment, missing access/credentials, ambiguous requirements, approval gates. The `--short` text is mandatory — explain what you need in seconds, not minutes.
 
 ### Actor Attribution
 
@@ -402,6 +421,8 @@ lattice status <task> <status> --actor agent:<id>
 lattice complete <task> --review "..." --actor agent:<id>   # closing ritual (not raw status done)
 lattice assign <task> <actor> --actor agent:<id>
 lattice comment <task> "<text>" --actor agent:<id>
+lattice raise <task> <alert-name> --short "<text>" --actor agent:<id>
+lattice clear <task> <alert-name> --actor human:<id>
 lattice link <task> <type> <target> --actor agent:<id>
 lattice branch-link <task> <branch> --actor agent:<id>
 lattice file-link <task> <path>... --actor agent:<id> [--reason "why"]
@@ -409,13 +430,14 @@ lattice file-unlink <task> <path> --actor agent:<id>
 lattice explain <path>                           # also supports directory/ and globs
 lattice next [--actor agent:<id>] [--claim]
 lattice show <task>
-lattice list
+lattice list [--alerted | --alert <name> | --no-alerts]
 ```
 
 **Useful flags:**
 - `--quiet` — prints only the task ID (scripting: `TASK=$(lattice create "..." --quiet)`)
 - `--json` — structured output: `{"ok": true, "data": ...}` or `{"ok": false, "error": ...}`
 - `lattice list --status in_progress` / `--assigned agent:<id>` / `--tag <tag>` — filters
+- `lattice list --alerted` / `--alert needs_human` / `--no-alerts` — alert filters (LAT-210)
 - `lattice link <task> subtask_of|depends_on|blocks <target>` — task relationships
 
 For the full CLI reference, see the `/lattice` skill.

--- a/Decisions.md
+++ b/Decisions.md
@@ -752,6 +752,35 @@ Additionally, `lattice advance N` processed multiple tasks in a single context w
 
 ---
 
+## 2026-05-06: needs_human and blocked become alerts (LAT-210)
+
+- **Context:** Today, a task `in_progress` that hits a question must move to `needs_human` status — which erases the "I'm mid-implementation" signal. The same problem applies to `blocked`. Both concepts are *modifiers* on a card, not lifecycle positions. Modeling them as alerts (orthogonal to status) preserves position, lets the dashboard visually highlight cards regardless of column, and composes cleanly with c11's `trigger-flash` / `set-status` / `notify` primitives.
+- **Decision:**
+  - Drop `needs_human` and `blocked` from default workflow `statuses`, `transitions`, `display_names`, `STATUS_DESCRIPTIONS`, and `_DEFAULT_STATUS_ORDER`.
+  - Reduce `workflow.universal_targets` to `["cancelled"]`.
+  - Introduce two new event types — `alert_raised`, `alert_cleared` — registered in `BUILTIN_EVENT_TYPES` (not `LIFECYCLE_EVENT_TYPES`) and materialized via `_register_mutation` handlers.
+  - Snapshot gains an `alerts: dict` field, listed in `PROTECTED_FIELDS` so `field_updated` cannot bypass the raise/clear contract. Snapshot `schema_version` stays at 1 (the new field is forward-compatible — defaults to `{}`); `config.schema_version` bumps **1 → 2** to mark the workflow contract change.
+  - Two new CLI verbs — `lattice raise <task> <alert-name>` and `lattice clear <task> <alert-name>`. Verb naming chosen over `flag/unflag` and a `lattice alert raise/clear` group: `raise`/`clear` reads naturally and the second positional argument disambiguates `clear`'s shell-builtin collision in practice.
+  - Mirror MCP tools (`lattice_raise_alert`, `lattice_clear_alert`).
+  - `lattice next` excludes any task with a non-empty `alerts` dict — strictly stronger than the old `blocked`-as-status rule.
+- **Locked semantics:**
+  - **Idempotent re-clear:** clearing a not-raised alert is a no-op success. No `alert_cleared` event is written. CLI returns `ok=true` with `data.cleared=false`.
+  - **Double-raise:** raising an already-raised alert writes a second `alert_raised` event (audit trail) and replaces the snapshot entry. `raised_at` reflects the latest raise. No implicit `alert_cleared` between them.
+  - **`evidence_ref` (singular)** lives only inside the alert payload; it does NOT touch the task-level `evidence_refs` array.
+  - **Multi-alert visuals:** the c11 sidebar shows one pill per active alert (no priority collapsing, since `set-status` is alert-name-keyed). The dashboard collapses to a single border/strip using sort priority (`needs_human > blocked`).
+  - **`workflow.alert_visuals` resolution:** per-key override from `workflow.alert_visuals.<name>` falls back to bridge defaults (`cmux_bridge.ALERT_VISUALS`) per-key — not total replacement.
+  - **Replay safety:** the snapshot mutation handler truncates oversize alert payload fields rather than raising, so a malformed historical event never breaks rebuild. The CLI rejects oversize payloads up-front via `validate_alert_payload`.
+- **v0 breaking change (accepted):** Sibling Lattice instances (`code/Aurum/.lattice/`, `code/EAIRQ_Demo/.lattice/`, `code/LatticeRemoteWorkspace/.lattice/`, `code/stage-11-company-board/.lattice/`, plus public consumers) retain `needs_human`/`blocked` in their `.lattice/config.json` until manually migrated. Per-instance migration recipe:
+  1. Edit `.lattice/config.json`:
+     - Remove `"needs_human"` and `"blocked"` from `workflow.statuses`, all `workflow.transitions[*]` lists, and `workflow.transitions` keys.
+     - Set `workflow.universal_targets = ["cancelled"]`.
+     - Add `workflow.alerts = ["needs_human", "blocked"]` and copy `workflow.alert_visuals` / `workflow.alert_descriptions` from the new default (`default_config()`).
+     - Bump `schema_version` to `2`.
+  2. For every active task at `status: needs_human` or `status: blocked`, manually transition it back to a real lifecycle status (commonly `in_planning` or the status it was in before being escalated) and `lattice raise` the equivalent alert. The CLI continues to read snapshots that contain the legacy status without crashing — `is_backward_status_transition` returns `False` when either status is missing from the rank dict.
+- **Consequence:** Every new `lattice init`-ed project gets the alerts mechanism by default. The boilerplate copied via `templates/claude_md_block.py`, the `lattice` skill (`SKILL.md`, `references/multi-agent-guide.md`), and project `CLAUDE.md` teach `lattice raise` / `lattice clear`. The dashboard renders alerted cards with a colored border + ALERT strip, and the c11 sidebar lights up the surface that raised the alert. The `lattice next` exclusion is strictly stronger than the old behavior — agents see scannable alerted-card queues rather than a "blocked" lane.
+
+---
+
 ## Note: This file is append-only
 
 `Decisions.md` is an append-only log. Entries are never edited or deleted after recording. Superseded decisions are noted inline with a reference to the superseding entry. Cross-cutting architectural decisions go here; task-scoped design decisions belong in the plan file (`.lattice/plans/<task_id>.md`).

--- a/Decisions.md
+++ b/Decisions.md
@@ -781,6 +781,16 @@ Additionally, `lattice advance N` processed multiple tasks in a single context w
 
 ---
 
+## 2026-05-06: LAT-210 review-fix decisions (post-PASS absorption)
+
+- **Context:** The LAT-210 implementation passed code review with 3 MAJOR + 5 MINOR findings flagged for in-PR absorption. Two findings produced architectural decisions worth recording.
+- **Decision (cube views — alert overlay):** Wired `CV2_ALERT_COLORS` and `CUBE3D_ALERT_COLORS` constants into the cube / cube3d node-color path so alerted cards render with their alert hue in those views, analogous to the main-board border treatment. The alternative (drop the unused constants and ship a follow-up ticket) was rejected — keep the mechanism cohesive within this PR.
+- **Decision (legacy status colors — three-file consistency):** `LANE_COLORS_BY_THEME` in `index.html` retained its `needs_human` / `blocked` per-theme entries so legacy snapshots from sibling Lattice instances (or this project before migration) render with sensible colors instead of gray fallback. For consistency, **added matching entries to `CV2_STATUS_COLORS` (cube-v2.js) and `CUBE3D_STATUS_COLORS` (cube3d.js)**. All three rendering surfaces now treat `needs_human` / `blocked` as legacy-fallback status colors. The mechanism for the *current* model is the alert overlay (already wired via `CV2_ALERT_COLORS` / `CUBE3D_ALERT_COLORS`); these legacy entries only matter when a snapshot still carries `status: needs_human` or `status: blocked`.
+- **Decision (plan_approval=human verdict gate):** `lattice plan-review` raises `needs_human` whenever `plan_approval == "human"` AND a plan-review artifact was produced — *regardless of verdict*. This is the locked behavior. Verdict-driven routing (fail → in_planning rework) lives in the in_planning loop already; the plan-approval handshake is purely the human-go/no-go signal at the gate, so a fail-verdict still raises (the human is the one who decides whether to accept or reject the plan). Documented in code via comments in both the single- and triple-mode branches of `plan_review`. A fail-verdict test (`test_plan_approval_human_raises_alert_even_when_verdict_fails`) locks this behavior in.
+- **Consequence:** No follow-up tickets are needed for the cube alert-rendering gap or the dashboard color inconsistency; both close inside this PR. Future agents reading the dashboard layer should treat the `*_ALERT_COLORS` constants as the alert overlay (current model) and the `needs_human` / `blocked` status-color entries as legacy-snapshot fallback only.
+
+---
+
 ## Note: This file is append-only
 
 `Decisions.md` is an append-only log. Entries are never edited or deleted after recording. Superseded decisions are noted inline with a reference to the superseding entry. Cross-cutting architectural decisions go here; task-scoped design decisions belong in the plan file (`.lattice/plans/<task_id>.md`).

--- a/ProjectRequirements_v1.md
+++ b/ProjectRequirements_v1.md
@@ -217,9 +217,12 @@ Recommended (nullable/optional):
   - allowed statuses
   - allowed transitions
   - optional WIP limits per status (advisory in v0)
+  - alerts: a list of orthogonal "needs attention" markers (LAT-210)
+  - alert_descriptions and alert_visuals (per-key, mergeable with bridge defaults)
 - Default workflow ships with:
-  - `backlog -> ready -> in_progress -> review -> done`
-  - plus `blocked` and `cancelled`
+  - `backlog -> in_planning -> planned -> in_progress -> review -> pr_open -> done`
+  - plus `cancelled` (the only universal target).
+  - **Alerts (orthogonal):** `needs_human` and `blocked`. Alerts decorate a card without changing its lifecycle status; raised via `lattice raise`, cleared via `lattice clear`. Any task with active alerts is excluded from `lattice next`. See `Decisions.md` (LAT-210).
 
 ### 7.2 Force override (v0)
 

--- a/src/lattice/cli/alert_cmds.py
+++ b/src/lattice/cli/alert_cmds.py
@@ -1,0 +1,425 @@
+"""Alert commands: raise and clear orthogonal "needs attention" markers.
+
+Alerts are the LAT-210 mechanism that replaces ``needs_human`` and ``blocked``
+as statuses.  An alert is a structured payload attached to a task at any
+status — it does not move the task in the workflow.  The c11 integration
+(see ``cmux_bridge.raise_alert_visual`` / ``clear_alert_visual``) wires the
+sidebar pill, optional flash, and OS notification.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from lattice.cli.helpers import (
+    common_options,
+    json_envelope,
+    load_project_config,
+    output_error,
+    output_result,
+    read_snapshot,
+    require_actor,
+    require_root,
+    resolve_task_id,
+    validate_actor_format_or_exit,
+    write_task_event,
+)
+from lattice.cli.main import cli
+from lattice.core.config import (
+    get_alert_visual,
+    get_workflow_alerts,
+    validate_alert_name,
+)
+from lattice.core.events import (
+    ALERT_LONG_MAX,
+    ALERT_PROMPT_MAX,
+    ALERT_SHORT_MAX,
+    create_event,
+    validate_alert_payload,
+)
+from lattice.core.tasks import apply_event_to_snapshot
+
+
+_TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "cancelled"})
+
+
+def _is_archived(lattice_dir: Path, task_id: str) -> bool:
+    return (lattice_dir / "archive" / "tasks" / f"{task_id}.json").exists()
+
+
+def _resolve_long_text(
+    long_text: str | None,
+    long_from_file: str | None,
+    is_json: bool,
+) -> str | None:
+    if long_text is not None and long_from_file is not None:
+        output_error(
+            "--long and --long-from-file are mutually exclusive.",
+            "VALIDATION_ERROR",
+            is_json,
+        )
+    if long_from_file is not None:
+        try:
+            return Path(long_from_file).read_text(encoding="utf-8")
+        except OSError as exc:
+            output_error(
+                f"Cannot read --long-from-file: {exc}",
+                "VALIDATION_ERROR",
+                is_json,
+            )
+    return long_text
+
+
+def _maybe_raise_visual(
+    *,
+    use_c11: bool,
+    surface_override: str | None,
+    workflow_visuals_override: dict | None,
+    flash: bool,
+    notify: bool,
+    alert_name: str,
+    short: str,
+    long: str | None,
+) -> dict | None:
+    """Best-effort fire of the c11 visual hooks.  Returns the location dict
+    that should be embedded in the event payload, or ``None``.
+    """
+    if not use_c11:
+        return None
+
+    from lattice.cli import cmux_bridge
+
+    workspace = cmux_bridge.get_workspace()
+    surface = surface_override or cmux_bridge.get_surface()
+    if not workspace or not surface:
+        return None
+
+    try:
+        cmux_bridge.raise_alert_visual(
+            workspace=workspace,
+            surface=surface,
+            alert_name=alert_name,
+            short=short,
+            long=long,
+            flash=flash,
+            notify=notify,
+            visual_overrides=workflow_visuals_override,
+        )
+    except Exception:  # noqa: BLE001 — visual side-effect must never block
+        return {"type": "c11", "workspace": workspace, "surface": surface}
+    return {"type": "c11", "workspace": workspace, "surface": surface}
+
+
+def _maybe_clear_visual(
+    *,
+    use_c11: bool,
+    surface_override: str | None,
+    alert_name: str,
+) -> None:
+    if not use_c11:
+        return
+
+    from lattice.cli import cmux_bridge
+
+    workspace = cmux_bridge.get_workspace()
+    surface = surface_override or cmux_bridge.get_surface()
+    if not workspace or not surface:
+        return
+    try:
+        cmux_bridge.clear_alert_visual(
+            workspace=workspace,
+            surface=surface,
+            alert_name=alert_name,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# lattice raise
+# ---------------------------------------------------------------------------
+
+
+@cli.command("raise")
+@click.argument("task_id")
+@click.argument("alert_name")
+@click.option("--short", "short_text", required=True, help=f"Short summary (≤{ALERT_SHORT_MAX} chars).")
+@click.option("--long", "long_text", default=None, help=f"Long detail (≤{ALERT_LONG_MAX} chars).")
+@click.option(
+    "--long-from-file",
+    "long_from_file",
+    default=None,
+    type=click.Path(exists=True),
+    help="Read the long detail from a file (mutually exclusive with --long).",
+)
+@click.option("--prompt", "prompt_text", default=None, help=f"Suggested clear command (≤{ALERT_PROMPT_MAX} chars).")
+@click.option("--c11-surface", "c11_surface", default=None, help="Override CMUX_SURFACE_ID detection.")
+@click.option("--no-c11", is_flag=True, help="Skip c11 sidebar/flash/notify side-effects.")
+@click.option("--no-flash", is_flag=True, help="Skip trigger-flash even when defaults say flash.")
+@click.option("--notify/--no-notify", "notify_override", default=None, help="Override notify-on-raise.")
+@click.option("--evidence-ref", "evidence_ref", default=None, help="Link an artifact id (e.g. plan-review).")
+@common_options
+def raise_alert(
+    task_id: str,
+    alert_name: str,
+    short_text: str,
+    long_text: str | None,
+    long_from_file: str | None,
+    prompt_text: str | None,
+    c11_surface: str | None,
+    no_c11: bool,
+    no_flash: bool,
+    notify_override: bool | None,
+    evidence_ref: str | None,
+    model: str | None,
+    session: str | None,
+    output_json: bool,
+    quiet: bool,
+    triggered_by: str | None,
+    on_behalf_of: str | None,
+    provenance_reason: str | None,
+) -> None:
+    """Raise an alert on a task (e.g. ``needs_human``, ``blocked``).
+
+    Alerts are orthogonal to status: the task stays in its current
+    workflow column.  Use ``lattice clear`` to remove the alert.
+    """
+    is_json = output_json
+
+    lattice_dir = require_root(is_json)
+    config = load_project_config(lattice_dir)
+    actor = require_actor(is_json)
+    if on_behalf_of is not None:
+        validate_actor_format_or_exit(on_behalf_of, is_json)
+
+    task_id = resolve_task_id(lattice_dir, task_id, is_json)
+
+    # Validate alert name against config.
+    if not validate_alert_name(config, alert_name):
+        valid = ", ".join(get_workflow_alerts(config)) or "(none configured)"
+        output_error(
+            f"Unknown alert: '{alert_name}'. Valid alerts: {valid}.",
+            "VALIDATION_ERROR",
+            is_json,
+        )
+
+    # Reject archived tasks.
+    if _is_archived(lattice_dir, task_id):
+        output_error(
+            f"Cannot raise alert on archived task {task_id}.",
+            "task_archived",
+            is_json,
+        )
+
+    snapshot = read_snapshot(lattice_dir, task_id)
+    if snapshot is None:
+        output_error(f"Task {task_id} not found.", "NOT_FOUND", is_json)
+
+    # Reject terminal-status tasks.
+    if snapshot.get("status") in _TERMINAL_STATUSES:
+        output_error(
+            f"Cannot raise alert on task in terminal status '{snapshot.get('status')}'.",
+            "task_terminal",
+            is_json,
+        )
+
+    long_resolved = _resolve_long_text(long_text, long_from_file, is_json)
+
+    # Build event data.
+    event_data: dict = {
+        "name": alert_name,
+        "short": short_text,
+    }
+    if long_resolved is not None:
+        event_data["long"] = long_resolved
+    if prompt_text is not None:
+        event_data["prompt"] = prompt_text
+    if evidence_ref is not None:
+        event_data["evidence_ref"] = evidence_ref
+
+    # Validate up-front; CLI rejects oversize.
+    ok, errors = validate_alert_payload(event_data)
+    if not ok:
+        output_error("; ".join(errors), "VALIDATION_ERROR", is_json)
+
+    # Resolve visual config to choose flash/notify defaults.
+    visual = get_alert_visual(config, alert_name)
+    flash_default = bool(visual.get("flash", False))
+    notify_default = bool(visual.get("notify", False))
+    flash = flash_default and not no_flash
+    notify = notify_default if notify_override is None else bool(notify_override)
+
+    use_c11 = not no_c11
+
+    location = _maybe_raise_visual(
+        use_c11=use_c11,
+        surface_override=c11_surface,
+        workflow_visuals_override=visual,
+        flash=flash,
+        notify=notify,
+        alert_name=alert_name,
+        short=short_text,
+        long=long_resolved,
+    )
+    if location is not None:
+        event_data["location"] = location
+
+    event = create_event(
+        type="alert_raised",
+        task_id=task_id,
+        actor=actor,
+        data=event_data,
+        model=model,
+        session=session,
+        triggered_by=triggered_by,
+        on_behalf_of=on_behalf_of,
+        reason=provenance_reason,
+    )
+    updated_snapshot = apply_event_to_snapshot(snapshot, event)
+    write_task_event(lattice_dir, task_id, [event], updated_snapshot, config)
+
+    display_id = updated_snapshot.get("short_id") or task_id
+    output_result(
+        data={
+            "task_id": task_id,
+            "short_id": updated_snapshot.get("short_id"),
+            "alert": alert_name,
+            "raised_at": event["ts"],
+            "alerts": updated_snapshot.get("alerts") or {},
+        },
+        human_message=f"Raised {alert_name} on {display_id}: {short_text}",
+        quiet_value="ok",
+        is_json=is_json,
+        is_quiet=quiet,
+    )
+
+
+# ---------------------------------------------------------------------------
+# lattice clear
+# ---------------------------------------------------------------------------
+
+
+@cli.command("clear")
+@click.argument("task_id")
+@click.argument("alert_name")
+@click.option("--answer", default=None, help="Recorded answer/justification (informational).")
+@click.option("--note", default=None, help="Alternate framing of the clear (informational).")
+@click.option("--c11-surface", "c11_surface", default=None, help="Override CMUX_SURFACE_ID detection.")
+@click.option("--no-c11", is_flag=True, help="Skip c11 sidebar clear.")
+@common_options
+def clear_alert(
+    task_id: str,
+    alert_name: str,
+    answer: str | None,
+    note: str | None,
+    c11_surface: str | None,
+    no_c11: bool,
+    model: str | None,
+    session: str | None,
+    output_json: bool,
+    quiet: bool,
+    triggered_by: str | None,
+    on_behalf_of: str | None,
+    provenance_reason: str | None,
+) -> None:
+    """Clear an alert from a task.  Idempotent: clearing a non-raised alert is a no-op success."""
+    is_json = output_json
+
+    lattice_dir = require_root(is_json)
+    config = load_project_config(lattice_dir)
+    actor = require_actor(is_json)
+    if on_behalf_of is not None:
+        validate_actor_format_or_exit(on_behalf_of, is_json)
+
+    task_id = resolve_task_id(lattice_dir, task_id, is_json)
+
+    # Validate alert name (so typos surface here, not silently no-op).
+    if not validate_alert_name(config, alert_name):
+        valid = ", ".join(get_workflow_alerts(config)) or "(none configured)"
+        output_error(
+            f"Unknown alert: '{alert_name}'. Valid alerts: {valid}.",
+            "VALIDATION_ERROR",
+            is_json,
+        )
+
+    if _is_archived(lattice_dir, task_id):
+        output_error(
+            f"Cannot clear alert on archived task {task_id}.",
+            "task_archived",
+            is_json,
+        )
+
+    snapshot = read_snapshot(lattice_dir, task_id)
+    if snapshot is None:
+        output_error(f"Task {task_id} not found.", "NOT_FOUND", is_json)
+
+    alerts = snapshot.get("alerts") or {}
+
+    # Idempotent re-clear: no event, no snapshot rewrite, ok=true.
+    if alert_name not in alerts:
+        # Best-effort clear of any stale c11 sidebar entry.
+        _maybe_clear_visual(
+            use_c11=not no_c11,
+            surface_override=c11_surface,
+            alert_name=alert_name,
+        )
+        if is_json:
+            click.echo(
+                json_envelope(
+                    True,
+                    data={
+                        "task_id": task_id,
+                        "alert": alert_name,
+                        "cleared": False,
+                        "alerts": alerts,
+                    },
+                )
+            )
+        elif quiet:
+            click.echo("ok")
+        else:
+            click.echo(f"Alert {alert_name} not raised on {task_id} (no-op).")
+        return
+
+    event_data: dict = {"name": alert_name}
+    if answer is not None:
+        event_data["answer"] = answer
+    if note is not None:
+        event_data["note"] = note
+
+    event = create_event(
+        type="alert_cleared",
+        task_id=task_id,
+        actor=actor,
+        data=event_data,
+        model=model,
+        session=session,
+        triggered_by=triggered_by,
+        on_behalf_of=on_behalf_of,
+        reason=provenance_reason,
+    )
+    updated_snapshot = apply_event_to_snapshot(snapshot, event)
+    write_task_event(lattice_dir, task_id, [event], updated_snapshot, config)
+
+    _maybe_clear_visual(
+        use_c11=not no_c11,
+        surface_override=c11_surface,
+        alert_name=alert_name,
+    )
+
+    display_id = updated_snapshot.get("short_id") or task_id
+    output_result(
+        data={
+            "task_id": task_id,
+            "short_id": updated_snapshot.get("short_id"),
+            "alert": alert_name,
+            "cleared": True,
+            "alerts": updated_snapshot.get("alerts") or {},
+        },
+        human_message=f"Cleared {alert_name} on {display_id}.",
+        quiet_value="ok",
+        is_json=is_json,
+        is_quiet=quiet,
+    )

--- a/src/lattice/cli/alert_cmds.py
+++ b/src/lattice/cli/alert_cmds.py
@@ -103,12 +103,12 @@ def _maybe_raise_visual(
             alert_name=alert_name,
             short=short,
             long=long,
-            flash=flash,
-            notify=notify,
+            should_flash=flash,
+            should_notify=notify,
             visual_overrides=workflow_visuals_override,
         )
     except Exception:  # noqa: BLE001 — visual side-effect must never block
-        return {"type": "c11", "workspace": workspace, "surface": surface}
+        pass
     return {"type": "c11", "workspace": workspace, "surface": surface}
 
 

--- a/src/lattice/cli/cmux_bridge.py
+++ b/src/lattice/cli/cmux_bridge.py
@@ -182,8 +182,8 @@ def raise_alert_visual(
     alert_name: str,
     short: str,
     long: str | None,
-    flash: bool,
-    notify: bool,
+    should_flash: bool,
+    should_notify: bool,
     visual_overrides: dict | None = None,
 ) -> None:
     """Wire a c11 sidebar pill + optional flash + optional notify for an alert.
@@ -191,6 +191,9 @@ def raise_alert_visual(
     Order: metadata first (durable), then sidebar pill, then flash
     (one-shot), then OS-level notification.  Subprocess failures inside
     ``_run_cmux`` are logged and swallowed — this never raises.
+
+    The ``should_flash`` / ``should_notify`` parameters are named to avoid
+    shadowing the module-level ``notify`` helper and ``trigger_flash``.
     """
     if not cmux_available():
         return
@@ -230,11 +233,11 @@ def raise_alert_visual(
     )
 
     # 3. Flash
-    if flash:
+    if should_flash:
         _run_cmux("trigger-flash", "--workspace", workspace, "--surface", surface)
 
     # 4. Notification
-    if notify:
+    if should_notify:
         body = (long or short)[:200]
         _run_cmux(
             "notify",

--- a/src/lattice/cli/cmux_bridge.py
+++ b/src/lattice/cli/cmux_bridge.py
@@ -13,6 +13,7 @@ Design principles:
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import subprocess
@@ -30,8 +31,6 @@ STATUS_VISUALS: dict[str, dict[str, str]] = {
     "in_progress": {"icon": "play.fill",                         "color": "#E67E22"},
     "review":      {"icon": "eye.fill",                          "color": "#FFD700"},
     "done":        {"icon": "checkmark.circle.fill",             "color": "#2ECC71"},
-    "blocked":     {"icon": "exclamationmark.triangle.fill",     "color": "#E74C3C"},
-    "needs_human": {"icon": "person.fill.questionmark",          "color": "#E74C3C"},
     "cancelled":   {"icon": "xmark.circle.fill",                 "color": "#95A5A6"},
 }
 
@@ -39,10 +38,28 @@ STATUS_VISUALS: dict[str, dict[str, str]] = {
 STATUS_LABELS: dict[str, str] = {
     "in_progress": "on it",
     "review": "review",
-    "blocked": "blocked",
-    "needs_human": "needs human",
     "done": "done",
     "cancelled": "cancelled",
+}
+
+# Alert visuals (LAT-210) — orthogonal "needs attention" markers.
+# Per-key overrides come from workflow.alert_visuals; these are the
+# canonical defaults.
+ALERT_VISUALS: dict[str, dict] = {
+    "needs_human": {
+        "color": "#FFD600",
+        "icon": "exclamationmark.triangle.fill",
+        "flash": True,
+        "notify": True,
+        "label": "NEEDS HUMAN",
+    },
+    "blocked": {
+        "color": "#FFA500",
+        "icon": "nosign",
+        "flash": False,
+        "notify": False,
+        "label": "BLOCKED",
+    },
 }
 
 
@@ -52,18 +69,21 @@ STATUS_LABELS: dict[str, str] = {
 
 
 def cmux_available() -> bool:
-    """Return True if we are running inside cmux."""
-    return bool(os.environ.get("CMUX_WORKSPACE_ID"))
+    """Return True if we are running inside cmux/c11."""
+    return bool(
+        os.environ.get("CMUX_WORKSPACE_ID")
+        or os.environ.get("C11_WORKSPACE_ID")
+    )
 
 
 def get_workspace() -> str | None:
-    """Return the current cmux workspace ref from the environment."""
-    return os.environ.get("CMUX_WORKSPACE_ID")
+    """Return the current cmux/c11 workspace ref from the environment."""
+    return os.environ.get("CMUX_WORKSPACE_ID") or os.environ.get("C11_WORKSPACE_ID")
 
 
 def get_surface() -> str | None:
-    """Return the current cmux surface ref from the environment."""
-    return os.environ.get("CMUX_SURFACE_ID")
+    """Return the current cmux/c11 surface ref from the environment."""
+    return os.environ.get("CMUX_SURFACE_ID") or os.environ.get("C11_SURFACE_ID")
 
 
 # ---------------------------------------------------------------------------
@@ -148,6 +168,111 @@ def notify(title: str, body: str | None = None) -> bool:
     if body:
         args += ["--body", body]
     return _run_cmux(*args)
+
+
+# ---------------------------------------------------------------------------
+# Alert visuals (LAT-210)
+# ---------------------------------------------------------------------------
+
+
+def raise_alert_visual(
+    *,
+    workspace: str,
+    surface: str,
+    alert_name: str,
+    short: str,
+    long: str | None,
+    flash: bool,
+    notify: bool,
+    visual_overrides: dict | None = None,
+) -> None:
+    """Wire a c11 sidebar pill + optional flash + optional notify for an alert.
+
+    Order: metadata first (durable), then sidebar pill, then flash
+    (one-shot), then OS-level notification.  Subprocess failures inside
+    ``_run_cmux`` are logged and swallowed — this never raises.
+    """
+    if not cmux_available():
+        return
+
+    visuals = dict(ALERT_VISUALS.get(alert_name, {}))
+    if visual_overrides:
+        for k, v in visual_overrides.items():
+            visuals[k] = v
+
+    color = visuals.get("color", "#FFD600")
+    icon = visuals.get("icon", "exclamationmark.triangle.fill")
+
+    # 1. Metadata (durable; survives sidebar refresh)
+    _run_cmux(
+        "set-metadata",
+        "--workspace",
+        workspace,
+        "--surface",
+        surface,
+        "--json",
+        json.dumps({"lattice": {alert_name: {"short": short}}}),
+    )
+
+    # 2. Sidebar pill
+    _run_cmux(
+        "set-status",
+        alert_name,
+        short[:32],
+        "--workspace",
+        workspace,
+        "--surface",
+        surface,
+        "--color",
+        color,
+        "--icon",
+        icon,
+    )
+
+    # 3. Flash
+    if flash:
+        _run_cmux("trigger-flash", "--workspace", workspace, "--surface", surface)
+
+    # 4. Notification
+    if notify:
+        body = (long or short)[:200]
+        _run_cmux(
+            "notify",
+            "--title",
+            f"Lattice: {alert_name}",
+            "--subtitle",
+            short[:80],
+            "--body",
+            body,
+        )
+
+
+def clear_alert_visual(
+    *,
+    workspace: str,
+    surface: str,
+    alert_name: str,
+) -> None:
+    """Clear the c11 sidebar pill and metadata key for an alert.  No un-flash."""
+    if not cmux_available():
+        return
+    _run_cmux(
+        "clear-status",
+        alert_name,
+        "--workspace",
+        workspace,
+        "--surface",
+        surface,
+    )
+    _run_cmux(
+        "clear-metadata",
+        "--key",
+        f"lattice.{alert_name}",
+        "--workspace",
+        workspace,
+        "--surface",
+        surface,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/lattice/cli/demo_cmd.py
+++ b/src/lattice/cli/demo_cmd.py
@@ -691,7 +691,7 @@ def _task_definitions(ts: dict[str, str]) -> list[dict]:
             "title": "Know who to wake at 3am",
             "type": "task",
             "priority": "critical",
-            "status": "needs_human",
+            "status": "in_planning",
             "assigned_to": "human:kai",
             "ts": ts["fri_noon"],
             "description": (
@@ -704,8 +704,14 @@ def _task_definitions(ts: dict[str, str]) -> list[dict]:
             "tags": ["alerting", "on-call"],
             "status_history": [
                 ("in_planning", ts["fri_noon"], "agent:gregorovich"),
-                ("needs_human", ts["fri_2pm"], "agent:gregorovich"),
             ],
+            "alerts": {
+                "needs_human": {
+                    "short": "Pick an escalation model",
+                    "raised_at": ts["fri_2pm"],
+                    "raised_by": "agent:gregorovich",
+                },
+            },
             "parent_idx": 2,
             "comments": [
                 (
@@ -989,7 +995,7 @@ def _task_definitions(ts: dict[str, str]) -> list[dict]:
             "title": "The question of trust",
             "type": "task",
             "priority": "critical",
-            "status": "needs_human",
+            "status": "in_planning",
             "assigned_to": "human:kai",
             "ts": ts["thu_9am"],
             "description": (
@@ -1002,8 +1008,14 @@ def _task_definitions(ts: dict[str, str]) -> list[dict]:
             "tags": ["infrastructure", "security", "decision"],
             "status_history": [
                 ("in_planning", ts["thu_9am"], "agent:gregorovich"),
-                ("needs_human", ts["thu_11am"], "agent:gregorovich"),
             ],
+            "alerts": {
+                "needs_human": {
+                    "short": "Pick auth model (A/B/C)",
+                    "raised_at": ts["thu_11am"],
+                    "raised_by": "agent:gregorovich",
+                },
+            },
             "comments": [
                 (
                     "The gateway routes are authenticated with placeholder "
@@ -1030,7 +1042,7 @@ def _task_definitions(ts: dict[str, str]) -> list[dict]:
             "title": "When two truths disagree",
             "type": "task",
             "priority": "high",
-            "status": "needs_human",
+            "status": "in_planning",
             "assigned_to": "human:lena",
             "ts": ts["fri_9am"],
             "description": (
@@ -1043,8 +1055,14 @@ def _task_definitions(ts: dict[str, str]) -> list[dict]:
             "tags": ["monitoring", "operations", "decision"],
             "status_history": [
                 ("in_planning", ts["fri_9am"], "agent:meridian"),
-                ("needs_human", ts["fri_11am"], "agent:meridian"),
             ],
+            "alerts": {
+                "needs_human": {
+                    "short": "Choose metric source of truth",
+                    "raised_at": ts["fri_11am"],
+                    "raised_by": "agent:meridian",
+                },
+            },
             "comments": [
                 (
                     "Real example from testing: Prometheus reports "
@@ -1329,6 +1347,27 @@ def _seed_demo(target_dir: Path, quiet: bool = False) -> None:
             )
             snapshot = apply_event_to_snapshot(snapshot, branch_event)
             all_events.append(branch_event)
+
+        # Apply seeded alerts (LAT-210)
+        for alert_name, alert_payload in (tdef.get("alerts") or {}).items():
+            raised_at = alert_payload.get("raised_at", tdef.get("ts", ts["mon_9am"]))
+            raised_by = alert_payload.get("raised_by", create_actor)
+            event_data = {
+                "name": alert_name,
+                "short": alert_payload.get("short", ""),
+            }
+            for optional in ("long", "prompt", "evidence_ref"):
+                if alert_payload.get(optional) is not None:
+                    event_data[optional] = alert_payload[optional]
+            alert_event = create_event(
+                type="alert_raised",
+                task_id=task_id,
+                actor=raised_by,
+                data=event_data,
+                ts=raised_at,
+            )
+            snapshot = apply_event_to_snapshot(snapshot, alert_event)
+            all_events.append(alert_event)
 
         # Write all events + snapshot
         write_task_event(lattice_dir, task_id, all_events, snapshot, config)

--- a/src/lattice/cli/main.py
+++ b/src/lattice/cli/main.py
@@ -1496,6 +1496,7 @@ from lattice.cli import file_cmds as _file_cmds  # noqa: E402, F401
 from lattice.cli import wait_cmd as _wait_cmd  # noqa: E402, F401
 from lattice.cli import watch_cmd as _watch_cmd  # noqa: E402, F401
 from lattice.cli import claim_cmd as _claim_cmd  # noqa: E402, F401
+from lattice.cli import alert_cmds as _alert_cmds  # noqa: E402, F401
 
 # ---------------------------------------------------------------------------
 # Load CLI plugins (must be after all built-in commands are registered)

--- a/src/lattice/cli/query_cmds.py
+++ b/src/lattice/cli/query_cmds.py
@@ -419,7 +419,7 @@ def list_cmd(
             t = snap.get("type", "?")
             title = snap.get("title", "?")
             assigned_to = snap.get("assigned_to") or "unassigned"
-            prefix = ">>> " if s == "needs_human" else ""
+            prefix = ">>> " if (snap.get("alerts") or {}) else ""
             archived_marker = " [A]" if snap.get("_archived") else ""
             click.echo(
                 f'{prefix}{display_id}  {s_display}  {p}  {t}  "{title}"  {assigned_to}{archived_marker}'

--- a/src/lattice/cli/query_cmds.py
+++ b/src/lattice/cli/query_cmds.py
@@ -302,6 +302,24 @@ def event_cmd(
     default=None,
     help="Filter by priority (critical, high, medium, low).",
 )
+@click.option(
+    "--alerted",
+    is_flag=True,
+    default=False,
+    help="Show only tasks with at least one active alert (LAT-210).",
+)
+@click.option(
+    "--alert",
+    "alert_name_filter",
+    default=None,
+    help="Show only tasks with the named alert active (e.g. needs_human).",
+)
+@click.option(
+    "--no-alerts",
+    is_flag=True,
+    default=False,
+    help="Show only tasks without any active alerts.",
+)
 @click.option("--include-archived", is_flag=True, help="Include archived tasks.")
 @click.option("--compact", is_flag=True, help="Compact JSON output.")
 @click.option("--json", "output_json", is_flag=True, help="Output structured JSON.")
@@ -312,6 +330,9 @@ def list_cmd(
     tag: str | None,
     task_type: str | None,
     priority: str | None,
+    alerted: bool,
+    alert_name_filter: str | None,
+    no_alerts: bool,
     include_archived: bool,
     compact: bool,
     output_json: bool,
@@ -359,6 +380,14 @@ def list_cmd(
                 snap["_archived"] = True
                 snapshots.append(snap)
 
+    # Validate alert filter combinations.
+    if no_alerts and (alerted or alert_name_filter):
+        output_error(
+            "--no-alerts is mutually exclusive with --alerted/--alert.",
+            "VALIDATION_ERROR",
+            is_json,
+        )
+
     # Apply filters (AND combination)
     filtered: list[dict] = []
     for snap in snapshots:
@@ -373,6 +402,13 @@ def list_cmd(
         if task_type is not None and snap.get("type") != task_type:
             continue
         if priority is not None and snap.get("priority") != priority:
+            continue
+        snap_alerts = snap.get("alerts") or {}
+        if alerted and not snap_alerts:
+            continue
+        if alert_name_filter is not None and alert_name_filter not in snap_alerts:
+            continue
+        if no_alerts and snap_alerts:
             continue
         filtered.append(snap)
 
@@ -491,16 +527,25 @@ def next_cmd(
     # Load all active snapshots
     active, _archived = load_all_snapshots(lattice_dir)
 
+    # LAT-210: count alerted tasks for the banner.
+    alerted_count = sum(1 for snap in active if snap.get("alerts"))
+
     # Select next task
     selected = select_next(active, actor=resolved_actor, ready_statuses=ready_statuses)
 
     if selected is None:
         if is_json:
-            # json_envelope skips data=None, so build manually
-            click.echo(json.dumps({"ok": True, "data": None}, sort_keys=True, indent=2) + "\n")
+            data: dict = {"ok": True, "data": None}
+            if alerted_count:
+                data["alerted_count"] = alerted_count
+            click.echo(json.dumps(data, sort_keys=True, indent=2) + "\n")
         elif quiet:
             pass  # no output
         else:
+            if alerted_count:
+                click.echo(
+                    f"[{alerted_count} task(s) need attention — see lattice list --alerted]"
+                )
             click.echo("No tasks available.")
         return
 
@@ -608,10 +653,18 @@ def next_cmd(
     if is_json:
         result_data = dict(selected)
         result_data["plan_content"] = _read_plan_content_for_next(lattice_dir, task_id)
+        if alerted_count:
+            result_data["alerted_count"] = alerted_count
+
+    banner = (
+        f"[{alerted_count} task(s) need attention — see lattice list --alerted]\n"
+        if alerted_count and not is_json and not quiet
+        else ""
+    )
     output_result(
         data=result_data,
         human_message=(
-            f"{display_id}  {selected.get('status', '?')}  "
+            f"{banner}{display_id}  {selected.get('status', '?')}  "
             f'{selected.get("priority", "?")}  "{selected.get("title", "?")}"'
         ),
         quiet_value=display_id,
@@ -1127,6 +1180,32 @@ def _print_human_show(
         click.echo(f"Warning: {reopened_warning}")
     if comment_count:
         click.echo(f"Comments: {comment_count}")
+
+    # LAT-210: render alerts prominently above relationships/comments.
+    alerts = snapshot.get("alerts") or {}
+    if alerts:
+        click.echo("")
+        click.echo("Alerts:")
+        # Sort: needs_human first, then alphabetical.
+        for alert_name in sorted(alerts.keys(), key=lambda n: (n != "needs_human", n)):
+            payload = alerts[alert_name] or {}
+            short = payload.get("short", "")
+            click.echo(f"  [{alert_name.upper()}] {short}")
+            raised_by = payload.get("raised_by")
+            raised_at = payload.get("raised_at")
+            if raised_by or raised_at:
+                click.echo(
+                    f"    raised by {get_actor_display(raised_by) or '?'} at {raised_at or '?'}"
+                )
+            prompt = payload.get("prompt")
+            if prompt:
+                click.echo(f"    prompt: {prompt}")
+            location = payload.get("location")
+            if location:
+                click.echo(f"    location: {location}")
+            evidence = payload.get("evidence_ref")
+            if evidence:
+                click.echo(f"    evidence_ref: {evidence}")
 
     if description:
         click.echo("")

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import logging
+import re
 import subprocess
 import tempfile
 from datetime import datetime, timezone
@@ -32,6 +34,38 @@ from lattice.core.review import (
 from lattice.templates import load_review_template
 
 
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Verdict parsing (LAT-210)
+# ---------------------------------------------------------------------------
+
+# Reviewers must terminate their artifact with a line like:
+#     VERDICT: pass | fail-rework | fail-decision
+# Last match wins so a "VERDICT: fail-rework" mid-document is overridden by the
+# trailing convention.  Lowercase ``verdict:`` is intentionally rejected — only
+# the uppercase form is the contract.
+_VERDICT_RE = re.compile(
+    r"^VERDICT:\s*(pass|fail-rework|fail-decision)[\s.!]*$",
+    re.MULTILINE,
+)
+
+
+def parse_verdict(body: str) -> str:
+    """Return the parsed verdict from a review artifact body.
+
+    Returns one of ``"pass"``, ``"fail-rework"``, ``"fail-decision"``.  When
+    no valid VERDICT line is present, returns ``"fail-rework"`` and logs a
+    warning — defaulting toward "needs rework" rather than "passed".
+    """
+    matches = _VERDICT_RE.findall(body or "")
+    if matches:
+        return matches[-1]
+    logger.warning("Review artifact missing VERDICT line; defaulting to fail-rework")
+    return "fail-rework"
+
+
 # ---------------------------------------------------------------------------
 # lattice code-review
 # ---------------------------------------------------------------------------
@@ -58,6 +92,31 @@ from lattice.templates import load_review_template
     default=None,
     help="Force a specific spawn backend. Raises if unavailable instead of falling through.",
 )
+@click.option(
+    "--escalate-on-fail",
+    is_flag=True,
+    default=False,
+    help="Raise a needs_human alert when verdict is fail-decision (LAT-210).",
+)
+@click.option(
+    "--escalate-after",
+    is_flag=True,
+    default=False,
+    help="Raise a needs_human alert after the review regardless of verdict.",
+)
+@click.option(
+    "--escalate-short",
+    "escalate_short",
+    default=None,
+    help="Short text for the escalation alert.",
+)
+@click.option(
+    "--escalate-long-from-file",
+    "escalate_long_from_file",
+    default=None,
+    type=click.Path(exists=True),
+    help="Read long alert text from a file.",
+)
 @common_options
 def code_review(
     task_id: str,
@@ -65,6 +124,10 @@ def code_review(
     base: str | None,
     headless: bool,
     backend: str | None,
+    escalate_on_fail: bool,
+    escalate_after: bool,
+    escalate_short: str | None,
+    escalate_long_from_file: str | None,
     model: str | None,
     session: str | None,
     output_json: bool,
@@ -131,8 +194,11 @@ def code_review(
 
     timeout = config.get("review_timeout_seconds", 600)
 
+    review_artifact_id: str | None = None
+    review_text: str | None = None
+
     if mode == "single":
-        _run_single_and_store(
+        review_artifact_id, review_text = _run_single_and_store(
             lattice_dir=lattice_dir,
             task_id=task_id,
             review_type="code-review",
@@ -146,10 +212,11 @@ def code_review(
             timeout=timeout,
             headless=headless,
             backend_force=backend,
+            return_text=True,
         )
 
     elif mode == "triple":
-        _run_triple_and_store(
+        art_ids, review_text = _run_triple_and_store(
             lattice_dir=lattice_dir,
             task_id=task_id,
             review_type="code-review",
@@ -162,7 +229,36 @@ def code_review(
             timeout=timeout,
             headless=headless,
             backend_force=backend,
+            return_text=True,
         )
+        review_artifact_id = art_ids[-1] if art_ids else None
+
+    if escalate_on_fail or escalate_after:
+        verdict = parse_verdict(review_text or "")
+        should_escalate = bool(escalate_after) or (
+            escalate_on_fail and verdict == "fail-decision"
+        )
+        if should_escalate:
+            display_id = snapshot.get("short_id") or task_id
+            short = escalate_short or (
+                f"Code review verdict: {verdict}. Human input requested."
+            )
+            long_text: str | None = None
+            if escalate_long_from_file:
+                try:
+                    long_text = Path(escalate_long_from_file).read_text(encoding="utf-8")
+                except OSError as exc:
+                    click.echo(f"Could not read --escalate-long-from-file: {exc}", err=True)
+            _raise_needs_human_alert(
+                lattice_dir,
+                task_id,
+                actor,
+                is_json,
+                short=short,
+                long_text=long_text,
+                evidence_ref=review_artifact_id,
+                prompt=f"lattice clear {display_id} needs_human --answer '...'",
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -257,6 +353,8 @@ def plan_review(
     plan_approval = config.get("plan_approval", "auto")
     timeout = config.get("review_timeout_seconds", 600)
 
+    plan_review_mode = mode
+
     if mode == "single":
         art_id = _run_single_and_store(
             lattice_dir=lattice_dir,
@@ -274,7 +372,19 @@ def plan_review(
             backend_force=backend,
         )
         if art_id and plan_approval == "human":
-            _move_to_needs_human(lattice_dir, task_id, actor, is_json)
+            short = (
+                f"Plan reviewed (mode: {plan_review_mode}). Approve to continue."
+            )
+            display_id = snapshot.get("short_id") or task_id
+            _raise_needs_human_alert(
+                lattice_dir,
+                task_id,
+                actor,
+                is_json,
+                short=short,
+                evidence_ref=art_id,
+                prompt=f"lattice clear {display_id} needs_human --answer 'approved'",
+            )
 
     elif mode == "triple":
         art_ids = _run_triple_and_store(
@@ -292,7 +402,20 @@ def plan_review(
             backend_force=backend,
         )
         if art_ids and plan_approval == "human":
-            _move_to_needs_human(lattice_dir, task_id, actor, is_json)
+            short = (
+                f"Plan reviewed (mode: {plan_review_mode}). Approve to continue."
+            )
+            display_id = snapshot.get("short_id") or task_id
+            # Last artifact id is the merged artifact (per _run_triple_and_store).
+            _raise_needs_human_alert(
+                lattice_dir,
+                task_id,
+                actor,
+                is_json,
+                short=short,
+                evidence_ref=art_ids[-1] if art_ids else None,
+                prompt=f"lattice clear {display_id} needs_human --answer 'approved'",
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -381,8 +504,14 @@ def _run_single_and_store(
     timeout: int = 600,
     headless: bool = False,
     backend_force: str | None = None,
-) -> str | None:
-    """Run single-agent review, store artifact, print result. Returns artifact ID or None."""
+    return_text: bool = False,
+):
+    """Run single-agent review, store artifact, print result.
+
+    Returns ``artifact_id`` by default (str | None).  When *return_text* is
+    True, returns ``(artifact_id, review_text)`` so callers can parse the
+    verdict for escalation decisions.
+    """
     click.echo(f"Running {review_type} (single mode)...")
 
     success, message, text = run_single_review(
@@ -399,7 +528,7 @@ def _run_single_and_store(
     if not success:
         click.echo(f"Review failed: {message}", err=True)
         cleanup_temp_files(task_id)
-        return None
+        return (None, None) if return_text else None
 
     assert text is not None
     art_id = _attach_review_artifact(
@@ -424,7 +553,7 @@ def _run_single_and_store(
         else:
             click.echo(f"Review stored as artifact {art_id} (role={role}).")
 
-    return art_id
+    return (art_id, text) if return_text else art_id
 
 
 def _run_triple_and_store(
@@ -441,8 +570,15 @@ def _run_triple_and_store(
     timeout: int = 600,
     headless: bool = False,
     backend_force: str | None = None,
-) -> list[str]:
-    """Run triple-agent review, store artifacts, print result. Returns list of artifact IDs."""
+    return_text: bool = False,
+):
+    """Run triple-agent review, store artifacts, print result.
+
+    Default return: ``list[str]`` of artifact IDs (last entry is the merged
+    artifact when merge succeeds).  When *return_text* is True, returns
+    ``(artifact_ids, merged_text_or_first_success)`` so callers can parse
+    the verdict.
+    """
     click.echo(f"Running {review_type} (triple mode — spawning claude, codex, gemini)...")
 
     overall_success, message, results = run_triple_review(
@@ -480,7 +616,7 @@ def _run_triple_and_store(
     if not overall_success:
         click.echo("All agents failed. No merged review produced.", err=True)
         cleanup_temp_files(task_id)
-        return artifact_ids
+        return (artifact_ids, None) if return_text else artifact_ids
 
     click.echo("Merging reviews...")
     merge_success, merged_text = run_merge_agent(
@@ -517,6 +653,15 @@ def _run_triple_and_store(
         click.echo(f"Merge agent failed: {merged_text}", err=True)
 
     cleanup_temp_files(task_id)
+    if return_text:
+        text_for_verdict = merged_text if merge_success else None
+        if text_for_verdict is None:
+            # Fall back to the first successful individual review.
+            for _agent, _success, _text in results:
+                if _success:
+                    text_for_verdict = _text
+                    break
+        return artifact_ids, text_for_verdict
     return artifact_ids
 
 
@@ -610,35 +755,50 @@ def _read_project_context(lattice_dir: Path) -> str:
     return "(no project context found)"
 
 
-def _move_to_needs_human(
+def _raise_needs_human_alert(
     lattice_dir: Path,
     task_id: str,
     actor: str | dict,
     is_json: bool,
+    *,
+    short: str,
+    long_text: str | None = None,
+    evidence_ref: str | None = None,
+    prompt: str | None = None,
 ) -> None:
-    """Move task to needs_human when plan_approval == 'human'."""
+    """Raise a ``needs_human`` alert (LAT-210 — replaces moving to that status).
+
+    Used by plan-review when ``plan_approval == 'human'`` and by
+    code-review's ``--escalate-on-fail`` / ``--escalate-after`` paths.
+    """
     actor_flag = _actor_flag(actor)
     if actor_flag is None:
-        click.echo("Cannot determine actor for status update.", err=True)
+        click.echo("Cannot determine actor for alert raise.", err=True)
         return
 
-    result = subprocess.run(
-        [
-            "lattice",
-            "status",
-            task_id,
-            "needs_human",
-            "--actor",
-            actor_flag,
-        ],
-        capture_output=True,
-        text=True,
-    )
+    args = [
+        "lattice",
+        "raise",
+        task_id,
+        "needs_human",
+        "--short",
+        short,
+        "--actor",
+        actor_flag,
+    ]
+    if long_text is not None:
+        args += ["--long", long_text]
+    if evidence_ref is not None:
+        args += ["--evidence-ref", evidence_ref]
+    if prompt is not None:
+        args += ["--prompt", prompt]
+
+    result = subprocess.run(args, capture_output=True, text=True)
     if result.returncode == 0:
-        click.echo("Task moved to needs_human (plan_approval=human).")
+        click.echo("Raised needs_human alert.")
     else:
         click.echo(
-            f"Note: Could not move to needs_human: {result.stderr.strip()}",
+            f"Note: Could not raise needs_human alert: {result.stderr.strip()}",
             err=True,
         )
 

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -233,7 +233,11 @@ def code_review(
         )
         review_artifact_id = art_ids[-1] if art_ids else None
 
-    if escalate_on_fail or escalate_after:
+    if (escalate_on_fail or escalate_after) and mode in ("single", "triple"):
+        # Guard: only single/triple produce a review_text we can parse.  The
+        # ``inline`` mode short-circuits earlier in this function, but a future
+        # mode could reach here without populating review_text — skip rather
+        # than dereference None.
         verdict = parse_verdict(review_text or "")
         should_escalate = bool(escalate_after) or (
             escalate_on_fail and verdict == "fail-decision"
@@ -372,6 +376,11 @@ def plan_review(
             backend_force=backend,
         )
         if art_id and plan_approval == "human":
+            # LAT-210 locked behavior: always raise needs_human on
+            # plan_approval=human regardless of verdict.  This gate is purely
+            # the human-approval handshake — a fail-verdict still routes
+            # through the existing in_planning rework loop, but the human is
+            # the one who decides whether to accept or reject the plan.
             short = (
                 f"Plan reviewed (mode: {plan_review_mode}). Approve to continue."
             )
@@ -402,6 +411,9 @@ def plan_review(
             backend_force=backend,
         )
         if art_ids and plan_approval == "human":
+            # See locked-behavior comment in the single-mode branch above:
+            # plan_approval=human raises unconditionally; verdict-driven
+            # routing is handled separately by the in_planning rework loop.
             short = (
                 f"Plan reviewed (mode: {plan_review_mode}). Approve to continue."
             )
@@ -793,7 +805,12 @@ def _raise_needs_human_alert(
     if prompt is not None:
         args += ["--prompt", prompt]
 
-    result = subprocess.run(args, capture_output=True, text=True)
+    result = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        cwd=str(lattice_dir.parent),
+    )
     if result.returncode == 0:
         click.echo("Raised needs_human alert.")
     else:

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -527,30 +527,7 @@ def compute_next_steps(
             "then": "done",
         }
 
-    if new_status == "needs_human":
-        # Try to surface the latest comment as a reminder of what's needed.
-        try:
-            events = read_task_events(lattice_dir, task_id)
-            comments = materialize_comments(events)
-            # Find the latest non-deleted top-level comment.
-            latest = None
-            for c in reversed(comments):
-                if not c.get("deleted"):
-                    latest = c
-                    break
-            if latest:
-                body = latest.get("body", "")
-                truncated = (body[:200] + "...") if len(body) > 200 else body
-                hint = f"Waiting on human.  Latest comment: {truncated}"
-                return hint, {
-                    "action": "awaiting_human",
-                    "latest_comment": body,
-                }
-        except Exception:
-            pass
-        hint = "Waiting on human input."
-        return hint, {"action": "awaiting_human"}
-
+    # LAT-210: ``needs_human`` is no longer a status — see lattice raise / clear.
     return None, None
 
 

--- a/src/lattice/cli/weather_cmds.py
+++ b/src/lattice/cli/weather_cmds.py
@@ -218,15 +218,21 @@ def _find_attention_needed(
                 }
             )
 
-    # Tasks waiting for human input
+    # Alerted tasks (LAT-210: replaces the needs_human-status check)
     for snap in active:
-        if snap.get("status") == "needs_human":
+        alerts = snap.get("alerts") or {}
+        if not alerts:
+            continue
+        # Surface needs_human first (highest priority alert) and then any others.
+        for alert_name in sorted(alerts.keys(), key=lambda n: (n != "needs_human", n)):
+            payload = alerts[alert_name] or {}
             items.append(
                 {
-                    "type": "needs_human",
+                    "type": f"alert:{alert_name}",
                     "id": snap.get("short_id") or snap.get("id", "?"),
                     "title": snap.get("title", "?"),
-                    "detail": "Waiting for human decision or input",
+                    "alert": alert_name,
+                    "detail": payload.get("short") or "Alert raised",
                 }
             )
 
@@ -333,8 +339,9 @@ def _print_text_weather(data: dict) -> None:
                 click.echo(f"  [WIP]   {item['status']} — {item['detail']}")
             elif item["type"] == "unassigned_active":
                 click.echo(f'  [UNASGN] {item["id"]} — {item["status"]} — "{item["title"]}"')
-            elif item["type"] == "needs_human":
-                click.echo(f'  [HUMAN] {item["id"]} — {item["detail"]} — "{item["title"]}"')
+            elif item.get("type", "").startswith("alert:"):
+                tag = (item.get("alert") or "alert").upper()
+                click.echo(f'  [{tag}] {item["id"]} — {item["detail"]} — "{item["title"]}"')
         click.echo("")
     else:
         click.echo("Attention Needed: None")
@@ -397,9 +404,10 @@ def _print_markdown_weather(data: dict) -> None:
                 click.echo(f"- **WIP BREACH** `{item['status']}` — {item['detail']}")
             elif item["type"] == "unassigned_active":
                 click.echo(f"- **UNASSIGNED** `{item['id']}` — {item['status']} — {item['title']}")
-            elif item["type"] == "needs_human":
+            elif item.get("type", "").startswith("alert:"):
+                tag = (item.get("alert") or "alert").upper().replace("_", " ")
                 click.echo(
-                    f"- **NEEDS HUMAN** `{item['id']}` — {item['detail']} — {item['title']}"
+                    f"- **{tag}** `{item['id']}` — {item['detail']} — {item['title']}"
                 )
     else:
         click.echo("Nothing needs attention.")

--- a/src/lattice/core/config.py
+++ b/src/lattice/core/config.py
@@ -99,8 +99,6 @@ WORKFLOW_PRESETS: dict[str, dict[str, str]] = {
             "review": "check my work",
             "pr_open": "PR up",
             "done": "shipped",
-            "blocked": "stuck",
-            "needs_human": "ask flesh",
             "cancelled": "never mind",
         },
     },
@@ -122,9 +120,44 @@ STATUS_DESCRIPTIONS: dict[str, str] = {
     "review": "Local review is underway. A review sub-agent is examining the diff before a PR is opened.",
     "pr_open": "PR is open and awaiting human review, CI, or merge. Local review artifact is recorded.",
     "done": "Work is reviewed, merged, and shipped. No further action needed.",
-    "blocked": "Work cannot proceed due to an external dependency or unresolved issue.",
-    "needs_human": "A human decision, approval, or input is required before work can continue.",
     "cancelled": "Work has been abandoned. No further action will be taken.",
+}
+
+
+# Alert descriptions parallel STATUS_DESCRIPTIONS — what each alert means.
+ALERT_DESCRIPTIONS: dict[str, str] = {
+    "needs_human": (
+        "A human decision, approval, or input is required before work can continue. "
+        "The task stays in its current workflow status; the alert is a modifier that "
+        "surfaces the card in 'needs attention' views."
+    ),
+    "blocked": (
+        "Work cannot proceed due to an external dependency or unresolved issue. "
+        "The task stays in its current workflow status; clear the alert when the "
+        "blocker resolves."
+    ),
+}
+
+
+# Alert visual defaults baked into config (overridable by per-instance config).
+# Mirrors cmux_bridge.ALERT_VISUALS for the dashboard to consume server-side.
+ALERT_VISUALS_DEFAULTS: dict[str, dict] = {
+    "needs_human": {
+        "color": "#FFD600",
+        "icon": "exclamationmark.triangle.fill",
+        "flash": True,
+        "notify": True,
+        "label": "NEEDS HUMAN",
+        "sort_priority": 0,
+    },
+    "blocked": {
+        "color": "#FFA500",
+        "icon": "nosign",
+        "flash": False,
+        "notify": False,
+        "label": "BLOCKED",
+        "sort_priority": 1,
+    },
 }
 
 
@@ -182,37 +215,24 @@ def default_config(preset: str = "classic") -> LatticeConfig:
             "review",
             "pr_open",
             "done",
-            "blocked",
-            "needs_human",
             "cancelled",
         ],
         "transitions": {
             "backlog": ["in_planning", "planned", "cancelled"],
-            "in_planning": ["planned", "needs_human", "cancelled"],
-            "planned": ["in_progress", "review", "blocked", "needs_human", "cancelled"],
-            "in_progress": ["review", "blocked", "needs_human", "cancelled"],
-            "review": ["pr_open", "done", "in_progress", "in_planning", "needs_human", "cancelled"],
+            "in_planning": ["planned", "cancelled"],
+            "planned": ["in_progress", "review", "cancelled"],
+            "in_progress": ["review", "cancelled"],
+            "review": ["pr_open", "done", "in_progress", "in_planning", "cancelled"],
             "pr_open": [
                 "done",
                 "in_progress",
                 "review",
-                "blocked",
-                "needs_human",
                 "cancelled",
             ],
             "done": [],
-            "blocked": ["in_planning", "planned", "in_progress", "pr_open", "cancelled"],
-            "needs_human": [
-                "in_planning",
-                "planned",
-                "in_progress",
-                "review",
-                "pr_open",
-                "cancelled",
-            ],
             "cancelled": [],
         },
-        "universal_targets": ["needs_human", "cancelled"],
+        "universal_targets": ["cancelled"],
         "roles": ["review", "plan-review", "review-individual"],
         "wip_limits": {
             "in_progress": 10,
@@ -222,6 +242,11 @@ def default_config(preset: str = "classic") -> LatticeConfig:
         "completion_policies": {
             "done": {"require_roles": ["review"]},
         },
+        "alerts": ["needs_human", "blocked"],
+        "alert_descriptions": dict(ALERT_DESCRIPTIONS),
+        "alert_visuals": {
+            name: dict(visuals) for name, visuals in ALERT_VISUALS_DEFAULTS.items()
+        },
     }
 
     if display_names:
@@ -230,7 +255,7 @@ def default_config(preset: str = "classic") -> LatticeConfig:
     workflow["descriptions"] = dict(STATUS_DESCRIPTIONS)
 
     config: LatticeConfig = {
-        "schema_version": 1,
+        "schema_version": 2,
         "default_status": "backlog",
         "default_priority": "medium",
         "task_types": [

--- a/src/lattice/core/config.py
+++ b/src/lattice/core/config.py
@@ -26,6 +26,9 @@ class Workflow(TypedDict, total=False):
     roles: list[str]
     descriptions: dict[str, str]
     review_cycle_limit: int
+    alerts: list[str]
+    alert_descriptions: dict[str, str]
+    alert_visuals: dict[str, dict]
 
 
 class HooksOnConfig(TypedDict, total=False):
@@ -43,6 +46,8 @@ class HooksOnConfig(TypedDict, total=False):
     relationship_added: str
     relationship_removed: str
     artifact_attached: str
+    alert_raised: str
+    alert_cleared: str
     branch_linked: str
     branch_unlinked: str
 
@@ -454,6 +459,61 @@ def validate_completion_policy(
         failures.append("Task must be assigned")
 
     return (len(failures) == 0, failures)
+
+
+# ---------------------------------------------------------------------------
+# Alerts (LAT-210) — orthogonal "needs attention" markers on a card
+# ---------------------------------------------------------------------------
+
+# Default fallback when a config predates LAT-210 and has no workflow.alerts.
+# The two original "modifier statuses" become the seed alert vocabulary.
+_LEGACY_ALERTS_FALLBACK: tuple[str, ...] = ("needs_human", "blocked")
+
+
+def get_workflow_alerts(config: dict) -> list[str]:
+    """Return the list of valid alert names for this project.
+
+    Reads ``workflow.alerts`` from config.  Falls back to the legacy
+    needs_human/blocked pair only when the field is missing entirely —
+    which makes pre-LAT-210 instances continue to work without
+    intervention.  An empty list in config is respected as-is (the
+    project has explicitly declared no alerts).
+    """
+    workflow = config.get("workflow") or {}
+    if "alerts" in workflow:
+        alerts = workflow.get("alerts") or []
+        if isinstance(alerts, list):
+            return [a for a in alerts if isinstance(a, str)]
+        return []
+    return list(_LEGACY_ALERTS_FALLBACK)
+
+
+def get_alert_descriptions(config: dict) -> dict[str, str]:
+    """Return ``workflow.alert_descriptions`` (empty dict when missing)."""
+    return dict(config.get("workflow", {}).get("alert_descriptions") or {})
+
+
+def get_alert_visual(config: dict, alert_name: str) -> dict:
+    """Return the visual-config dict for *alert_name*, merging config + defaults.
+
+    Resolution order: per-key override from ``workflow.alert_visuals.<name>``
+    falls back to the bridge defaults (``ALERT_VISUALS``) per-key.  This is
+    a per-key merge, not total replacement, so partial overrides are safe.
+    """
+    from lattice.cli.cmux_bridge import ALERT_VISUALS  # local import — CLI layer
+
+    bridge_defaults = ALERT_VISUALS.get(alert_name, {})
+    workflow = config.get("workflow") or {}
+    config_visuals = (workflow.get("alert_visuals") or {}).get(alert_name) or {}
+    merged: dict = dict(bridge_defaults)
+    for key, value in config_visuals.items():
+        merged[key] = value
+    return merged
+
+
+def validate_alert_name(config: dict, alert_name: str) -> bool:
+    """Return True when *alert_name* is in the configured alerts list."""
+    return alert_name in get_workflow_alerts(config)
 
 
 def get_configured_roles(config: LatticeConfig) -> set[str]:

--- a/src/lattice/core/events.py
+++ b/src/lattice/core/events.py
@@ -28,6 +28,8 @@ BUILTIN_EVENT_TYPES: frozenset[str] = frozenset(
         "relationship_added",
         "relationship_removed",
         "artifact_attached",
+        "alert_raised",
+        "alert_cleared",
         "git_event",
         "branch_linked",
         "branch_unlinked",
@@ -251,3 +253,71 @@ def count_review_rework_cycles(events: list[dict]) -> int:
 def utc_now() -> str:
     """Return the current UTC time as an RFC 3339 string with ``Z`` suffix."""
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Alert payload validation (LAT-210)
+# ---------------------------------------------------------------------------
+
+# Field-length caps for alert payloads.  CLI raises on violation; replay
+# truncates instead so historical events never break snapshot rebuild.
+ALERT_SHORT_MAX = 200
+ALERT_LONG_MAX = 4096
+ALERT_PROMPT_MAX = 256
+
+
+def validate_alert_payload(data: dict) -> tuple[bool, list[str]]:
+    """Validate an ``alert_raised`` event ``data`` payload.
+
+    Returns ``(True, [])`` when the payload conforms.  Returns
+    ``(False, [error, ...])`` when it does not.  CLI callers should raise
+    on errors; mutation handlers must truncate instead so an oversize
+    legacy event still replays into a (slightly degraded) snapshot.
+    """
+    errors: list[str] = []
+
+    name = data.get("name")
+    if not isinstance(name, str) or not name:
+        errors.append("alert.name is required and must be a non-empty string")
+
+    short = data.get("short")
+    if not isinstance(short, str) or not short:
+        errors.append("alert.short is required and must be a non-empty string")
+    elif len(short) > ALERT_SHORT_MAX:
+        errors.append(f"alert.short exceeds {ALERT_SHORT_MAX} chars")
+
+    long = data.get("long")
+    if long is not None:
+        if not isinstance(long, str):
+            errors.append("alert.long must be a string when set")
+        elif len(long) > ALERT_LONG_MAX:
+            errors.append(f"alert.long exceeds {ALERT_LONG_MAX} chars")
+
+    prompt = data.get("prompt")
+    if prompt is not None:
+        if not isinstance(prompt, str):
+            errors.append("alert.prompt must be a string when set")
+        elif len(prompt) > ALERT_PROMPT_MAX:
+            errors.append(f"alert.prompt exceeds {ALERT_PROMPT_MAX} chars")
+
+    return (not errors, errors)
+
+
+def truncate_alert_payload(data: dict) -> dict:
+    """Return a copy of *data* with oversized string fields truncated.
+
+    Used by the replay/mutation path so that an oversize historical event
+    does not crash snapshot rebuild.  CLI writers should use
+    ``validate_alert_payload`` and reject before writing.
+    """
+    out = dict(data)
+    short = out.get("short")
+    if isinstance(short, str) and len(short) > ALERT_SHORT_MAX:
+        out["short"] = short[:ALERT_SHORT_MAX]
+    long = out.get("long")
+    if isinstance(long, str) and len(long) > ALERT_LONG_MAX:
+        out["long"] = long[:ALERT_LONG_MAX]
+    prompt = out.get("prompt")
+    if isinstance(prompt, str) and len(prompt) > ALERT_PROMPT_MAX:
+        out["prompt"] = prompt[:ALERT_PROMPT_MAX]
+    return out

--- a/src/lattice/core/next.py
+++ b/src/lattice/core/next.py
@@ -8,15 +8,22 @@ from lattice.core.events import get_actor_display
 PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
 URGENCY_ORDER = {"immediate": 0, "high": 1, "normal": 2, "low": 3}
 
-# Statuses that are NOT eligible for next (terminal, waiting, or active).
+# Statuses that are NOT eligible for next (terminal or waiting on external work).
 # pr_open is waiting on external review/merge, so it is not pickable as next work.
-EXCLUDED_STATUSES = frozenset({"needs_human", "blocked", "done", "cancelled", "pr_open"})
+# needs_human and blocked are no longer statuses (LAT-210); see _has_alerts below
+# — any task with a non-empty alerts dict is ineligible regardless of status.
+EXCLUDED_STATUSES = frozenset({"done", "cancelled", "pr_open"})
 
 # Statuses indicating work already in progress (for resume-first logic)
 RESUME_STATUSES = frozenset({"in_progress", "in_planning"})
 
 # Default statuses considered "ready to pick up"
 DEFAULT_READY_STATUSES = frozenset({"backlog", "planned"})
+
+
+def _has_alerts(snap: dict) -> bool:
+    """Return True when *snap* has any active alerts."""
+    return bool(snap.get("alerts"))
 
 
 def _actors_match(assigned: str | dict | None, actor: str | dict | None) -> bool:
@@ -61,6 +68,8 @@ def select_next(
         for snap in snapshots:
             status = snap.get("status", "")
             assigned = snap.get("assigned_to")
+            if _has_alerts(snap):
+                continue  # alerted tasks are unpickable regardless of status
             if status in RESUME_STATUSES and _actors_match(assigned, actor):
                 resume_candidates.append(snap)
         if resume_candidates:
@@ -77,6 +86,8 @@ def select_next(
         # terminal/waiting states, still exclude them.
         if status in EXCLUDED_STATUSES:
             continue
+        if _has_alerts(snap):
+            continue  # alerted tasks are unpickable regardless of status
         assigned = snap.get("assigned_to")
         if assigned is not None and actor is not None and not _actors_match(assigned, actor):
             continue  # assigned to someone else
@@ -110,6 +121,8 @@ def select_all_ready(
         if status not in ready_statuses:
             continue
         if status in EXCLUDED_STATUSES:
+            continue
+        if _has_alerts(snap):
             continue
         candidates.append(snap)
 

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -164,10 +164,15 @@ def create_failure_diagnostic_task(
     agent_type: str,
     failure_count: int,
     actor: str,
+    *,
+    evidence_ref: str | None = None,
 ) -> str | None:
-    """Create a needs_human task for investigating persistent agent failures.
+    """Create a diagnostic task with a ``needs_human`` alert raised on it
+    (LAT-210 — replaces the old "move new task to needs_human status" path).
 
-    Returns the created task ID, or None on failure.
+    The new task is created at the default ``backlog`` status; the alert
+    is the signal for human attention.  Returns the created task ID, or
+    ``None`` on failure.
     """
     title = f"Investigate {agent_type} review failures — failed {failure_count} times"
     try:
@@ -189,16 +194,22 @@ def create_failure_diagnostic_task(
         new_task_id = result.stdout.strip()
         if not new_task_id:
             return None
-        # Move to needs_human
+        # Raise a needs_human alert on the diagnostic task instead of moving
+        # to needs_human status (LAT-210).
+        raise_args = [
+            "lattice",
+            "raise",
+            new_task_id,
+            "needs_human",
+            "--short",
+            f"Persistent {agent_type} agent failure ({failure_count}x)",
+            "--actor",
+            actor,
+        ]
+        if evidence_ref is not None:
+            raise_args += ["--evidence-ref", evidence_ref]
         subprocess.run(
-            [
-                "lattice",
-                "status",
-                new_task_id,
-                "needs_human",
-                "--actor",
-                actor,
-            ],
+            raise_args,
             capture_output=True,
             text=True,
             cwd=str(lattice_dir.parent),

--- a/src/lattice/core/stats.py
+++ b/src/lattice/core/stats.py
@@ -212,41 +212,71 @@ def _compute_time_in_status(events: list[dict], now: datetime) -> list[dict]:
     return result
 
 
-def _compute_blocked_counts(events: list[dict], active: list[dict]) -> dict:
-    """Compute blocked-related metrics.
+def _compute_alert_episode_counts(events: list[dict], active: list[dict]) -> dict:
+    """Compute alert-episode metrics (LAT-210 replacement for blocked counts).
 
-    Returns {currently_blocked, total_blocked_episodes, avg_blocked_hours}.
+    Walks ``alert_raised`` / ``alert_cleared`` event pairs.  Returns a
+    summary block plus per-alert-name breakdowns.
     """
-    currently_blocked = sum(1 for s in active if s.get("status") == "blocked")
-
-    # Count how many times any task entered "blocked"
-    unblocked_times: list[float] = []  # hours spent blocked
-
-    task_blocked_at: dict[str, datetime] = {}  # task_id -> when it entered blocked
+    # Per-alert tracking.
+    open_at: dict[tuple[str, str], datetime] = {}  # (task_id, alert_name) -> raised ts
+    durations_by_name: dict[str, list[float]] = {}  # alert_name -> hours per closed episode
 
     for ev in events:
-        if ev.get("type") != "status_changed":
+        et = ev.get("type")
+        if et not in ("alert_raised", "alert_cleared"):
             continue
-        data = ev.get("data", {})
-        ts = parse_ts(ev.get("ts", ""))
+        data = ev.get("data") or {}
+        name = data.get("name")
         tid = ev.get("task_id", "")
-        if not ts:
+        ts = parse_ts(ev.get("ts", ""))
+        if not name or not ts:
             continue
+        key = (tid, name)
+        if et == "alert_raised":
+            # Replace any existing open episode (double-raise overwrites raised_at).
+            open_at[key] = ts
+        else:  # alert_cleared
+            raised_at = open_at.pop(key, None)
+            if raised_at is not None:
+                hours = (ts - raised_at).total_seconds() / 3600
+                durations_by_name.setdefault(name, []).append(hours)
 
-        if data.get("to") == "blocked":
-            task_blocked_at[tid] = ts
-        elif data.get("from") == "blocked" and tid in task_blocked_at:
-            hours = (ts - task_blocked_at[tid]).total_seconds() / 3600
-            unblocked_times.append(hours)
-            del task_blocked_at[tid]
+    # Active counts come from snapshots (the source of truth post-replay).
+    currently_alerted = 0
+    by_name_active: dict[str, int] = {}
+    for snap in active:
+        alerts = snap.get("alerts") or {}
+        if alerts:
+            currently_alerted += 1
+        for alert_name in alerts:
+            by_name_active[alert_name] = by_name_active.get(alert_name, 0) + 1
 
-    total_episodes = len(unblocked_times) + len(task_blocked_at)  # resolved + still blocked
-    avg_hours = round(sum(unblocked_times) / len(unblocked_times), 1) if unblocked_times else 0
+    # Per-alert summary
+    by_alert: dict[str, dict] = {}
+    all_names = set(durations_by_name) | set(by_name_active) | {n for (_t, n) in open_at}
+    for name in sorted(all_names):
+        durations = durations_by_name.get(name, [])
+        still_open = sum(1 for k in open_at if k[1] == name)
+        total_episodes = len(durations) + still_open
+        avg_hours = round(sum(durations) / len(durations), 1) if durations else 0
+        by_alert[name] = {
+            "currently_alerted": by_name_active.get(name, 0),
+            "total_alert_episodes": total_episodes,
+            "avg_alert_hours": avg_hours,
+        }
+
+    total_episodes = sum(b["total_alert_episodes"] for b in by_alert.values())
+    all_durations = [d for ds in durations_by_name.values() for d in ds]
+    overall_avg = (
+        round(sum(all_durations) / len(all_durations), 1) if all_durations else 0
+    )
 
     return {
-        "currently_blocked": currently_blocked,
-        "total_blocked_episodes": total_episodes,
-        "avg_blocked_hours": avg_hours,
+        "currently_alerted": currently_alerted,
+        "total_alert_episodes": total_episodes,
+        "avg_alert_hours": overall_avg,
+        "by_alert": by_alert,
     }
 
 
@@ -389,7 +419,7 @@ def build_stats(lattice_dir: Path, config: dict) -> dict:
     all_events = load_all_events(lattice_dir)
     velocity = _compute_velocity(all_events, now)
     time_in_status = _compute_time_in_status(all_events, now)
-    blocked = _compute_blocked_counts(all_events, active)
+    alert_episodes = _compute_alert_episode_counts(all_events, active)
     agent_activity = _compute_agent_activity(all_events)
 
     return {
@@ -411,6 +441,6 @@ def build_stats(lattice_dir: Path, config: dict) -> dict:
         "busiest": busiest,
         "velocity": velocity,
         "time_in_status": time_in_status,
-        "blocked": blocked,
+        "alert_episodes": alert_episodes,
         "agent_activity": agent_activity,
     }

--- a/src/lattice/core/tasks.py
+++ b/src/lattice/core/tasks.py
@@ -133,6 +133,10 @@ def compact_snapshot(snapshot: dict) -> dict:
         "evidence_ref_count": len(snapshot.get("evidence_refs", [])),
         "branch_link_count": len(snapshot.get("branch_links", [])),
         "linked_file_count": len(snapshot.get("linked_files", [])),
+        # LAT-210: alerts surface on cards regardless of status — keep the
+        # full payload (small dict) in the compact view so the client can
+        # render alert visuals without a per-card detail fetch.
+        "alerts": snapshot.get("alerts") or {},
     }
     short_id = snapshot.get("short_id")
     if short_id is not None:

--- a/src/lattice/core/tasks.py
+++ b/src/lattice/core/tasks.py
@@ -28,6 +28,7 @@ PROTECTED_FIELDS: frozenset[str] = frozenset(
         "comment_count",
         "reopened_count",
         "custom_fields",
+        "alerts",
     }
 )
 
@@ -40,8 +41,6 @@ _DEFAULT_STATUS_ORDER: tuple[str, ...] = (
     "review",
     "pr_open",
     "done",
-    "blocked",
-    "needs_human",
     "cancelled",
 )
 _DEFAULT_STATUS_RANK: dict[str, int] = {
@@ -173,6 +172,7 @@ def _init_snapshot(event: dict) -> dict:
         "comment_count": 0,
         "reopened_count": 0,
         "custom_fields": data.get("custom_fields") or {},
+        "alerts": {},
         "last_event_id": event["id"],
     }
     short_id = data.get("short_id")
@@ -383,6 +383,38 @@ def _mut_comment_deleted(snap: dict, event: dict) -> None:
             for er in snap["evidence_refs"]
             if not (er.get("source_type") == "comment" and er.get("id") == comment_id)
         ]
+
+
+@_register_mutation("alert_raised")
+def _mut_alert_raised(snap: dict, event: dict) -> None:
+    from lattice.core.events import truncate_alert_payload
+
+    data = truncate_alert_payload(event.get("data") or {})
+    name = data.get("name")
+    if not isinstance(name, str) or not name:
+        # Malformed historical event — skip, don't crash replay.
+        return
+    alerts = snap.setdefault("alerts", {})
+    alerts[name] = {
+        "short": data.get("short", ""),
+        "long": data.get("long"),
+        "prompt": data.get("prompt"),
+        "location": data.get("location"),
+        "evidence_ref": data.get("evidence_ref"),
+        "raised_by": event.get("actor"),
+        "raised_at": event.get("ts"),
+    }
+
+
+@_register_mutation("alert_cleared")
+def _mut_alert_cleared(snap: dict, event: dict) -> None:
+    data = event.get("data") or {}
+    name = data.get("name")
+    if not isinstance(name, str) or not name:
+        return
+    alerts = snap.get("alerts") or {}
+    alerts.pop(name, None)
+    snap["alerts"] = alerts
 
 
 @_register_mutation("surface_bound")

--- a/src/lattice/dashboard/static/cube-v2.js
+++ b/src/lattice/dashboard/static/cube-v2.js
@@ -43,8 +43,15 @@ function _cv2CloseDetailPanel() {
 
 var CV2_STATUS_COLORS = {
   backlog: '#6b7280', in_planning: '#a78bfa', planned: '#60a5fa',
-  in_progress: '#34d399', review: '#fbbf24', done: '#22d3ee',
-  blocked: '#f87171', needs_human: '#f59e0b', cancelled: '#374151'
+  in_progress: '#34d399', review: '#fbbf24', pr_open: '#06b6d4',
+  done: '#22d3ee', cancelled: '#374151'
+};
+
+// LAT-210: alerts are orthogonal modifiers; the dashboard renders an
+// alert border on top of the status color when a card is alerted.
+var CV2_ALERT_COLORS = {
+  needs_human: '#FFD600',
+  blocked: '#FFA500'
 };
 
 var CV2_EDGE_COLORS = {

--- a/src/lattice/dashboard/static/cube-v2.js
+++ b/src/lattice/dashboard/static/cube-v2.js
@@ -44,7 +44,13 @@ function _cv2CloseDetailPanel() {
 var CV2_STATUS_COLORS = {
   backlog: '#6b7280', in_planning: '#a78bfa', planned: '#60a5fa',
   in_progress: '#34d399', review: '#fbbf24', pr_open: '#06b6d4',
-  done: '#22d3ee', cancelled: '#374151'
+  done: '#22d3ee', cancelled: '#374151',
+  // LAT-210: needs_human/blocked are no longer statuses in the default
+  // workflow, but legacy snapshots (or sibling instances that haven't
+  // migrated their config) may still carry these as a status value.  Keep
+  // entries here so those nodes render with a sensible color rather than
+  // the gray fallback.  Mirrors LANE_COLORS_BY_THEME in index.html.
+  needs_human: '#F2994A', blocked: '#EB5757'
 };
 
 // LAT-210: alerts are orthogonal modifiers; the dashboard renders an
@@ -53,6 +59,27 @@ var CV2_ALERT_COLORS = {
   needs_human: '#FFD600',
   blocked: '#FFA500'
 };
+
+// Pick the dominant alert color for a node, or null if no alerts are active.
+// Sort priority: needs_human > blocked (matches index.html alertCls block).
+function _cv2AlertColor(node) {
+  var a = node && node.alerts;
+  if (!a) return null;
+  if (a.needs_human) return CV2_ALERT_COLORS.needs_human;
+  if (a.blocked) return CV2_ALERT_COLORS.blocked;
+  // Generic fallback: any alert key present → use its color or yellow default.
+  for (var k in a) {
+    if (Object.prototype.hasOwnProperty.call(a, k)) {
+      return CV2_ALERT_COLORS[k] || '#FFD600';
+    }
+  }
+  return null;
+}
+
+// Resolve the rendered color for a node: alert color when alerted, else status.
+function _cv2NodeColor(node) {
+  return _cv2AlertColor(node) || CV2_STATUS_COLORS[node.status] || '#6b7280';
+}
 
 var CV2_EDGE_COLORS = {
   blocks: '#ef4444', depends_on: '#f97316', subtask_of: '#3b82f6',
@@ -328,7 +355,7 @@ function _cv2InitSimulation(nodes, links) {
   _cv2.nodeTargetColors = [];
   _cv2.nodeCurrentColors = [];
   for (var i = 0; i < nodes.length; i++) {
-    var c = new THREE.Color(CV2_STATUS_COLORS[nodes[i].status] || '#6b7280');
+    var c = new THREE.Color(_cv2NodeColor(nodes[i]));
     _cv2.nodeTargetColors.push({ r: c.r, g: c.g, b: c.b });
     _cv2.nodeCurrentColors.push({ r: c.r, g: c.g, b: c.b });
   }
@@ -1196,7 +1223,7 @@ function updateCubeV2Data(data) {
   _cv2.nodeTargetColors = [];
   _cv2.nodeCurrentColors = _cv2.nodeCurrentColors || [];
   for (var i = 0; i < nodes.length; i++) {
-    var c = new THREE.Color(CV2_STATUS_COLORS[nodes[i].status] || '#6b7280');
+    var c = new THREE.Color(_cv2NodeColor(nodes[i]));
     _cv2.nodeTargetColors.push({ r: c.r, g: c.g, b: c.b });
     // Preserve current colors for smooth transition, or init if new
     if (!_cv2.nodeCurrentColors[i]) {

--- a/src/lattice/dashboard/static/cube3d.js
+++ b/src/lattice/dashboard/static/cube3d.js
@@ -41,14 +41,39 @@ function _cube3dCurrentView() { return (_L.getCurrentView ? _L.getCurrentView() 
 var CUBE3D_STATUS_COLORS = {
   backlog: '#6b7280', in_planning: '#a78bfa', planned: '#60a5fa',
   in_progress: '#34d399', review: '#fbbf24', pr_open: '#06b6d4',
-  done: '#22d3ee', cancelled: '#374151'
+  done: '#22d3ee', cancelled: '#374151',
+  // LAT-210: legacy fallback for snapshots from sibling instances that
+  // still carry needs_human/blocked as a status.  Mirrors index.html's
+  // LANE_COLORS_BY_THEME and cube-v2.js's CV2_STATUS_COLORS.
+  needs_human: '#F2994A', blocked: '#EB5757'
 };
 
-// LAT-210: alert overlay colors (rendered as a card border).
+// LAT-210: alert overlay colors.  When a node has any active alert, its
+// rendered color is the alert hue (priority: needs_human > blocked) — the
+// 3D analogue of the main board's alert border.
 var CUBE3D_ALERT_COLORS = {
   needs_human: '#FFD600',
   blocked: '#FFA500'
 };
+
+// Pick the dominant alert color for a node, or null if no alerts are active.
+function cube3dAlertColor(node) {
+  var a = node && node.alerts;
+  if (!a) return null;
+  if (a.needs_human) return CUBE3D_ALERT_COLORS.needs_human;
+  if (a.blocked) return CUBE3D_ALERT_COLORS.blocked;
+  for (var k in a) {
+    if (Object.prototype.hasOwnProperty.call(a, k)) {
+      return CUBE3D_ALERT_COLORS[k] || '#FFD600';
+    }
+  }
+  return null;
+}
+
+// Resolve the rendered color for a node: alert color when alerted, else status.
+function cube3dNodeColor(node) {
+  return cube3dAlertColor(node) || cube3dStatusColor(node.status);
+}
 
 var CUBE3D_EDGE_COLORS = {
   blocks: '#ef4444', depends_on: '#f97316', subtask_of: '#3b82f6',
@@ -505,7 +530,7 @@ function _cube3dCreateNodes(nodes) {
     dummy.updateMatrix();
     mesh.setMatrixAt(i, dummy.matrix);
 
-    var rgb = cube3dHexToRgb(cube3dStatusColor(node.status));
+    var rgb = cube3dHexToRgb(cube3dNodeColor(node));
     colors[i * 3]     = rgb.r;
     colors[i * 3 + 1] = rgb.g;
     colors[i * 3 + 2] = rgb.b;
@@ -1156,7 +1181,7 @@ function _cube3dApplySearch(query) {
   for (var j = 0; j < _cube3d.nodeData.length; j++) {
     var n = _cube3d.nodeData[j];
     if (_cube3d.searchMatches.has(j)) {
-      var rgb = cube3dHexToRgb(cube3dStatusColor(n.status));
+      var rgb = cube3dHexToRgb(cube3dNodeColor(n));
       arr[j * 3]     = rgb.r;
       arr[j * 3 + 1] = rgb.g;
       arr[j * 3 + 2] = rgb.b;
@@ -1201,7 +1226,7 @@ function _cube3dClearSearchHighlight() {
   var arr = colors.array;
   for (var i = 0; i < _cube3d.nodeData.length; i++) {
     var n = _cube3d.nodeData[i];
-    var rgb = cube3dHexToRgb(cube3dStatusColor(n.status));
+    var rgb = cube3dHexToRgb(cube3dNodeColor(n));
     arr[i * 3]     = rgb.r;
     arr[i * 3 + 1] = rgb.g;
     arr[i * 3 + 2] = rgb.b;

--- a/src/lattice/dashboard/static/cube3d.js
+++ b/src/lattice/dashboard/static/cube3d.js
@@ -40,8 +40,14 @@ function _cube3dCurrentView() { return (_L.getCurrentView ? _L.getCurrentView() 
 
 var CUBE3D_STATUS_COLORS = {
   backlog: '#6b7280', in_planning: '#a78bfa', planned: '#60a5fa',
-  in_progress: '#34d399', review: '#fbbf24', done: '#22d3ee',
-  blocked: '#f87171', needs_human: '#f59e0b', cancelled: '#374151'
+  in_progress: '#34d399', review: '#fbbf24', pr_open: '#06b6d4',
+  done: '#22d3ee', cancelled: '#374151'
+};
+
+// LAT-210: alert overlay colors (rendered as a card border).
+var CUBE3D_ALERT_COLORS = {
+  needs_human: '#FFD600',
+  blocked: '#FFA500'
 };
 
 var CUBE3D_EDGE_COLORS = {
@@ -875,10 +881,10 @@ function _cube3dShowCard(node) {
     + '<div class="cube3d-card-meta">'
     + (node.priority
       ? '<span class="cube3d-card-priority" style="background:'
-        + cube3dStatusColor(
-            node.priority === 'critical' ? 'blocked'
-            : node.priority === 'high' ? 'review'
-            : 'in_progress'
+        + (
+            node.priority === 'critical' ? '#f87171'
+            : node.priority === 'high' ? '#fbbf24'
+            : '#34d399'
           ) + '"></span>'
       : '')
     + (node.assigned_to

--- a/src/lattice/dashboard/static/index.html
+++ b/src/lattice/dashboard/static/index.html
@@ -260,6 +260,19 @@ tr.heat-cooling td:first-child{border-left:3px solid #eab308}
 .alert-strip{display:block;font-size:.65rem;font-weight:700;letter-spacing:.08em;padding:1px 4px;margin-bottom:2px;border-radius:2px}
 .alert-strip-needs_human{background:#FFD600;color:#212529}
 .alert-strip-blocked{background:#FFA500;color:#212529}
+/* LAT-210: top-of-board alerts banner + filter (Phase 6). */
+.board-alerts-controls{display:flex;align-items:center;gap:12px;margin:0 0 6px 0;padding:0 4px;font-size:.8rem;color:var(--text-secondary)}
+.board-alerts-controls select{padding:0.2rem 0.4rem;border:1px solid var(--border);border-radius:var(--radius-sm);font-size:.8rem;background:var(--surface);color:var(--text-primary)}
+.board-alerts-summary{font-size:.75rem;color:var(--text-muted)}
+.board-alerts-banner{display:flex;flex-wrap:wrap;gap:6px;margin:0 0 10px 0;padding:6px 8px;border-radius:var(--radius-sm,4px);background:var(--surface);border:1px solid var(--border-subtle,var(--border))}
+.board-alerts-banner-item{display:inline-flex;align-items:center;gap:6px;padding:3px 8px;border-radius:var(--radius-sm,4px);border:1px solid transparent;cursor:pointer;font:inherit;font-size:.72rem;max-width:340px;overflow:hidden}
+.board-alerts-banner-item.alert-strip-needs_human{background:#FFD600;color:#212529}
+.board-alerts-banner-item.alert-strip-blocked{background:#FFA500;color:#212529}
+.board-alerts-banner-tag{font-weight:700;font-size:.62rem;letter-spacing:.06em}
+.board-alerts-banner-id{font-weight:600;font-size:.68rem;opacity:.9}
+.board-alerts-banner-title{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:220px}
+.card.alert-flash{animation:alert-flash-anim 1.5s ease-out}
+@keyframes alert-flash-anim{0%{box-shadow:0 0 0 6px rgba(255,214,0,.85)}100%{box-shadow:0 0 0 0 transparent}}
 .status-review .board-col-header{background:#6f42c1;color:var(--text-on-lane)}
 
 /* List view */
@@ -4289,6 +4302,31 @@ function renderBoardCard(t) {
 }
 
 // --- Board View ---
+// LAT-210 Phase 6: alert filter state.  One of: "any", "needs_human_only",
+// "blocked_only", "no_alerts".  Persisted across renders within a session.
+var boardAlertFilter = "any";
+
+function _alertNamesOf(t) { return (t && t.alerts) ? Object.keys(t.alerts) : []; }
+function _hasAlert(t, name) { return !!(t && t.alerts && Object.prototype.hasOwnProperty.call(t.alerts, name)); }
+function _matchesAlertFilter(t) {
+  switch (boardAlertFilter) {
+    case "needs_human_only": return _hasAlert(t, "needs_human");
+    case "blocked_only": return _hasAlert(t, "blocked");
+    case "no_alerts": return _alertNamesOf(t).length === 0;
+    default: return true;
+  }
+}
+function _primaryAlertOf(t) {
+  if (_hasAlert(t, "needs_human")) return "needs_human";
+  var names = _alertNamesOf(t);
+  return names.length > 0 ? names[0] : null;
+}
+function _alertSortRank(name) {
+  if (name === "needs_human") return 0;
+  if (name === "blocked") return 1;
+  return 2;
+}
+
 function renderBoard() {
   var app = document.getElementById("app");
   if (!config || !tasks) { app.innerHTML = '<div class="loading"><div class="spinner"></div></div>'; return; }
@@ -4305,9 +4343,22 @@ function renderBoard() {
   window._latticeBoardData = tasks;
 
   var transitions = (config.workflow && config.workflow.transitions) || {};
+
+  // LAT-210 Phase 6: collect alerted tasks for the top banner (always shows
+  // every alerted card, regardless of the active filter), then apply the
+  // alert filter to the column-rendering pass.
+  var alertedTasks = tasks.filter(function(tt) { return _alertNamesOf(tt).length > 0; });
+  alertedTasks.sort(function(a, b) {
+    var ra = _alertSortRank(_primaryAlertOf(a));
+    var rb = _alertSortRank(_primaryAlertOf(b));
+    if (ra !== rb) return ra - rb;
+    return (a.short_id || "").localeCompare(b.short_id || "");
+  });
+  var visibleTasks = tasks.filter(_matchesAlertFilter);
+
   var grouped = {};
   statuses.forEach(function(s) { grouped[s] = []; });
-  tasks.forEach(function(t) {
+  visibleTasks.forEach(function(t) {
     var s = t.status || "unknown";
     if (!grouped[s]) grouped[s] = [];
     grouped[s].push(t);
@@ -4323,6 +4374,38 @@ function renderBoard() {
   }).join(' ');
 
   var html = '<div class="board-wrapper">';
+
+  // LAT-210 Phase 6: alerts controls strip + top-of-board banner.
+  html += '<div class="board-alerts-controls">';
+  html += '<label>Alerts: ';
+  html += '<select id="board-alert-filter">';
+  [["any","Any"],["needs_human_only","needs_human only"],["blocked_only","blocked only"],["no_alerts","No alerts"]].forEach(function(opt) {
+    var sel = boardAlertFilter === opt[0] ? ' selected' : '';
+    html += '<option value="' + opt[0] + '"' + sel + '>' + esc(opt[1]) + '</option>';
+  });
+  html += '</select>';
+  html += '</label>';
+  if (alertedTasks.length > 0) {
+    html += '<span class="board-alerts-summary">' + alertedTasks.length + ' alerted</span>';
+  }
+  html += '</div>';
+
+  if (alertedTasks.length > 0) {
+    html += '<div class="board-alerts-banner" role="region" aria-label="Active alerts">';
+    alertedTasks.forEach(function(at) {
+      var prim = _primaryAlertOf(at);
+      var label = (prim || "alert").toUpperCase().replace(/_/g, " ");
+      var alertObj = (at.alerts && prim && at.alerts[prim]) || {};
+      var shortText = alertObj.short || "";
+      var cls = prim ? " alert-strip-" + prim : "";
+      html += '<button type="button" class="board-alerts-banner-item' + cls + '" data-task-id="' + esc(at.id) + '" title="' + esc(shortText) + '">';
+      html += '<span class="board-alerts-banner-tag">' + esc(label) + '</span>';
+      if (at.short_id) html += '<span class="board-alerts-banner-id">' + esc(at.short_id) + '</span>';
+      html += '<span class="board-alerts-banner-title">' + esc(at.title || "") + '</span>';
+      html += '</button>';
+    });
+    html += '</div>';
+  }
 
   // Board columns
   html += '<div class="board-scroll-outer"><div class="board-scroll">';
@@ -4433,6 +4516,32 @@ function renderBoard() {
   html += "</div>"; // close .board-wrapper
 
   app.innerHTML = html;
+
+  // LAT-210 Phase 6: alert filter dropdown.  On change, save the new filter
+  // value to the module-level state and re-render the board.
+  var alertFilterSelect = document.getElementById("board-alert-filter");
+  if (alertFilterSelect) {
+    alertFilterSelect.addEventListener("change", function() {
+      boardAlertFilter = this.value;
+      renderBoard();
+    });
+  }
+
+  // LAT-210 Phase 6: alerts banner — clicking an entry scrolls its card
+  // into view and flashes a halo to draw the eye.
+  app.querySelectorAll(".board-alerts-banner-item").forEach(function(btn) {
+    btn.addEventListener("click", function() {
+      var tid = btn.getAttribute("data-task-id");
+      if (!tid) return;
+      var sel = '.card[data-task-id="' + (window.CSS && CSS.escape ? CSS.escape(tid) : tid) + '"]';
+      var card = app.querySelector(sel);
+      if (card) {
+        card.scrollIntoView({ behavior: "smooth", block: "center" });
+        card.classList.add("alert-flash");
+        setTimeout(function() { card.classList.remove("alert-flash"); }, 1500);
+      }
+    });
+  });
 
   // Add click handlers for card → floating detail panel (separate from drag)
   app.querySelectorAll(".card").forEach(function(card) {

--- a/src/lattice/dashboard/static/index.html
+++ b/src/lattice/dashboard/static/index.html
@@ -252,9 +252,14 @@ tr.heat-cooling td:first-child{border-left:3px solid #eab308}
 .status-implemented .board-col-header{background:#0dcaf0;color:var(--text-on-lane)}
 .status-in_review .board-col-header{background:#6f42c1;color:var(--text-on-lane)}
 .status-backlog .board-col-header{background:#adb5bd;color:var(--text-on-lane)}
-.status-blocked .board-col-header{background:#dc3545;color:var(--text-on-lane)}
-.status-needs_human .board-col-header{background:#f59e0b;color:#212529}
 .status-in_progress .board-col-header{background:#0d6efd;color:var(--text-on-lane)}
+
+/* LAT-210: alerts are orthogonal modifiers — render a colored card border. */
+.alert-needs_human{border:2px solid #FFD600 !important;box-shadow:0 0 6px rgba(255,214,0,.45)}
+.alert-blocked{border:2px solid #FFA500 !important;box-shadow:0 0 6px rgba(255,165,0,.35)}
+.alert-strip{display:block;font-size:.65rem;font-weight:700;letter-spacing:.08em;padding:1px 4px;margin-bottom:2px;border-radius:2px}
+.alert-strip-needs_human{background:#FFD600;color:#212529}
+.alert-strip-blocked{background:#FFA500;color:#212529}
 .status-review .board-col-header{background:#6f42c1;color:var(--text-on-lane)}
 
 /* List view */
@@ -4238,9 +4243,21 @@ function renderBoardCard(t) {
   var tier = heatEnabled ? getHeatTier(t.last_status_changed_at) : null;
   var ratio = heatEnabled ? getHeatBarRatio(t.last_status_changed_at) : 0;
 
-  var html = '<div class="card' + (heatCls ? " " + heatCls : "") + '" draggable="true" data-task-id="' + esc(t.id) + '" data-task-status="' + esc(t.status || "") + '"';
+  // LAT-210: surface alerts via a card-level border class + strip text.
+  var alertNames = t.alerts ? Object.keys(t.alerts) : [];
+  var primaryAlert = null;
+  if (alertNames.indexOf("needs_human") >= 0) primaryAlert = "needs_human";
+  else if (alertNames.length > 0) primaryAlert = alertNames[0];
+  var alertCls = primaryAlert ? " alert-" + primaryAlert : "";
+
+  var html = '<div class="card' + (heatCls ? " " + heatCls : "") + alertCls + '" draggable="true" data-task-id="' + esc(t.id) + '" data-task-status="' + esc(t.status || "") + '"';
   if (t.last_status_changed_at) html += ' data-heat-ts="' + esc(t.last_status_changed_at) + '"';
   html += ' ondragstart="window._boardDragStart(event)" ondragend="window._boardDragEnd(event)">';
+
+  if (primaryAlert) {
+    var alertLabel = primaryAlert.toUpperCase().replace(/_/g, " ");
+    html += '<span class="alert-strip alert-strip-' + primaryAlert + '" title="ALERT: ' + esc(alertLabel) + '">ALERT: ' + esc(alertLabel) + '</span>';
+  }
 
   // Heat bar: vertical bar on left that shrinks as heat cools (gradient: solid at bottom, fading to transparent)
   if (heatEnabled && tier && tier.color && ratio > 0) {

--- a/src/lattice/dashboard/static/index.html
+++ b/src/lattice/dashboard/static/index.html
@@ -2621,9 +2621,8 @@ function drawWebNode(node, ctx, globalScale) {
   var color = getLaneColor(node.status);
   var alpha = 1.0;
 
-  // Dimming for done/blocked
+  // Dimming for terminal statuses (LAT-210: blocked is now an alert, not a status)
   if (node.status === "done" || node.status === "cancelled") alpha = 0.3;
-  else if (node.status === "blocked") alpha = 0.4;
 
   ctx.globalAlpha = alpha;
 
@@ -6150,14 +6149,15 @@ async function renderStats() {
       html += '</div>';
     }
 
-    // Blocked counts
-    if (data.blocked) {
-      html += '<div class="stats-section"><h3>Blocked</h3>';
+    // Alert episodes (LAT-210; replaces the old blocked-status counts)
+    if (data.alert_episodes) {
+      var ae = data.alert_episodes;
+      html += '<div class="stats-section"><h3>Alerts</h3>';
       html += '<div class="blocked-cards">';
-      html += '<div class="blocked-card"><div class="blocked-card-value' + (data.blocked.currently_blocked > 0 ? ' danger' : '') + '">' + esc(data.blocked.currently_blocked) + '</div><div class="blocked-card-label">Currently Blocked</div></div>';
-      html += '<div class="blocked-card"><div class="blocked-card-value">' + esc(data.blocked.total_blocked_episodes) + '</div><div class="blocked-card-label">Total Episodes</div></div>';
-      var avgBlk = data.blocked.avg_blocked_hours >= 24 ? (data.blocked.avg_blocked_hours / 24).toFixed(1) + 'd' : data.blocked.avg_blocked_hours.toFixed(1) + 'h';
-      html += '<div class="blocked-card"><div class="blocked-card-value">' + esc(avgBlk) + '</div><div class="blocked-card-label">Avg Resolution</div></div>';
+      html += '<div class="blocked-card"><div class="blocked-card-value' + (ae.currently_alerted > 0 ? ' danger' : '') + '">' + esc(ae.currently_alerted) + '</div><div class="blocked-card-label">Currently Alerted</div></div>';
+      html += '<div class="blocked-card"><div class="blocked-card-value">' + esc(ae.total_alert_episodes) + '</div><div class="blocked-card-label">Total Episodes</div></div>';
+      var avgAlert = ae.avg_alert_hours >= 24 ? (ae.avg_alert_hours / 24).toFixed(1) + 'd' : ae.avg_alert_hours.toFixed(1) + 'h';
+      html += '<div class="blocked-card"><div class="blocked-card-value">' + esc(avgAlert) + '</div><div class="blocked-card-label">Avg Resolution</div></div>';
       html += '</div></div>';
     }
 

--- a/src/lattice/mcp/tools.py
+++ b/src/lattice/mcp/tools.py
@@ -1367,3 +1367,149 @@ def lattice_doctor(
         if (lattice_dir / "archive" / "tasks").is_dir()
         else 0,
     }
+
+
+# ---------------------------------------------------------------------------
+# Alerts (LAT-210)
+# ---------------------------------------------------------------------------
+
+
+_TERMINAL_STATUSES_FOR_ALERTS: frozenset[str] = frozenset({"done", "cancelled"})
+
+
+def _is_archived_task(lattice_dir: Path, task_id: str) -> bool:
+    return (lattice_dir / "archive" / "tasks" / f"{task_id}.json").exists()
+
+
+@mcp.tool()
+def lattice_raise_alert(
+    task_id: Annotated[str, Field(description="Task ID (ULID or short ID)")],
+    alert_name: Annotated[
+        str, Field(description="Alert name from workflow.alerts (e.g. needs_human, blocked)")
+    ],
+    short: Annotated[
+        str, Field(description="Short summary (≤200 chars)")
+    ],
+    actor: Annotated[str, Field(description="Actor raising the alert")],
+    long: Annotated[
+        str | None, Field(description="Long-form detail (≤4096 chars)")
+    ] = None,
+    prompt: Annotated[
+        str | None, Field(description="Suggested clear command (≤256 chars)")
+    ] = None,
+    evidence_ref: Annotated[
+        str | None, Field(description="Linked artifact id (e.g. plan-review)")
+    ] = None,
+    lattice_root: Annotated[
+        str | None, Field(description="Path to project directory containing .lattice/")
+    ] = None,
+) -> dict:
+    """Raise an alert on a task (LAT-210). Alerts are orthogonal to status."""
+    from lattice.core.config import get_workflow_alerts, validate_alert_name
+    from lattice.core.events import validate_alert_payload
+
+    lattice_dir = _find_root(lattice_root)
+    config = _load_config(lattice_dir)
+    _validate_actor(actor)
+
+    if not validate_alert_name(config, alert_name):
+        valid = ", ".join(get_workflow_alerts(config)) or "(none configured)"
+        raise ValueError(f"Unknown alert: '{alert_name}'. Valid alerts: {valid}.")
+
+    task_id = _resolve_task_id(lattice_dir, task_id)
+
+    if _is_archived_task(lattice_dir, task_id):
+        raise ValueError(f"Cannot raise alert on archived task {task_id}.")
+
+    snapshot = _read_snapshot_or_error(lattice_dir, task_id)
+    if snapshot.get("status") in _TERMINAL_STATUSES_FOR_ALERTS:
+        raise ValueError(
+            f"Cannot raise alert on task in terminal status '{snapshot.get('status')}'."
+        )
+
+    event_data: dict = {"name": alert_name, "short": short}
+    if long is not None:
+        event_data["long"] = long
+    if prompt is not None:
+        event_data["prompt"] = prompt
+    if evidence_ref is not None:
+        event_data["evidence_ref"] = evidence_ref
+
+    ok, errors = validate_alert_payload(event_data)
+    if not ok:
+        raise ValueError("; ".join(errors))
+
+    event = create_event(
+        type="alert_raised",
+        task_id=task_id,
+        actor=actor,
+        data=event_data,
+    )
+    updated_snapshot = apply_event_to_snapshot(snapshot, event)
+    write_task_event(lattice_dir, task_id, [event], updated_snapshot, config)
+    return updated_snapshot
+
+
+@mcp.tool()
+def lattice_clear_alert(
+    task_id: Annotated[str, Field(description="Task ID (ULID or short ID)")],
+    alert_name: Annotated[
+        str, Field(description="Alert name to clear (must be in workflow.alerts)")
+    ],
+    actor: Annotated[str, Field(description="Actor clearing the alert")],
+    answer: Annotated[
+        str | None, Field(description="Recorded answer / justification")
+    ] = None,
+    note: Annotated[str | None, Field(description="Alternate framing of the clear")] = None,
+    lattice_root: Annotated[
+        str | None, Field(description="Path to project directory containing .lattice/")
+    ] = None,
+) -> dict:
+    """Clear an alert from a task. Idempotent: re-clear is a no-op success."""
+    from lattice.core.config import get_workflow_alerts, validate_alert_name
+
+    lattice_dir = _find_root(lattice_root)
+    config = _load_config(lattice_dir)
+    _validate_actor(actor)
+
+    if not validate_alert_name(config, alert_name):
+        valid = ", ".join(get_workflow_alerts(config)) or "(none configured)"
+        raise ValueError(f"Unknown alert: '{alert_name}'. Valid alerts: {valid}.")
+
+    task_id = _resolve_task_id(lattice_dir, task_id)
+
+    if _is_archived_task(lattice_dir, task_id):
+        raise ValueError(f"Cannot clear alert on archived task {task_id}.")
+
+    snapshot = _read_snapshot_or_error(lattice_dir, task_id)
+    alerts = snapshot.get("alerts") or {}
+
+    # Idempotent re-clear.
+    if alert_name not in alerts:
+        return {
+            "task_id": task_id,
+            "alert": alert_name,
+            "cleared": False,
+            "alerts": alerts,
+        }
+
+    event_data: dict = {"name": alert_name}
+    if answer is not None:
+        event_data["answer"] = answer
+    if note is not None:
+        event_data["note"] = note
+
+    event = create_event(
+        type="alert_cleared",
+        task_id=task_id,
+        actor=actor,
+        data=event_data,
+    )
+    updated_snapshot = apply_event_to_snapshot(snapshot, event)
+    write_task_event(lattice_dir, task_id, [event], updated_snapshot, config)
+    return {
+        "task_id": task_id,
+        "alert": alert_name,
+        "cleared": True,
+        "alerts": updated_snapshot.get("alerts") or {},
+    }

--- a/src/lattice/skills/lattice/SKILL.md
+++ b/src/lattice/skills/lattice/SKILL.md
@@ -49,8 +49,8 @@ The `--review` text is your breadcrumb for every future agent and human who read
 | Outcome | Action |
 |---------|--------|
 | **Done** | `lattice complete <task_id> --review "..." --actor agent:claude-cli` |
-| **Need human input** | `lattice status <task_id> needs_human --actor agent:claude-cli` + comment explaining what you need |
-| **Blocked on dependency** | `lattice status <task_id> blocked --actor agent:claude-cli` + comment explaining the blocker |
+| **Need human input** | `lattice raise <task_id> needs_human --short "..." --actor agent:claude-cli` (LAT-210; alert is orthogonal to status) |
+| **Blocked on dependency** | `lattice raise <task_id> blocked --short "..." --actor agent:claude-cli` |
 
 ## The Work In Between
 
@@ -120,12 +120,29 @@ Relationship types for `link`: `blocks`, `blocked_by`, `subtask_of`, `parent_of`
 ## Status Workflow
 
 ```
-backlog → in_planning → planned → in_progress → review → done
-                                       ↕            ↕
-                                    blocked      needs_human
+backlog → in_planning → planned → in_progress → review → pr_open → done
+                                                   ↘ cancelled
 ```
 
 Transitions are enforced. Use `--force --reason "..."` to override when genuinely needed.
+
+## Alerts (LAT-210)
+
+`needs_human` and `blocked` are no longer statuses — they are **alerts**, orthogonal to lifecycle position. Raise an alert to signal "this card needs attention right now"; the task stays in its current column.
+
+```bash
+lattice raise PROJ-1 needs_human --short "Decide REST or GraphQL?" --actor agent:claude-cli
+lattice raise PROJ-1 blocked     --short "CI down on shared runner" --actor agent:claude-cli
+lattice clear PROJ-1 needs_human --answer "REST. Client simplicity wins." --actor human:atin
+```
+
+- `lattice next` excludes any task with active alerts.
+- `lattice list --alerted`, `--alert <name>`, `--no-alerts` filter the queue.
+- `lattice show <task>` renders an Alerts: block.
+- The dashboard paints a colored border + ALERT strip on the card.
+- The c11 sidebar gets a pill (yellow for needs_human, orange for blocked); needs_human flashes the surface and posts a notification by default.
+
+Clearing a not-raised alert is a no-op success (idempotent). Re-raising overwrites the snapshot entry and writes a second `alert_raised` event for audit.
 
 ## Actor IDs
 
@@ -146,7 +163,7 @@ All commands support `--json` for structured output: `{"ok": true, "data": ...}`
 
 Check if enabled: look for `"heartbeat": {"enabled": true}` in `.lattice/config.json`.
 
-When enabled, keep advancing after each task: complete the current task → `lattice next --claim` → work the next one → repeat. Stop after `max_advances` (default 10), when the backlog is empty, or when a task hits `needs_human` or `blocked`.
+When enabled, keep advancing after each task: complete the current task → `lattice next --claim` → work the next one → repeat. Stop after `max_advances` (default 10), when the backlog is empty, or when a task has any active alerts (`lattice next` skips alerted tasks).
 
 ## Rules
 
@@ -154,7 +171,7 @@ When enabled, keep advancing after each task: complete the current task → `lat
 2. **Close with `lattice complete`.** Never raw `lattice status ... done`.
 3. **One task at a time.** Finish or transition before claiming the next.
 4. **Don't force transitions.** If a transition fails, investigate why.
-5. **Don't cancel human tasks.** Use `needs_human` instead — let the human decide.
+5. **Don't cancel work that needs human input.** Raise a `needs_human` alert instead — let the human decide.
 6. **Comment liberally.** The next agent has no hallway to find you in.
 
 ## References

--- a/src/lattice/skills/lattice/references/multi-agent-guide.md
+++ b/src/lattice/skills/lattice/references/multi-agent-guide.md
@@ -58,20 +58,26 @@ lattice next --actor agent:worker-1 --claim
 
 `lattice next` considers priority, dependencies, and blockers to suggest the best task.
 
-### 5. Handling Blocks
+### 5. Handling Blocks (Alerts — LAT-210)
+
+`needs_human` and `blocked` are alerts now, not statuses. The task stays in its current lifecycle column; the alert decorates it and excludes it from `lattice next`.
 
 When a worker is stuck:
 
 ```bash
-lattice status PROJ-2 blocked --actor agent:worker-1
-lattice comment PROJ-2 "Blocked: need database schema from PROJ-5" --actor agent:worker-1
+lattice raise PROJ-2 blocked --short "Need database schema from PROJ-5" --actor agent:worker-1
 ```
 
 When a worker needs a human decision:
 
 ```bash
-lattice status PROJ-2 needs_human --actor agent:worker-1
-lattice comment PROJ-2 "Need: which OAuth provider to use?" --actor agent:worker-1
+lattice raise PROJ-2 needs_human --short "Which OAuth provider to use?" --actor agent:worker-1
+```
+
+The orchestrator (or human) clears the alert when resolved:
+
+```bash
+lattice clear PROJ-2 needs_human --answer "Use Auth0" --actor human:atin
 ```
 
 ### 6. Event History

--- a/src/lattice/templates/claude_md_block.py
+++ b/src/lattice/templates/claude_md_block.py
@@ -26,7 +26,7 @@ lattice create "<title>" --actor agent:<your-id>
 
 When in doubt, create the task. A small task costs nothing. Lost visibility costs everything.
 
-**Recurring observations become tasks.** If you observe the same issue in 2+ consecutive sessions or advances (e.g., a failing test, a lint warning, a flaky behavior), create a task for it. Agents are disciplined about tracking assigned work but not discovered work — this convention closes that gap. Create discovered issues at `needs_human` if they need scoping, or `backlog` if they're well-understood.
+**Recurring observations become tasks.** If you observe the same issue in 2+ consecutive sessions or advances (e.g., a failing test, a lint warning, a flaky behavior), create a task for it. Agents are disciplined about tracking assigned work but not discovered work — this convention closes that gap. Create discovered issues at `backlog` if they're well-understood; if they need human scoping, raise a `needs_human` alert via `lattice raise <task> needs_human --short "..."`.
 
 ### Descriptions Carry Context
 
@@ -45,10 +45,23 @@ lattice status <task> <status> --actor agent:<your-id>
 ```
 
 ```
-backlog → in_planning → planned → in_progress → review → done
-                                       ↕            ↕
-                                    blocked      needs_human
+backlog → in_planning → planned → in_progress → review → pr_open → done
+                                                   ↘ cancelled
 ```
+
+**Alerts are orthogonal to status (LAT-210).** When work needs human input or is
+blocked on something external, you raise an *alert* on the card — it stays in
+its current lifecycle position, and the alert decorates it.
+
+```
+lattice raise <task> needs_human --short "Decide approach" --actor agent:<id>
+lattice raise <task> blocked     --short "CI down"           --actor agent:<id>
+lattice clear <task> needs_human --answer "REST"             --actor human:<id>
+```
+
+Alerts auto-exclude a task from `lattice next`. The dashboard renders an alert
+border + strip on the card. `lattice list --alerted` and `--alert <name>`
+surface the queue.
 
 **Transition discipline:**
 - `in_planning` — before you open the first file to read. Then write the plan.
@@ -105,7 +118,7 @@ cat .lattice/config.json | python3 -c "import sys,json; d=json.load(sys.stdin); 
 | `single` | Spawns one review agent |
 | `inline` | Reviews the plan in-session (use when codex/gemini aren't available, or for small/throwaway projects) |
 
-When `plan_approval` is `human`, the CLI automatically moves the task to `needs_human` after `lattice plan-review` completes. Wait for human approval before proceeding to `in_progress`.
+When `plan_approval` is `human`, the CLI automatically raises a `needs_human` alert on the task after `lattice plan-review` completes (LAT-210; the task stays in its current status). Wait for the human to clear the alert (`lattice clear <task> needs_human --answer "approved"`) before proceeding to `in_progress`.
 
 ### Plan Review Triage
 
@@ -115,7 +128,7 @@ When the plan review returns (trident or otherwise), the orchestrator sorts ever
 |--------|--------------------|----------------|
 | **Obvious** | Missing acceptance criteria, contradictions, plan bugs, trivial clarifications, concrete omissions | Fix directly — amend the plan file, record a short `lattice comment` noting what was resolved. |
 | **Evolutionary** | Speculative additions, "while we're at it" scope creep, refactor suggestions not tied to the ticket's goal, nice-to-haves | Be skeptical. Default to skip. If worth tracking, create a new Lattice task (`lattice create ...`) and link it — do not fold into this ticket. Record a comment explaining why it was deferred. |
-| **Complex** | Genuine design decisions, ambiguity the agent can't resolve alone, trade-offs with real stakes, requirement questions | Bring to the human. Move to `needs_human` with a short comment stating the open question(s). |
+| **Complex** | Genuine design decisions, ambiguity the agent can't resolve alone, trade-offs with real stakes, requirement questions | Bring to the human. Raise a `needs_human` alert (`lattice raise <task> needs_human --short "..."`) and pause until it is cleared. |
 
 Every finding must be explicitly triaged — no silent drops. If triage produces no complex questions, advance to `in_progress`. Otherwise, wait for the human answer, fold it into the plan, then advance.
 
@@ -183,7 +196,7 @@ When a review agent evaluates work, it produces one of three outcomes:
 | Route to in_progress vs in_planning | Orchestrator | Follows review agent's recommendation |
 | Whether to spawn fresh sub-agent | Orchestrator | Encouraged by convention, not enforced |
 
-**3-cycle safety valve:** After 3 review-to-rework transitions (any combination of `review -> in_progress` and `review -> in_planning`), the CLI blocks the 4th attempt. The error message instructs the agent to move the task to `needs_human` with a comment explaining the situation. The limit is configurable via `review_cycle_limit` in the workflow config (default: 3). Override with `--force --reason` for genuinely exceptional cases.
+**3-cycle safety valve:** After 3 review-to-rework transitions (any combination of `review -> in_progress` and `review -> in_planning`), the CLI blocks the 4th attempt. The error message instructs the agent to raise a `needs_human` alert with a comment explaining the situation. The limit is configurable via `review_cycle_limit` in the workflow config (default: 3). Override with `--force --reason` for genuinely exceptional cases.
 
 **Allowed lifecycle paths:**
 
@@ -192,7 +205,7 @@ Normal:       in_progress -> review -> done
 Minor fix:    in_progress -> review -> (fix inline) -> done
 1 impl rework: in_progress -> review -> in_progress -> review -> done
 1 plan rework: in_progress -> review -> in_planning -> planned -> in_progress -> review -> done
-Max cycles:   3 review->rework transitions, then CLI blocks -> needs_human
+Max cycles:   3 review->rework transitions, then CLI blocks -> raise needs_human alert
 ```
 
 ### Review Config Reference
@@ -203,22 +216,28 @@ Three settings in `.lattice/config.json` control review behavior:
 |---------|--------|---------|---------|
 | `review_mode` | `inline`, `single`, `triple` | `single` | How code review is performed at the review gate |
 | `plan_review_mode` | `inline`, `single`, `triple` | `triple` | How plan review is performed after the plan is written |
-| `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` moves to `needs_human` for approval |
+| `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` raises a `needs_human` alert and waits for the human to clear it |
 
 **`inline`** — review happens in the same agent session (no subprocess spawned).
 **`single`** — one review agent is spawned; result stored as a `review` or `plan-review` artifact.
 **`triple`** — three agents (claude, codex, gemini) run in parallel; individual results stored as `review-individual` artifacts; a merged result stored as `review` or `plan-review`.
 
-### When You're Stuck
+### When You're Stuck (Alerts — LAT-210)
 
-Use `needs_human` when you need human decision, approval, or input **right now**. This is distinct from `blocked` (generic external dependency) — it creates a scannable queue. **`needs_human` means actionable NOW** — future checkpoints (quality gates, review gates, approval milestones) stay at `planned` or `backlog` until the preceding work is complete. The orchestrator flips them to `needs_human` at the moment they become actionable.
+Alerts are **orthogonal to status**. The card stays in its current lifecycle column; the alert is a "needs attention right now" decoration. Two alerts ship by default:
+
+- `needs_human` — you need a human decision, approval, or input. Highest urgency. The card surfaces in `lattice list --alerted` and is excluded from `lattice next`. The c11 sidebar gets a yellow pill, optional flash, optional OS notification.
+- `blocked` — work cannot proceed due to an external dependency. Same exclusion from `lattice next`, but no flash by default.
 
 ```
-lattice status <task> needs_human --actor agent:<your-id>
-lattice comment <task> "Need: <what you need, in one line>" --actor agent:<your-id>
+lattice raise <task> needs_human --short "Decide REST or GraphQL?" --actor agent:<id>
+lattice raise <task> blocked --short "CI on shared runner is down" --actor agent:<id>
+lattice clear <task> needs_human --answer "REST. Client simplicity wins." --actor human:<id>
 ```
 
-Use for: design decisions requiring human judgment, missing access/credentials, ambiguous requirements, approval gates. The comment is mandatory — explain what you need in seconds, not minutes. The human's queue should be scannable.
+The `--short` text is mandatory and shows on the card; `--long`, `--prompt`, and `--evidence-ref` are optional. Clearing a not-raised alert is a no-op success (idempotent). Use `lattice show <task>` to see active alerts, raised-by, raised-at, and the suggested clear command.
+
+Use for: design decisions requiring human judgment, missing access/credentials, ambiguous requirements, approval gates. The `--short` text is mandatory — explain what you need in seconds, not minutes.
 
 ### Actor Attribution
 
@@ -272,6 +291,8 @@ lattice create "<title>" --actor agent:<id>
 lattice status <task> <status> --actor agent:<id>
 lattice assign <task> <actor> --actor agent:<id>
 lattice comment <task> "<text>" --actor agent:<id>
+lattice raise <task> <alert-name> --short "<text>" --actor agent:<id>
+lattice clear <task> <alert-name> --actor human:<id>
 lattice link <task> <type> <target> --actor agent:<id>
 lattice branch-link <task> <branch> --actor agent:<id>
 lattice file-link <task> <path>... --actor agent:<id> [--reason "why"]
@@ -279,7 +300,7 @@ lattice file-unlink <task> <path> --actor agent:<id>
 lattice explain <path>                           # also supports directory/ and globs
 lattice next [--actor agent:<id>] [--claim]
 lattice show <task>
-lattice list
+lattice list [--alerted | --alert <name> | --no-alerts]
 ```
 
 **Useful flags:**

--- a/tests/test_cli/test_alerts.py
+++ b/tests/test_cli/test_alerts.py
@@ -1,0 +1,296 @@
+"""Tests for `lattice raise` / `lattice clear` (LAT-210 alerts mechanism)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lattice.storage.fs import LATTICE_DIR
+
+
+_ACTOR_AGENT = "agent:claude"
+_ACTOR_HUMAN = "human:test"
+
+
+def _read_events(root: Path, task_id: str) -> list[dict]:
+    path = root / LATTICE_DIR / "events" / f"{task_id}.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _read_snapshot(root: Path, task_id: str) -> dict:
+    return json.loads(
+        (root / LATTICE_DIR / "tasks" / f"{task_id}.json").read_text()
+    )
+
+
+def _create_task(invoke, title: str = "Test task") -> str:
+    r = invoke("create", title, "--actor", _ACTOR_AGENT, "--json")
+    assert r.exit_code == 0, r.output
+    return json.loads(r.output)["data"]["id"]
+
+
+# ---------------------------------------------------------------------------
+# Raise — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseHappyPath:
+    def test_raise_writes_event_and_snapshot(self, invoke, initialized_root):
+        task_id = _create_task(invoke)
+
+        r = invoke(
+            "raise",
+            task_id,
+            "needs_human",
+            "--short",
+            "Decision: REST or GraphQL?",
+            "--actor",
+            _ACTOR_AGENT,
+            "--no-c11",
+            "--json",
+        )
+        assert r.exit_code == 0, r.output
+
+        events = _read_events(initialized_root, task_id)
+        raise_events = [e for e in events if e["type"] == "alert_raised"]
+        assert len(raise_events) == 1
+        assert raise_events[0]["data"]["name"] == "needs_human"
+        assert raise_events[0]["data"]["short"] == "Decision: REST or GraphQL?"
+
+        snap = _read_snapshot(initialized_root, task_id)
+        assert "needs_human" in snap["alerts"]
+        assert snap["alerts"]["needs_human"]["short"] == "Decision: REST or GraphQL?"
+        assert snap["alerts"]["needs_human"]["raised_by"] == _ACTOR_AGENT
+
+    def test_raise_with_long_and_prompt(self, invoke, initialized_root):
+        task_id = _create_task(invoke)
+
+        r = invoke(
+            "raise",
+            task_id,
+            "blocked",
+            "--short",
+            "CI failing",
+            "--long",
+            "The pipeline cannot resolve dependency X.",
+            "--prompt",
+            "lattice clear LAT-1 blocked --answer fixed",
+            "--actor",
+            _ACTOR_AGENT,
+            "--no-c11",
+        )
+        assert r.exit_code == 0
+
+        snap = _read_snapshot(initialized_root, task_id)
+        alert = snap["alerts"]["blocked"]
+        assert alert["long"].startswith("The pipeline")
+        assert alert["prompt"].startswith("lattice clear")
+
+    def test_raise_with_evidence_ref(self, invoke, initialized_root):
+        task_id = _create_task(invoke)
+
+        r = invoke(
+            "raise",
+            task_id,
+            "needs_human",
+            "--short",
+            "Plan needs approval",
+            "--evidence-ref",
+            "art_01HEXAMPLE",
+            "--actor",
+            _ACTOR_AGENT,
+            "--no-c11",
+        )
+        assert r.exit_code == 0
+        snap = _read_snapshot(initialized_root, task_id)
+        assert snap["alerts"]["needs_human"]["evidence_ref"] == "art_01HEXAMPLE"
+
+
+# ---------------------------------------------------------------------------
+# Double-raise + idempotent re-clear
+# ---------------------------------------------------------------------------
+
+
+class TestDoubleRaiseAndIdempotentClear:
+    def test_double_raise_writes_two_events_and_overwrites_snapshot(
+        self, invoke, initialized_root
+    ):
+        task_id = _create_task(invoke)
+
+        invoke(
+            "raise", task_id, "needs_human",
+            "--short", "Q1", "--actor", _ACTOR_AGENT, "--no-c11",
+        )
+        invoke(
+            "raise", task_id, "needs_human",
+            "--short", "Q2", "--actor", _ACTOR_AGENT, "--no-c11",
+        )
+
+        events = _read_events(initialized_root, task_id)
+        raises = [e for e in events if e["type"] == "alert_raised"]
+        assert len(raises) == 2
+
+        snap = _read_snapshot(initialized_root, task_id)
+        assert snap["alerts"]["needs_human"]["short"] == "Q2"
+
+    def test_idempotent_reclear_no_event_no_op_success(self, invoke, initialized_root):
+        task_id = _create_task(invoke)
+
+        # Clear before raising — should be a no-op success.
+        r = invoke(
+            "clear",
+            task_id,
+            "needs_human",
+            "--actor",
+            _ACTOR_HUMAN,
+            "--no-c11",
+            "--json",
+        )
+        assert r.exit_code == 0, r.output
+        parsed = json.loads(r.output)
+        assert parsed["ok"] is True
+        assert parsed["data"]["cleared"] is False
+
+        events = _read_events(initialized_root, task_id)
+        clears = [e for e in events if e["type"] == "alert_cleared"]
+        assert len(clears) == 0
+
+
+# ---------------------------------------------------------------------------
+# Clear — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestClearHappyPath:
+    def test_clear_after_raise_removes_alert(self, invoke, initialized_root):
+        task_id = _create_task(invoke)
+
+        invoke(
+            "raise", task_id, "needs_human",
+            "--short", "Q?", "--actor", _ACTOR_AGENT, "--no-c11",
+        )
+        r = invoke(
+            "clear",
+            task_id,
+            "needs_human",
+            "--answer",
+            "REST.",
+            "--actor",
+            _ACTOR_HUMAN,
+            "--no-c11",
+            "--json",
+        )
+        assert r.exit_code == 0
+        parsed = json.loads(r.output)
+        assert parsed["data"]["cleared"] is True
+
+        snap = _read_snapshot(initialized_root, task_id)
+        assert "needs_human" not in snap["alerts"]
+
+        events = _read_events(initialized_root, task_id)
+        clears = [e for e in events if e["type"] == "alert_cleared"]
+        assert len(clears) == 1
+        assert clears[0]["data"]["answer"] == "REST."
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_unknown_alert_name_rejected(self, invoke, initialized_root):
+        task_id = _create_task(invoke)
+        r = invoke(
+            "raise",
+            task_id,
+            "totally_made_up",
+            "--short",
+            "x",
+            "--actor",
+            _ACTOR_AGENT,
+            "--no-c11",
+            "--json",
+        )
+        assert r.exit_code != 0
+        parsed = json.loads(r.output)
+        assert parsed["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_oversized_short_rejected(self, invoke, initialized_root):
+        task_id = _create_task(invoke)
+        r = invoke(
+            "raise",
+            task_id,
+            "needs_human",
+            "--short",
+            "x" * 1000,
+            "--actor",
+            _ACTOR_AGENT,
+            "--no-c11",
+            "--json",
+        )
+        assert r.exit_code != 0
+
+    def test_terminal_status_rejected(self, invoke, cli_runner, cli_env, fill_plan, initialized_root):
+        from lattice.cli.main import cli
+
+        task_id = _create_task(invoke)
+        # Fast-track to done via cancelled (universal target).
+        r = cli_runner.invoke(
+            cli,
+            ["status", task_id, "cancelled", "--actor", _ACTOR_HUMAN],
+            env=cli_env,
+        )
+        assert r.exit_code == 0, r.output
+
+        r = invoke(
+            "raise",
+            task_id,
+            "needs_human",
+            "--short",
+            "x",
+            "--actor",
+            _ACTOR_AGENT,
+            "--no-c11",
+            "--json",
+        )
+        assert r.exit_code != 0
+        parsed = json.loads(r.output)
+        assert parsed["error"]["code"] == "task_terminal"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot rebuild determinism (replay survival)
+# ---------------------------------------------------------------------------
+
+
+class TestReplayDeterminism:
+    def test_oversize_long_event_truncated_on_replay(self, initialized_root):
+        """A historical event with an oversize ``long`` must replay cleanly."""
+        from lattice.core.events import ALERT_LONG_MAX, create_event
+        from lattice.core.tasks import apply_event_to_snapshot
+
+        # Build a minimal task_created snapshot.
+        created = create_event(
+            type="task_created",
+            task_id="task_01TESTREPLAY00000000000",
+            actor=_ACTOR_AGENT,
+            data={"title": "x", "status": "backlog"},
+        )
+        snap = apply_event_to_snapshot(None, created)
+
+        # Synthesize an oversize alert_raised event (bypassing CLI validation).
+        oversize = "y" * (ALERT_LONG_MAX + 500)
+        ev = create_event(
+            type="alert_raised",
+            task_id=created["task_id"],
+            actor=_ACTOR_AGENT,
+            data={"name": "needs_human", "short": "ok", "long": oversize},
+        )
+        snap = apply_event_to_snapshot(snap, ev)
+
+        # Mutation handler must truncate, not crash.
+        assert "needs_human" in snap["alerts"]
+        assert len(snap["alerts"]["needs_human"]["long"]) == ALERT_LONG_MAX

--- a/tests/test_cli/test_cmux_bridge_alerts.py
+++ b/tests/test_cli/test_cmux_bridge_alerts.py
@@ -35,8 +35,8 @@ class TestRaiseAlertVisual:
             alert_name="needs_human",
             short="Approve plan",
             long="Reviewer says PASS, awaiting human approval.",
-            flash=True,
-            notify=True,
+            should_flash=True,
+            should_notify=True,
         )
 
         # 4 calls: set-metadata, set-status, trigger-flash, notify
@@ -67,8 +67,8 @@ class TestRaiseAlertVisual:
             alert_name="blocked",
             short="CI failing",
             long=None,
-            flash=False,
-            notify=False,
+            should_flash=False,
+            should_notify=False,
         )
         verbs = [c[0] for c in rec.calls]
         assert "trigger-flash" not in verbs
@@ -86,8 +86,8 @@ class TestRaiseAlertVisual:
             alert_name="needs_human",
             short="Override color",
             long=None,
-            flash=False,
-            notify=False,
+            should_flash=False,
+            should_notify=False,
             visual_overrides={"color": "#00FF00"},
         )
         status_args = rec.calls[1]

--- a/tests/test_cli/test_cmux_bridge_alerts.py
+++ b/tests/test_cli/test_cmux_bridge_alerts.py
@@ -1,0 +1,149 @@
+"""Tests for cmux_bridge alert visuals (LAT-210)."""
+
+from __future__ import annotations
+
+import json
+
+from lattice.cli import cmux_bridge
+
+
+class _CallRecorder:
+    """Stand-in for ``_run_cmux`` that captures positional args."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def __call__(self, *args: str) -> bool:
+        self.calls.append(list(args))
+        return True
+
+
+def _patch_run(monkeypatch, recorder: _CallRecorder) -> None:
+    monkeypatch.setattr(cmux_bridge, "_run_cmux", recorder)
+    # Force cmux_available -> True regardless of env.
+    monkeypatch.setattr(cmux_bridge, "cmux_available", lambda: True)
+
+
+class TestRaiseAlertVisual:
+    def test_emits_metadata_status_flash_notify_for_needs_human(self, monkeypatch):
+        rec = _CallRecorder()
+        _patch_run(monkeypatch, rec)
+
+        cmux_bridge.raise_alert_visual(
+            workspace="workspace:7",
+            surface="surface:42",
+            alert_name="needs_human",
+            short="Approve plan",
+            long="Reviewer says PASS, awaiting human approval.",
+            flash=True,
+            notify=True,
+        )
+
+        # 4 calls: set-metadata, set-status, trigger-flash, notify
+        assert len(rec.calls) == 4
+        verbs = [c[0] for c in rec.calls]
+        assert verbs == ["set-metadata", "set-status", "trigger-flash", "notify"]
+
+        meta_args = rec.calls[0]
+        assert "--workspace" in meta_args
+        assert "--surface" in meta_args
+        assert "--json" in meta_args
+        json_payload = meta_args[meta_args.index("--json") + 1]
+        decoded = json.loads(json_payload)
+        assert decoded == {"lattice": {"needs_human": {"short": "Approve plan"}}}
+
+        status_args = rec.calls[1]
+        assert "--color" in status_args
+        # needs_human default color is yellow
+        assert "#FFD600" in status_args
+
+    def test_skips_flash_and_notify_when_disabled(self, monkeypatch):
+        rec = _CallRecorder()
+        _patch_run(monkeypatch, rec)
+
+        cmux_bridge.raise_alert_visual(
+            workspace="workspace:7",
+            surface="surface:42",
+            alert_name="blocked",
+            short="CI failing",
+            long=None,
+            flash=False,
+            notify=False,
+        )
+        verbs = [c[0] for c in rec.calls]
+        assert "trigger-flash" not in verbs
+        assert "notify" not in verbs
+        # Still emits metadata + sidebar pill.
+        assert verbs == ["set-metadata", "set-status"]
+
+    def test_visual_overrides_take_precedence(self, monkeypatch):
+        rec = _CallRecorder()
+        _patch_run(monkeypatch, rec)
+
+        cmux_bridge.raise_alert_visual(
+            workspace="workspace:7",
+            surface="surface:42",
+            alert_name="needs_human",
+            short="Override color",
+            long=None,
+            flash=False,
+            notify=False,
+            visual_overrides={"color": "#00FF00"},
+        )
+        status_args = rec.calls[1]
+        assert "#00FF00" in status_args
+        # Default icon is preserved (per-key merge, not full replacement).
+        assert "exclamationmark.triangle.fill" in status_args
+
+
+class TestClearAlertVisual:
+    def test_emits_clear_status_and_clear_metadata(self, monkeypatch):
+        rec = _CallRecorder()
+        _patch_run(monkeypatch, rec)
+
+        cmux_bridge.clear_alert_visual(
+            workspace="workspace:7",
+            surface="surface:42",
+            alert_name="needs_human",
+        )
+        verbs = [c[0] for c in rec.calls]
+        assert verbs == ["clear-status", "clear-metadata"]
+        meta_args = rec.calls[1]
+        assert "--key" in meta_args
+        assert meta_args[meta_args.index("--key") + 1] == "lattice.needs_human"
+
+
+class TestC11EnvDetection:
+    def test_get_workspace_falls_back_to_c11_var(self, monkeypatch):
+        monkeypatch.delenv("CMUX_WORKSPACE_ID", raising=False)
+        monkeypatch.setenv("C11_WORKSPACE_ID", "workspace:99")
+        assert cmux_bridge.get_workspace() == "workspace:99"
+
+    def test_get_surface_falls_back_to_c11_var(self, monkeypatch):
+        monkeypatch.delenv("CMUX_SURFACE_ID", raising=False)
+        monkeypatch.setenv("C11_SURFACE_ID", "surface:88")
+        assert cmux_bridge.get_surface() == "surface:88"
+
+    def test_cmux_available_with_only_c11_var(self, monkeypatch):
+        monkeypatch.delenv("CMUX_WORKSPACE_ID", raising=False)
+        monkeypatch.setenv("C11_WORKSPACE_ID", "workspace:5")
+        assert cmux_bridge.cmux_available() is True
+
+    def test_cmux_var_takes_precedence_over_c11(self, monkeypatch):
+        monkeypatch.setenv("CMUX_WORKSPACE_ID", "workspace:1")
+        monkeypatch.setenv("C11_WORKSPACE_ID", "workspace:2")
+        assert cmux_bridge.get_workspace() == "workspace:1"
+
+
+class TestStatusVisualsCleanup:
+    def test_status_visuals_drops_needs_human_and_blocked(self):
+        assert "needs_human" not in cmux_bridge.STATUS_VISUALS
+        assert "blocked" not in cmux_bridge.STATUS_VISUALS
+
+    def test_status_labels_drops_needs_human_and_blocked(self):
+        assert "needs_human" not in cmux_bridge.STATUS_LABELS
+        assert "blocked" not in cmux_bridge.STATUS_LABELS
+
+    def test_alert_visuals_present(self):
+        assert "needs_human" in cmux_bridge.ALERT_VISUALS
+        assert "blocked" in cmux_bridge.ALERT_VISUALS

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -77,12 +77,13 @@ class TestInitConfig:
         config = json.loads(config_path.read_text())
         assert isinstance(config, dict)
 
-    def test_config_has_schema_version_1(self, tmp_path: Path) -> None:
+    def test_config_has_schema_version_2(self, tmp_path: Path) -> None:
         runner = CliRunner()
         runner.invoke(cli, ["init", "--path", str(tmp_path)], input=_SKIP_ALL)
 
         config = json.loads((tmp_path / ".lattice" / "config.json").read_text())
-        assert config["schema_version"] == 1
+        # LAT-210 bumped the config schema_version to 2 (workflow contract change).
+        assert config["schema_version"] == 2
 
     def test_config_contains_default_fields(self, tmp_path: Path) -> None:
         """Config on disk must contain all default config fields plus instance_id."""

--- a/tests/test_cli/test_query_alerts.py
+++ b/tests/test_cli/test_query_alerts.py
@@ -1,0 +1,132 @@
+"""Tests for the LAT-210 alert filters in lattice list / show / next."""
+
+from __future__ import annotations
+
+import json
+
+
+_ACTOR = "agent:claude"
+_HUMAN = "human:test"
+
+
+def _create(invoke, title: str) -> str:
+    r = invoke("create", title, "--actor", _ACTOR, "--json")
+    assert r.exit_code == 0, r.output
+    return json.loads(r.output)["data"]["id"]
+
+
+def _raise(invoke, task_id: str, alert_name: str, short: str = "x") -> None:
+    r = invoke(
+        "raise",
+        task_id,
+        alert_name,
+        "--short",
+        short,
+        "--actor",
+        _ACTOR,
+        "--no-c11",
+    )
+    assert r.exit_code == 0, r.output
+
+
+# ---------------------------------------------------------------------------
+# lattice list --alerted / --alert / --no-alerts
+# ---------------------------------------------------------------------------
+
+
+class TestListAlertFilters:
+    def test_alerted_filter_returns_only_alerted_tasks(self, invoke):
+        a = _create(invoke, "Plain task")
+        b = _create(invoke, "Alerted task")
+        _raise(invoke, b, "needs_human", "Q?")
+
+        r = invoke("list", "--alerted", "--json")
+        assert r.exit_code == 0
+        data = json.loads(r.output)["data"]
+        ids = {t["id"] for t in data}
+        assert b in ids
+        assert a not in ids
+
+    def test_alert_named_filter(self, invoke):
+        a = _create(invoke, "needs_human alert")
+        _raise(invoke, a, "needs_human", "Decision?")
+        b = _create(invoke, "blocked alert")
+        _raise(invoke, b, "blocked", "CI down")
+
+        r = invoke("list", "--alert", "needs_human", "--json")
+        data = json.loads(r.output)["data"]
+        ids = {t["id"] for t in data}
+        assert a in ids
+        assert b not in ids
+
+    def test_no_alerts_filter(self, invoke):
+        a = _create(invoke, "Quiet task")
+        b = _create(invoke, "Loud task")
+        _raise(invoke, b, "blocked", "stuck")
+
+        r = invoke("list", "--no-alerts", "--json")
+        data = json.loads(r.output)["data"]
+        ids = {t["id"] for t in data}
+        assert a in ids
+        assert b not in ids
+
+    def test_no_alerts_and_alerted_are_mutually_exclusive(self, invoke):
+        r = invoke("list", "--alerted", "--no-alerts", "--json")
+        assert r.exit_code != 0
+        parsed = json.loads(r.output)
+        assert parsed["error"]["code"] == "VALIDATION_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# lattice show — Alerts block
+# ---------------------------------------------------------------------------
+
+
+class TestShowAlertsBlock:
+    def test_alerts_block_present_when_alerted(self, invoke):
+        task_id = _create(invoke, "Task w/ alert")
+        _raise(invoke, task_id, "needs_human", "Decide approach")
+
+        r = invoke("show", task_id)
+        assert r.exit_code == 0
+        assert "Alerts:" in r.output
+        assert "[NEEDS_HUMAN]" in r.output
+        assert "Decide approach" in r.output
+
+    def test_alerts_block_absent_when_clean(self, invoke):
+        task_id = _create(invoke, "Plain")
+        r = invoke("show", task_id)
+        assert r.exit_code == 0
+        assert "Alerts:" not in r.output
+
+
+# ---------------------------------------------------------------------------
+# lattice next — banner
+# ---------------------------------------------------------------------------
+
+
+class TestNextBanner:
+    def test_banner_appears_when_alerts_exist(self, invoke):
+        a = _create(invoke, "Alerted")
+        _raise(invoke, a, "needs_human", "decide")
+        # Need a pickable task.
+        _create(invoke, "Pickable")
+
+        r = invoke("next")
+        assert r.exit_code == 0
+        assert "task(s) need attention" in r.output
+
+    def test_no_banner_when_no_alerts(self, invoke):
+        _create(invoke, "Pickable")
+        r = invoke("next")
+        assert r.exit_code == 0
+        assert "task(s) need attention" not in r.output
+
+    def test_alerted_task_excluded_from_next(self, invoke):
+        task_id = _create(invoke, "Solo")
+        _raise(invoke, task_id, "needs_human", "?")
+
+        r = invoke("next", "--json")
+        data = json.loads(r.output)
+        assert data["data"] is None
+        assert data.get("alerted_count") == 1

--- a/tests/test_cli/test_review_cmds.py
+++ b/tests/test_cli/test_review_cmds.py
@@ -9,8 +9,45 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from lattice.cli.main import cli
+from lattice.cli.review_cmds import parse_verdict
 from lattice.core.config import default_config, serialize_config
 from lattice.storage.fs import LATTICE_DIR, ensure_lattice_dirs, atomic_write
+
+
+# ---------------------------------------------------------------------------
+# Verdict parser (LAT-210)
+# ---------------------------------------------------------------------------
+
+
+class TestParseVerdict:
+    def test_pass(self):
+        assert parse_verdict("Some content\n\nVERDICT: pass\n") == "pass"
+
+    def test_fail_rework(self):
+        assert parse_verdict("VERDICT: fail-rework") == "fail-rework"
+
+    def test_fail_decision(self):
+        assert parse_verdict("VERDICT: fail-decision") == "fail-decision"
+
+    def test_trailing_period_parses(self):
+        assert parse_verdict("VERDICT: pass.") == "pass"
+
+    def test_trailing_exclamation_parses(self):
+        assert parse_verdict("VERDICT: fail-rework!") == "fail-rework"
+
+    def test_lowercase_does_not_parse(self):
+        # Only uppercase VERDICT: is the contract.
+        assert parse_verdict("verdict: pass") == "fail-rework"
+
+    def test_two_verdict_lines_last_wins(self):
+        body = "VERDICT: fail-rework\n\n... more text ...\n\nVERDICT: pass\n"
+        assert parse_verdict(body) == "pass"
+
+    def test_missing_verdict_defaults_to_fail_rework(self):
+        assert parse_verdict("Looks good to me, no issues") == "fail-rework"
+
+    def test_empty_defaults_to_fail_rework(self):
+        assert parse_verdict("") == "fail-rework"
 
 
 # ---------------------------------------------------------------------------
@@ -354,13 +391,14 @@ class TestPlanReviewSingle:
         # Should not crash
         assert result.exit_code == 0 or "failed" in result.output
 
-    def test_plan_approval_human_moves_status(self, tmp_path):
+    def test_plan_approval_human_raises_alert(self, tmp_path):
+        """LAT-210: plan_approval=human raises a needs_human alert (not a status move)."""
         root = _make_board(tmp_path, {"plan_review_mode": "single", "plan_approval": "human"})
         runner = CliRunner()
         task_id = _create_task(runner, root)
         _write_plan(root, task_id, "## Plan\nRefactor the auth module.")
 
-        fake_review = "### 1. Verdict\n**PASS**"
+        fake_review = "### 1. Verdict\n**PASS**\n\nVERDICT: pass\n"
         fake_art_id = "art_fakeid123"
 
         with (
@@ -371,7 +409,7 @@ class TestPlanReviewSingle:
                 "lattice.cli.review_cmds._attach_review_artifact",
                 return_value=fake_art_id,
             ),
-            patch("lattice.cli.review_cmds._move_to_needs_human") as mock_move,
+            patch("lattice.cli.review_cmds._raise_needs_human_alert") as mock_raise,
         ):
             runner.invoke(
                 cli,
@@ -379,7 +417,11 @@ class TestPlanReviewSingle:
                 env={"LATTICE_ROOT": str(root)},
                 catch_exceptions=False,
             )
-        mock_move.assert_called_once()
+        mock_raise.assert_called_once()
+        # evidence_ref should be the artifact id we mocked.
+        kwargs = mock_raise.call_args.kwargs
+        assert kwargs.get("evidence_ref") == fake_art_id
+        assert "Plan reviewed" in kwargs.get("short", "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli/test_review_cmds.py
+++ b/tests/test_cli/test_review_cmds.py
@@ -423,6 +423,41 @@ class TestPlanReviewSingle:
         assert kwargs.get("evidence_ref") == fake_art_id
         assert "Plan reviewed" in kwargs.get("short", "")
 
+    def test_plan_approval_human_raises_alert_even_when_verdict_fails(self, tmp_path):
+        """LAT-210 locked behavior: plan_approval=human raises unconditionally.
+
+        Verdict-driven routing is handled separately by the in_planning rework
+        loop; this gate is purely the human-approval handshake, so a failing
+        plan-review still raises the alert.
+        """
+        root = _make_board(tmp_path, {"plan_review_mode": "single", "plan_approval": "human"})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        _write_plan(root, task_id, "## Plan\nRefactor the auth module.")
+
+        fake_review = "### 1. Verdict\n**FAIL**\n\nVERDICT: fail-rework\n"
+        fake_art_id = "art_failart_456"
+
+        with (
+            patch(
+                "lattice.cli.review_cmds.run_single_review", return_value=(True, "ok", fake_review)
+            ),
+            patch(
+                "lattice.cli.review_cmds._attach_review_artifact",
+                return_value=fake_art_id,
+            ),
+            patch("lattice.cli.review_cmds._raise_needs_human_alert") as mock_raise,
+        ):
+            runner.invoke(
+                cli,
+                ["plan-review", task_id, "--mode", "single", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+        mock_raise.assert_called_once()
+        kwargs = mock_raise.call_args.kwargs
+        assert kwargs.get("evidence_ref") == fake_art_id
+
 
 # ---------------------------------------------------------------------------
 # Tests: triple mode (mocked agents)

--- a/tests/test_cli/test_stats_cmds.py
+++ b/tests/test_cli/test_stats_cmds.py
@@ -158,7 +158,7 @@ class TestStatsCommand:
             "busiest",
             "velocity",
             "time_in_status",
-            "blocked",
+            "alert_episodes",
             "agent_activity",
         }
         assert expected_keys == set(data.keys())

--- a/tests/test_cli/test_task_status.py
+++ b/tests/test_cli/test_task_status.py
@@ -148,12 +148,12 @@ class TestCompletionPolicyGating:
         assert parsed["ok"] is True
 
     def test_universal_target_bypasses_policy(self, invoke, initialized_root, fill_plan) -> None:
-        """Universal targets bypass policies — even with a policy on needs_human."""
+        """Universal targets bypass policies — LAT-210: cancelled is the only universal target."""
         _add_policies_to_config(
             initialized_root,
             {
                 "done": {"require_roles": ["review"]},
-                "needs_human": {"require_roles": ["review"]},
+                "cancelled": {"require_roles": ["review"]},
             },
         )
 
@@ -164,7 +164,7 @@ class TestCompletionPolicyGating:
         invoke("status", task_id, "planned", "--actor", _ACTOR)
         invoke("status", task_id, "in_progress", "--actor", _ACTOR)
 
-        r = invoke("status", task_id, "needs_human", "--actor", _ACTOR, "--json")
+        r = invoke("status", task_id, "cancelled", "--actor", _ACTOR, "--json")
         assert r.exit_code == 0
 
     def test_no_policy_no_gating(self, invoke, initialized_root, fill_plan) -> None:
@@ -665,28 +665,9 @@ class TestNextStepsHints:
         assert "implement the plan" in r.output
         assert "move to review" in r.output
 
-    def test_needs_human_echoes_latest_comment(self, invoke, initialized_root) -> None:
-        r = invoke("create", "Needs human hint", "--actor", _ACTOR, "--json")
-        task_id = json.loads(r.output)["data"]["id"]
-        invoke("status", task_id, "in_planning", "--actor", _ACTOR)
-        invoke("comment", task_id, "Need API design decision", "--actor", _ACTOR)
-
-        r = invoke("status", task_id, "needs_human", "--actor", _ACTOR)
-        assert r.exit_code == 0
-        assert "Need API design decision" in r.output
-
-    def test_needs_human_json_includes_comment(self, invoke, initialized_root) -> None:
-        r = invoke("create", "NH json", "--actor", _ACTOR, "--json")
-        task_id = json.loads(r.output)["data"]["id"]
-        invoke("status", task_id, "in_planning", "--actor", _ACTOR)
-        invoke("comment", task_id, "Blocked on credentials", "--actor", _ACTOR)
-
-        r = invoke("status", task_id, "needs_human", "--actor", _ACTOR, "--json")
-        assert r.exit_code == 0
-        data = json.loads(r.output)["data"]
-        ns = data["next_steps"]
-        assert ns["action"] == "awaiting_human"
-        assert ns["latest_comment"] == "Blocked on credentials"
+    # LAT-210: needs_human is no longer a status; the "echo latest comment"
+    # hint moved out with it. Equivalent context now lives in the alert
+    # payload (lattice raise <task> needs_human --short ...).
 
     def test_planned_no_hint_when_inline(self, invoke, initialized_root, fill_plan) -> None:
         """When plan_review_mode is inline, planned produces no hint."""

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -29,7 +29,7 @@ class TestDefaultConfig:
 
     def test_has_schema_version(self) -> None:
         config = default_config()
-        assert config["schema_version"] == 1
+        assert config["schema_version"] == 2
 
     def test_has_default_status(self) -> None:
         config = default_config()
@@ -53,11 +53,33 @@ class TestDefaultConfig:
             "review",
             "pr_open",
             "done",
-            "blocked",
-            "needs_human",
             "cancelled",
         ]
         assert config["workflow"]["statuses"] == expected
+
+    def test_no_needs_human_or_blocked_in_default_statuses(self) -> None:
+        """LAT-210: needs_human/blocked moved out of statuses into alerts."""
+        config = default_config()
+        assert "needs_human" not in config["workflow"]["statuses"]
+        assert "blocked" not in config["workflow"]["statuses"]
+
+    def test_default_workflow_alerts_listed(self) -> None:
+        config = default_config()
+        assert config["workflow"]["alerts"] == ["needs_human", "blocked"]
+
+    def test_alert_visuals_present(self) -> None:
+        config = default_config()
+        visuals = config["workflow"]["alert_visuals"]
+        assert "needs_human" in visuals
+        assert "blocked" in visuals
+        assert visuals["needs_human"]["color"]
+        assert visuals["blocked"]["color"]
+
+    def test_alert_descriptions_present(self) -> None:
+        config = default_config()
+        descs = config["workflow"]["alert_descriptions"]
+        assert "needs_human" in descs
+        assert "blocked" in descs
 
     def test_workflow_transitions_keys(self) -> None:
         config = default_config()
@@ -70,8 +92,6 @@ class TestDefaultConfig:
             "review",
             "pr_open",
             "done",
-            "blocked",
-            "needs_human",
             "cancelled",
         }
         assert set(transitions.keys()) == expected_keys
@@ -85,8 +105,8 @@ class TestDefaultConfig:
     def test_has_universal_targets(self) -> None:
         config = default_config()
         assert "universal_targets" in config["workflow"]
-        assert "needs_human" in config["workflow"]["universal_targets"]
-        assert "cancelled" in config["workflow"]["universal_targets"]
+        # LAT-210: needs_human is no longer a status; only cancelled remains.
+        assert config["workflow"]["universal_targets"] == ["cancelled"]
 
     def test_wip_limits(self) -> None:
         config = default_config()
@@ -278,17 +298,26 @@ class TestValidateTransition:
                     f"Universal target {target!r} should be reachable from {from_s!r}"
                 )
 
-    def test_universal_target_backlog_to_needs_human(self) -> None:
+    def test_universal_target_backlog_to_cancelled(self) -> None:
         config = default_config()
-        assert validate_transition(config, "backlog", "needs_human") is True
+        assert validate_transition(config, "backlog", "cancelled") is True
 
-    def test_universal_target_done_to_needs_human(self) -> None:
+    def test_universal_target_in_progress_to_cancelled(self) -> None:
         config = default_config()
-        assert validate_transition(config, "done", "needs_human") is True
+        assert validate_transition(config, "in_progress", "cancelled") is True
 
     def test_universal_target_done_to_cancelled(self) -> None:
         config = default_config()
         assert validate_transition(config, "done", "cancelled") is True
+
+    def test_needs_human_no_longer_a_status(self) -> None:
+        """LAT-210: transitions to ``needs_human`` are invalid; it is an alert now."""
+        config = default_config()
+        assert validate_transition(config, "in_progress", "needs_human") is False
+
+    def test_blocked_no_longer_a_status(self) -> None:
+        config = default_config()
+        assert validate_transition(config, "in_progress", "blocked") is False
 
     def test_no_universal_targets_falls_back_to_explicit(self) -> None:
         config: dict = {
@@ -551,12 +580,13 @@ class TestValidateCompletionPolicy:
         assert ok is True
 
     def test_universal_target_bypasses_policy(self) -> None:
+        # LAT-210: cancelled is the only universal target now.
         config = default_config()
         config["workflow"]["completion_policies"] = {
-            "needs_human": {"require_roles": ["review"]},
+            "cancelled": {"require_roles": ["review"]},
         }
         snap = _snap_with_evidence([])
-        ok, failures = validate_completion_policy(config, snap, "needs_human")
+        ok, failures = validate_completion_policy(config, snap, "cancelled")
         assert ok is True
 
     def test_cancelled_bypasses_policy(self) -> None:

--- a/tests/test_core/test_events.py
+++ b/tests/test_core/test_events.py
@@ -39,6 +39,8 @@ class TestBuiltinEventTypes:
             "relationship_added",
             "relationship_removed",
             "artifact_attached",
+            "alert_raised",
+            "alert_cleared",
             "git_event",
             "branch_linked",
             "branch_unlinked",
@@ -60,7 +62,7 @@ class TestBuiltinEventTypes:
         assert isinstance(BUILTIN_EVENT_TYPES, frozenset)
 
     def test_count(self) -> None:
-        assert len(BUILTIN_EVENT_TYPES) == 26
+        assert len(BUILTIN_EVENT_TYPES) == 28
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_next.py
+++ b/tests/test_core/test_next.py
@@ -130,18 +130,28 @@ class TestSelectNextExclusions:
         snaps = [_snap("task_cancel", status="cancelled")]
         assert select_next(snaps) is None
 
-    def test_excludes_blocked(self) -> None:
-        snaps = [_snap("task_block", status="blocked")]
-        assert select_next(snaps) is None
-
-    def test_excludes_needs_human(self) -> None:
-        snaps = [_snap("task_human", status="needs_human")]
-        assert select_next(snaps) is None
-
     def test_excludes_in_progress_without_actor(self) -> None:
         """in_progress is not in ready_statuses by default."""
         snaps = [_snap("task_ip", status="in_progress")]
         assert select_next(snaps) is None
+
+    def test_alerted_task_excluded_regardless_of_status(self) -> None:
+        """LAT-210: any task with non-empty alerts is unpickable, regardless of status."""
+        snap = _snap("task_alerted", status="backlog")
+        snap["alerts"] = {
+            "needs_human": {"short": "decision", "raised_at": "2026-05-06T00:00:00Z"}
+        }
+        assert select_next([snap]) is None
+
+    def test_alerted_in_progress_task_not_resumed(self) -> None:
+        """LAT-210: an in_progress + alerted task is not picked even via resume-first."""
+        snap = _snap(
+            "task_resumable",
+            status="in_progress",
+            assigned_to="agent:claude",
+        )
+        snap["alerts"] = {"blocked": {"short": "stuck", "raised_at": "x"}}
+        assert select_next([snap], actor="agent:claude") is None
 
 
 class TestSelectNextAssignment:

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -15,6 +16,7 @@ from lattice.core.review import (
     cleanup_temp_files,
     clear_review_state,
     count_agent_failures,
+    create_failure_diagnostic_task,
     read_review_state,
     record_agent_failure,
     write_review_state,
@@ -145,3 +147,108 @@ class TestConfigTimeout:
 
     def test_default_agent_timeout_constant(self) -> None:
         assert DEFAULT_AGENT_TIMEOUT == 600
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat path (LAT-210): create_failure_diagnostic_task
+#
+# The function shells out to `lattice create` then `lattice raise needs_human`
+# (instead of moving the new task to a `needs_human` *status*).  We verify the
+# end-to-end behavior by routing subprocess.run through Click's in-process
+# CliRunner against a fully-initialized board.
+# ---------------------------------------------------------------------------
+
+
+class TestCreateFailureDiagnosticTask:
+    def _make_board(self, tmp_path: Path) -> Path:
+        from lattice.core.config import default_config, serialize_config
+        from lattice.storage.fs import LATTICE_DIR, atomic_write, ensure_lattice_dirs
+
+        ensure_lattice_dirs(tmp_path)
+        ld = tmp_path / LATTICE_DIR
+        atomic_write(ld / "config.json", serialize_config(default_config()))
+        (ld / "events" / "_lifecycle.jsonl").touch()
+        return tmp_path
+
+    def _route_to_in_process_cli(self, monkeypatch, root: Path) -> None:
+        """Make subprocess.run(['lattice', ...]) execute via Click's CliRunner.
+
+        Avoids relying on the system-installed `lattice` binary from a unit
+        test, and keeps the assertion target — the materialized snapshot —
+        in this process's filesystem view.  Also forces ``cmux_available``
+        to False so the c11 visual hooks don't try to shell out to a real
+        cmux binary inside the test runner.
+        """
+        from click.testing import CliRunner
+        from lattice.cli import cmux_bridge
+        from lattice.cli.main import cli
+
+        monkeypatch.setattr(cmux_bridge, "cmux_available", lambda: False)
+
+        runner = CliRunner()
+        real_run = subprocess.run
+
+        def fake_run(args, *a, **kwargs):
+            if not args or args[0] != "lattice":
+                return real_run(args, *a, **kwargs)
+            cli_args = list(args[1:])
+            cwd = kwargs.get("cwd") or str(root)
+            env = {"LATTICE_ROOT": str(cwd)}
+            result = runner.invoke(cli, cli_args, env=env)
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=result.exit_code,
+                stdout=result.output,
+                stderr="",
+            )
+
+        monkeypatch.setattr("lattice.core.review.subprocess.run", fake_run)
+
+    def test_creates_diagnostic_task_with_needs_human_alert(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """LAT-210 heartbeat path: diagnostic task is created at status=backlog
+        with a `needs_human` alert raised on it (not moved to a status)."""
+        root = self._make_board(tmp_path)
+        self._route_to_in_process_cli(monkeypatch, root)
+
+        new_id = create_failure_diagnostic_task(
+            root / ".lattice",
+            agent_type="codex",
+            failure_count=2,
+            actor="agent:test",
+            evidence_ref=None,
+        )
+        assert new_id is not None and new_id.startswith("task_"), new_id
+
+        snap = json.loads(
+            (root / ".lattice" / "tasks" / f"{new_id}.json").read_text()
+        )
+        # The diagnostic task is created at the default lifecycle status, not
+        # promoted to a `needs_human` status (the old behavior).
+        assert snap["status"] == "backlog"
+        # The alert is the human-attention signal.
+        assert "alerts" in snap
+        assert "needs_human" in snap["alerts"]
+        alert = snap["alerts"]["needs_human"]
+        assert "Persistent codex agent failure" in alert["short"]
+
+    def test_evidence_ref_is_recorded_on_alert_payload(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        root = self._make_board(tmp_path)
+        self._route_to_in_process_cli(monkeypatch, root)
+
+        new_id = create_failure_diagnostic_task(
+            root / ".lattice",
+            agent_type="claude",
+            failure_count=3,
+            actor="agent:test",
+            evidence_ref="art_failure_001",
+        )
+        assert new_id is not None
+
+        snap = json.loads(
+            (root / ".lattice" / "tasks" / f"{new_id}.json").read_text()
+        )
+        assert snap["alerts"]["needs_human"].get("evidence_ref") == "art_failure_001"

--- a/tests/test_core/test_tasks.py
+++ b/tests/test_core/test_tasks.py
@@ -1034,6 +1034,7 @@ class TestCompactSnapshot:
             "evidence_ref_count",
             "branch_link_count",
             "linked_file_count",
+            "alerts",  # LAT-210: alerts surface on board cards regardless of status.
         }
         assert set(compact.keys()) == expected_keys
 

--- a/tests/test_dashboard/test_server.py
+++ b/tests/test_dashboard/test_server.py
@@ -1049,7 +1049,8 @@ class TestPostDashboardConfig:
         cfg = json.loads((ld / "config.json").read_text())
         assert "workflow" in cfg
         assert "statuses" in cfg["workflow"]
-        assert cfg["schema_version"] == 1
+        # LAT-210 bumped schema_version 1 -> 2.
+        assert cfg["schema_version"] == 2
         assert cfg["dashboard"]["background_image"] == "https://example.com/bg.jpg"
 
     def test_config_returned_via_get_after_save(self, dashboard_server):

--- a/tests/test_dashboard/test_server.py
+++ b/tests/test_dashboard/test_server.py
@@ -136,6 +136,14 @@ class TestTasksEndpoint:
         task_ids = [t["id"] for t in body["data"]]
         assert archived_id not in task_ids
 
+    def test_tasks_compact_view_includes_alerts_field(self, dashboard_server):
+        """LAT-210: alert payloads must round-trip through the board-view JSON."""
+        base_url, _ld, _ids = dashboard_server
+        status, body = _get(base_url, "/api/tasks")
+        assert status == 200
+        for t in body["data"]:
+            assert "alerts" in t  # always present, even if empty
+
 
 class TestTaskDetailEndpoint:
     def test_get_task_detail(self, dashboard_server):

--- a/tests/test_mcp/test_completion_policy.py
+++ b/tests/test_mcp/test_completion_policy.py
@@ -74,18 +74,18 @@ class TestMCPCompletionPolicy:
         assert snapshot["status"] == "done"
 
     def test_universal_target_bypasses_policy(self, lattice_env: Path) -> None:
+        # LAT-210: cancelled is the only universal target now.
         _config_with_policy(
             lattice_env,
             {
                 "done": {"require_roles": ["review"]},
-                "needs_human": {"require_roles": ["review"]},
+                "cancelled": {"require_roles": ["review"]},
             },
         )
         task_id = _create_task_at_review(lattice_env)
 
-        # needs_human is a universal target — should bypass policy
-        snapshot = lattice_status(task_id=task_id, new_status="needs_human", actor=_ACTOR)
-        assert snapshot["status"] == "needs_human"
+        snapshot = lattice_status(task_id=task_id, new_status="cancelled", actor=_ACTOR)
+        assert snapshot["status"] == "cancelled"
 
     def test_no_policy_no_gating(self, lattice_env: Path) -> None:
         """Without completion_policies, transitions work normally."""

--- a/tests/test_mcp/test_resources.py
+++ b/tests/test_mcp/test_resources.py
@@ -20,6 +20,7 @@ from lattice.mcp.tools import (
     lattice_archive,
     lattice_assign,
     lattice_create,
+    lattice_raise_alert,
     lattice_status,
 )
 
@@ -48,6 +49,18 @@ class TestResourceTaskDetail:
         task = lattice_create(title="Short ID", actor="human:test")
         result = json.loads(resource_task_detail(task["short_id"]))
         assert result["id"] == task["id"]
+
+    def test_alerts_field_round_trips_through_detail(self, lattice_env: Path):
+        """LAT-210: alerts must surface through the MCP task resource."""
+        task = lattice_create(title="Alerted", actor="agent:claude")
+        lattice_raise_alert(
+            task_id=task["id"],
+            alert_name="needs_human",
+            short="?",
+            actor="agent:claude",
+        )
+        result = json.loads(resource_task_detail(task["id"]))
+        assert "needs_human" in result.get("alerts", {})
 
     def test_archived(self, lattice_env: Path):
         task = lattice_create(title="Archived", actor="human:test")

--- a/tests/test_mcp/test_tools.py
+++ b/tests/test_mcp/test_tools.py
@@ -11,6 +11,7 @@ from lattice.mcp.tools import (
     lattice_archive,
     lattice_assign,
     lattice_attach,
+    lattice_clear_alert,
     lattice_comment,
     lattice_config,
     lattice_create,
@@ -18,6 +19,7 @@ from lattice.mcp.tools import (
     lattice_event,
     lattice_link,
     lattice_list,
+    lattice_raise_alert,
     lattice_show,
     lattice_status,
     lattice_unarchive,
@@ -434,3 +436,54 @@ class TestAttach:
         )
         assert result["type"] == "reference"
         assert result["custom_fields"]["url"] == "https://example.com/doc.pdf"
+
+
+class TestRaiseAlert:
+    """LAT-210: lattice_raise_alert / lattice_clear_alert MCP tools."""
+
+    def test_raise_writes_alert(self, lattice_env: Path):
+        task = lattice_create(title="Alert me", actor="agent:claude")
+        result = lattice_raise_alert(
+            task_id=task["id"],
+            alert_name="needs_human",
+            short="REST or GraphQL?",
+            actor="agent:claude",
+        )
+        assert "needs_human" in result["alerts"]
+        assert result["alerts"]["needs_human"]["short"] == "REST or GraphQL?"
+
+    def test_clear_after_raise(self, lattice_env: Path):
+        task = lattice_create(title="Clear me", actor="agent:claude")
+        lattice_raise_alert(
+            task_id=task["id"],
+            alert_name="needs_human",
+            short="?",
+            actor="agent:claude",
+        )
+        result = lattice_clear_alert(
+            task_id=task["id"],
+            alert_name="needs_human",
+            actor="human:test",
+            answer="REST.",
+        )
+        assert result["cleared"] is True
+        assert "needs_human" not in result["alerts"]
+
+    def test_idempotent_clear_no_event(self, lattice_env: Path):
+        task = lattice_create(title="Re-clear", actor="agent:claude")
+        result = lattice_clear_alert(
+            task_id=task["id"],
+            alert_name="needs_human",
+            actor="human:test",
+        )
+        assert result["cleared"] is False
+
+    def test_raise_unknown_alert_rejected(self, lattice_env: Path):
+        task = lattice_create(title="x", actor="agent:claude")
+        with pytest.raises(ValueError, match="Unknown alert"):
+            lattice_raise_alert(
+                task_id=task["id"],
+                alert_name="madeup",
+                short="x",
+                actor="agent:claude",
+            )

--- a/tests/test_storage/test_hooks.py
+++ b/tests/test_storage/test_hooks.py
@@ -374,6 +374,128 @@ cat > "{output_file}"
 
 
 # ---------------------------------------------------------------------------
+# 8b. CLI integration: lattice raise / clear fire alert hooks (LAT-210)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_raise_fires_alert_raised_hook(tmp_path: Path, cli_runner, cli_env: dict) -> None:
+    """`lattice raise` fires on.alert_raised hook."""
+    from lattice.cli.main import cli
+
+    output_file = tmp_path / "raise_hook_output.json"
+
+    hook_script = tmp_path / "raise_hook.sh"
+    hook_script.write_text(
+        f"""#!/bin/sh
+cat > "{output_file}"
+"""
+    )
+    hook_script.chmod(hook_script.stat().st_mode | stat.S_IEXEC)
+
+    # Create a task first
+    result = cli_runner.invoke(
+        cli,
+        ["create", "Alert hook task", "--actor", "human:test", "--json"],
+        env=cli_env,
+    )
+    assert result.exit_code == 0
+    task_id = json.loads(result.output)["data"]["id"]
+
+    # Update config with alert_raised hook
+    lattice_dir = Path(cli_env["LATTICE_ROOT"]) / ".lattice"
+    config = json.loads((lattice_dir / "config.json").read_text())
+    config["hooks"] = {"on": {"alert_raised": str(hook_script)}}
+    (lattice_dir / "config.json").write_text(json.dumps(config, sort_keys=True, indent=2) + "\n")
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "raise",
+            task_id,
+            "needs_human",
+            "--short",
+            "Need a decision",
+            "--actor",
+            "agent:test",
+            "--no-c11",
+        ],
+        env=cli_env,
+    )
+    assert result.exit_code == 0, f"raise failed: {result.output}"
+
+    assert output_file.exists(), "alert_raised hook did not fire"
+    event = json.loads(output_file.read_text())
+    assert event["type"] == "alert_raised"
+    assert event["data"]["name"] == "needs_human"
+
+
+def test_cli_clear_fires_alert_cleared_hook(tmp_path: Path, cli_runner, cli_env: dict) -> None:
+    """`lattice clear` fires on.alert_cleared hook."""
+    from lattice.cli.main import cli
+
+    output_file = tmp_path / "clear_hook_output.json"
+
+    hook_script = tmp_path / "clear_hook.sh"
+    hook_script.write_text(
+        f"""#!/bin/sh
+cat > "{output_file}"
+"""
+    )
+    hook_script.chmod(hook_script.stat().st_mode | stat.S_IEXEC)
+
+    # Create + raise so there is an active alert to clear
+    result = cli_runner.invoke(
+        cli,
+        ["create", "Alert clear task", "--actor", "human:test", "--json"],
+        env=cli_env,
+    )
+    assert result.exit_code == 0
+    task_id = json.loads(result.output)["data"]["id"]
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "raise",
+            task_id,
+            "blocked",
+            "--short",
+            "CI down",
+            "--actor",
+            "agent:test",
+            "--no-c11",
+        ],
+        env=cli_env,
+    )
+    assert result.exit_code == 0
+
+    # Now wire up the alert_cleared hook (after the raise so the raise hook
+    # doesn't run and overwrite the sentinel).
+    lattice_dir = Path(cli_env["LATTICE_ROOT"]) / ".lattice"
+    config = json.loads((lattice_dir / "config.json").read_text())
+    config["hooks"] = {"on": {"alert_cleared": str(hook_script)}}
+    (lattice_dir / "config.json").write_text(json.dumps(config, sort_keys=True, indent=2) + "\n")
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "clear",
+            task_id,
+            "blocked",
+            "--actor",
+            "human:test",
+            "--no-c11",
+        ],
+        env=cli_env,
+    )
+    assert result.exit_code == 0, f"clear failed: {result.output}"
+
+    assert output_file.exists(), "alert_cleared hook did not fire"
+    event = json.loads(output_file.read_text())
+    assert event["type"] == "alert_cleared"
+    assert event["data"]["name"] == "blocked"
+
+
+# ---------------------------------------------------------------------------
 # 9. _parse_transition_key unit tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Converts `needs_human` and `blocked` from workflow **statuses** to a new orthogonal **alerts** mechanism. Status answers "where is this work in its lifecycle?"; alerts answer "does this card need attention right now?" — and the two now live independently.

Lattice ticket: [LAT-210](https://github.com/Stage-11-Agentics/lattice/blob/feat/LAT-210-alerts-mechanism/.lattice/plans/task_01KQXNA3M8AKTNMMRZPQBX6A3M.md) — full plan, decisions, and acceptance criteria.

**Stacking note:** This PR is stacked on `feat/LAT-213-pr-open-status` (#10), which is itself stacked on `feat/LAT-205-agent-spawn-primitive`. After LAT-205 → LAT-213 → main land, this PR's base will retarget to `main`.

## What changed

Delivered as 8 phase commits + 2 review-fix commits on `feat/LAT-210-alerts-mechanism`:

- **Phase 1** (`98203a0`) — Schema + events + mutation handlers + CLI primitives + hooks. New `alerts` field on snapshot (in `PROTECTED_FIELDS`), new `alert_raised` / `alert_cleared` event types in `BUILTIN_EVENT_TYPES`, `lattice raise` / `lattice clear` Click commands, payload validation with replay-time truncation, `HooksOnConfig` extension, plus `cmux_bridge.ALERT_VISUALS` + `raise_alert_visual` / `clear_alert_visual` (absorbed forward from Phase 3 because `alert_cmds.py` imports from the bridge).
- **Phase 2** (`478b155`) — Workflow contract change. Drop `needs_human` / `blocked` from default `statuses`, `transitions`, `display_names`, `STATUS_DESCRIPTIONS`, and `_DEFAULT_STATUS_ORDER`. Reduce `universal_targets` to `["cancelled"]`. Add `workflow.alerts` / `workflow.alert_descriptions` / `workflow.alert_visuals`. Bump `config.schema_version` 1 → 2 (snapshot stays at 1; `alerts` field is forward-compatible). `lattice next` excludes any task with non-empty `alerts` regardless of status.
- **Phase 3** (`4a80b99`) — c11 integration tests for `cmux_bridge` alerts (the production code shipped in Phase 1).
- **Phase 4** (`bb1dd43`) — Review-command integration + verdict contract. New `parse_verdict` reads `VERDICT: pass | fail-rework | fail-decision` (last-match wins, lowercase rejected, missing → fail-rework + warning). `lattice plan-review` with `plan_approval=human` raises `needs_human` alert (with `evidence_ref` to plan-review artifact). `lattice code-review` grows `--escalate-on-fail` (raises only on `fail-decision`) and `--escalate-after` (always raises). `core/review.py::create_failure_diagnostic_task` creates the diagnostic task at `backlog` status and raises `needs_human` instead of transitioning to that status.
- **Phase 5** (`cc129fe`) — Read-side CLI in `query_cmds.py`. `lattice list --alerted` / `--alert <name>` / `--no-alerts` filters (mutually exclusive). `lattice show` renders an `Alerts:` block prominently (sorted needs_human-first). `lattice next` prepends `[N task(s) need attention — see lattice list --alerted]` banner.
- **Phase 6** (`ceed57e`) — Dashboard rendering. Card renderer adds alert-aware class + `ALERT: <NAME>` strip + colored border; `compact_snapshot` includes alerts payload; cube-v2.js / cube3d.js drop hardcoded status colors and define `ALERT_COLORS` overlays.
- **Phase 7** (`34c1251`) — MCP. `lattice_raise_alert` / `lattice_clear_alert` tools mirror CLI signatures (alert-name validation, terminal-status guards, idempotent re-clear); task resources round-trip alerts via the snapshot dict.
- **Phase 8** (`0336a2d`) — Documentation. `CLAUDE.md`, `Decisions.md`, `ProjectRequirements_v1.md`, `templates/claude_md_block.py`, `skills/lattice/SKILL.md`, `references/multi-agent-guide.md` all updated to teach `lattice raise` / `lattice clear` and the alert mechanism.
- **Review fix 1** (`8983605`) — Cube alerts wire-up + 7 MINOR cleanups (dead try/except, notify/flash param rename, _raise_needs_human_alert cwd, escalate-on-fail mode guard, plan_review locked-behavior doc + fail-verdict test, hooks-fire tests, dashboard legacy fallback).
- **Review fix 2** (`85912c0`) — Heartbeat diagnostic test (Plan-Review v2 AC) + Phase 6 alert filter dropdown + top-of-board alerts banner with click-to-scroll.

Diff summary: 41 files changed, ~2540 insertions, ~270 deletions.

### Locked semantics (per Decisions.md entry)

- **Idempotent re-clear** — clearing a not-raised alert is `ok=true, data.cleared=false`, no event written.
- **Double-raise** — writes a second `alert_raised` event and replaces the snapshot entry; `raised_at` reflects the latest raise.
- **`evidence_ref` (singular)** lives only inside the alert payload; doesn't touch the task-level `evidence_refs` array.
- **Multi-alert visuals** — c11 sidebar shows one pill per alert (`set-status` is alert-name-keyed); dashboard collapses to one border/strip with `needs_human > blocked` priority.
- **`workflow.alert_visuals` resolution** — per-key override merges with `cmux_bridge.ALERT_VISUALS` defaults (not total replacement).
- **Replay safety** — mutation handler truncates oversize payloads; CLI rejects up-front via `validate_alert_payload`.

### v0 breaking change (intentional)

Sibling Lattice instances (`code/Aurum/.lattice/`, `code/EAIRQ_Demo/.lattice/`, `code/LatticeRemoteWorkspace/.lattice/`, `code/stage-11-company-board/.lattice/`) keep `needs_human`/`blocked` in their workflow until manually re-initialized or migrated. The CLI reads such legacy snapshots without crashing; per-instance migration recipe is in `Decisions.md`.

## Test plan

- [x] `uv run pytest --tb=short --deselect tests/test_core/test_short_ids.py::TestValidateShortId::test_invalid_digits_in_prefix` → **1825 passed in 33.78s** (5 new tests vs pre-LAT-210 baseline; deselect is for an unrelated pre-existing failure from LAT-205's short-ID regex relaxation, commit `84a225e`).
- [x] `uv run ruff check src/ tests/` → **All checks passed!**
- [x] Manual smoke (delegator-run from worktree):
  - [x] `lattice raise <task> needs_human --short "..."` → `alert_raised` event written, snapshot.alerts populated, c11 location auto-captured from `C11_SURFACE_ID` / `C11_WORKSPACE_ID` env.
  - [x] `lattice show <task>` renders the `Alerts:` block prominently with NEEDS_HUMAN label, short text, raised_by, raised_at, location.
  - [x] Status stayed at `backlog` throughout (orthogonal to status — never moved into a needs_human column).
  - [x] `lattice clear <task> needs_human --answer "..."` → `alert_cleared` event, alerts dict emptied.
  - [x] Idempotent re-clear → `{ok: true, data: {cleared: false}}`, no event written.
  - [x] c11 sidebar pill + metadata write fire via `cmux_bridge.raise_alert_visual` / `clear_alert_visual`.

## Validation evidence

- All 22 plan acceptance criteria verified (see `.lattice/plans/task_01KQXNA3M8AKTNMMRZPQBX6A3M.md` § "Acceptance criteria").
- Code-review artifact: `art_01KQXY4GYEPHGS4PA689H620BQ` (single-mode, **VERDICT: pass**, 3 MAJOR + 5 MINOR findings — all absorbed into this PR per the project's "Prefer cohesive ticket" guardrail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)