### PR TITLE
feat(cli): add edit-description command (LAT-186)

### DIFF
--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -458,6 +458,86 @@ def update(
 
 
 # ---------------------------------------------------------------------------
+# lattice edit-description
+# ---------------------------------------------------------------------------
+
+
+@cli.command("edit-description")
+@click.argument("task_id")
+@click.argument("description")
+@common_options
+def edit_description(
+    task_id: str,
+    description: str,
+    model: str | None,
+    session: str | None,
+    output_json: bool,
+    quiet: bool,
+    triggered_by: str | None,
+    on_behalf_of: str | None,
+    provenance_reason: str | None,
+) -> None:
+    """Edit a task's description.
+
+    Sugar over `lattice update <task> description=<text>` — same event-sourced
+    semantics, but takes the description as a positional argument so it doesn't
+    need field=value escaping.
+    """
+    is_json = output_json
+
+    lattice_dir = require_root(is_json)
+    config = load_project_config(lattice_dir)
+    actor = require_actor(is_json)
+    if on_behalf_of is not None:
+        validate_actor_format_or_exit(on_behalf_of, is_json)
+
+    task_id = resolve_task_id(lattice_dir, task_id, is_json)
+
+    snapshot = read_snapshot_or_exit(lattice_dir, task_id, is_json)
+
+    old_value = snapshot.get("description")
+    new_value = description
+
+    if old_value == new_value:
+        if is_json:
+            click.echo(
+                json.dumps(
+                    {"ok": True, "data": {"message": "No changes"}}, sort_keys=True, indent=2
+                )
+                + "\n"
+            )
+        elif quiet:
+            click.echo("ok")
+        else:
+            click.echo("No changes")
+        return
+
+    event = create_event(
+        type="field_updated",
+        task_id=task_id,
+        actor=actor,
+        data={"field": "description", "from": old_value, "to": new_value},
+        ts=utc_now(),
+        model=model,
+        session=session,
+        triggered_by=triggered_by,
+        on_behalf_of=on_behalf_of,
+        reason=provenance_reason,
+    )
+
+    updated_snapshot = apply_event_to_snapshot(snapshot, event)
+    write_task_event(lattice_dir, task_id, [event], updated_snapshot, config)
+
+    output_result(
+        data=updated_snapshot,
+        human_message=f"Updated description on {task_id}",
+        quiet_value="ok",
+        is_json=is_json,
+        is_quiet=quiet,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Next-step hints after status transitions (LAT-197)
 # ---------------------------------------------------------------------------
 

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -296,7 +296,12 @@ def update(
     on_behalf_of: str | None,
     provenance_reason: str | None,
 ) -> None:
-    """Update task fields.  Pass field=value pairs."""
+    """Update task fields.
+
+    Pass field=value pairs (e.g., title=, description=, priority=, urgency=,
+    complexity=, type=, tags=). Use 'lattice edit-description' for
+    description-only edits.
+    """
     is_json = output_json
 
     lattice_dir = require_root(is_json)

--- a/tests/test_cli/test_task_cmds.py
+++ b/tests/test_cli/test_task_cmds.py
@@ -255,6 +255,93 @@ class TestUpdate:
 
 
 # ---------------------------------------------------------------------------
+# TestEditDescription
+# ---------------------------------------------------------------------------
+
+
+class TestEditDescription:
+    """Tests for `lattice edit-description`."""
+
+    def test_happy_path(self, create_task, invoke, initialized_root):
+        task = create_task("Edit desc happy", "--description", "old")
+        task_id = task["id"]
+        result = invoke("edit-description", task_id, "new", "--actor", "human:test")
+        assert result.exit_code == 0
+
+        snap_path = initialized_root / ".lattice" / "tasks" / f"{task_id}.json"
+        snap = json.loads(snap_path.read_text())
+        assert snap["description"] == "new"
+
+    def test_no_op(self, create_task, invoke):
+        task = create_task("Edit desc no-op", "--description", "same")
+        task_id = task["id"]
+        result = invoke("edit-description", task_id, "same", "--actor", "human:test")
+        assert result.exit_code == 0
+        assert "No changes" in result.output
+
+    def test_description_with_equals(self, create_task, invoke_json):
+        """Description containing '=' is stored verbatim — no field=value parsing."""
+        task = create_task("Edit desc equals", "--description", "old")
+        task_id = task["id"]
+        data, code = invoke_json("edit-description", task_id, "k=v", "--actor", "human:test")
+        assert code == 0
+        assert data["data"]["description"] == "k=v"
+
+    def test_description_with_embedded_quotes(self, create_task, invoke_json):
+        """Embedded quotes round-trip byte-clean through invoke()."""
+        task = create_task("Edit desc quotes", "--description", "old")
+        task_id = task["id"]
+        new_desc = 'She said "hello" and left.'
+        data, code = invoke_json("edit-description", task_id, new_desc, "--actor", "human:test")
+        assert code == 0
+        assert data["data"]["description"] == new_desc
+
+    def test_empty_description(self, create_task, invoke_json):
+        task = create_task("Edit desc empty", "--description", "old")
+        task_id = task["id"]
+        data, code = invoke_json("edit-description", task_id, "", "--actor", "human:test")
+        assert code == 0
+        assert data["data"]["description"] == ""
+
+    def test_nonexistent_task(self, invoke):
+        result = invoke(
+            "edit-description",
+            "task_99999999999999999999999999",
+            "anything",
+            "--actor",
+            "human:test",
+        )
+        assert result.exit_code != 0
+
+    def test_event_emission(self, create_task, invoke, initialized_root):
+        task = create_task("Edit desc event", "--description", "old")
+        task_id = task["id"]
+        result = invoke("edit-description", task_id, "new", "--actor", "human:test")
+        assert result.exit_code == 0
+
+        events_path = initialized_root / ".lattice" / "events" / f"{task_id}.jsonl"
+        lines = events_path.read_text().strip().split("\n")
+        all_events = [json.loads(line) for line in lines]
+        desc_events = [
+            e
+            for e in all_events
+            if e.get("type") == "field_updated" and e.get("data", {}).get("field") == "description"
+        ]
+        assert len(desc_events) == 1
+        assert desc_events[0]["data"]["from"] == "old"
+        assert desc_events[0]["data"]["to"] == "new"
+        assert desc_events[0]["actor"] == "human:test"
+
+    def test_json_envelope(self, create_task, invoke_json):
+        task = create_task("Edit desc json", "--description", "old")
+        task_id = task["id"]
+        data, code = invoke_json("edit-description", task_id, "new", "--actor", "human:test")
+        assert code == 0
+        assert data["ok"] is True
+        assert data["data"]["description"] == "new"
+
+
+# ---------------------------------------------------------------------------
 # TestStatus
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds `lattice edit-description <task> "<text>"` as a thin, discoverable alias over `lattice update <task> description="<text>"`.

The capability the ticket asked for already existed inside `lattice update`, but the surface area was undiscoverable — the LAT-186 reporter went looking for `lattice edit` and didn't find that `update description=...` already covers it. This PR closes the gap two ways:

- **New verb**: positional `<task_id> <description>` so users don't have to think about `field=value` escaping (descriptions can contain `=`, quotes, etc., byte-clean).
- **Better discoverability** on the existing `update` command — the docstring now enumerates the seven updatable fields and points at `edit-description` as sugar.

Same event-sourced semantics: emits a single `field_updated` event with `data.field == "description"`, `data.from`, `data.to` — identical to what `update` produces today. No new event type, no schema change, no refactor of `update`, no dashboard change.

## Lifecycle

- LAT-186 ticket: https://lattice/LAT-186 (lives in this repo's `.lattice/`)
- Plan: `.lattice/plans/task_01KJR2N6S3FJB77J1EKJ479NDB.md`
- Plan-review verdict: PASS with 5 MINOR findings (4 folded into plan, 1 deferred as evolutionary)
- Code-review verdict: PASS, no fixes required, recommend merge

## Test plan

- [x] `uv run pytest tests/test_cli/test_task_cmds.py::TestEditDescription -v` — 8/8 passed
- [x] `uv run pytest -q` — full suite 1738/1738 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check` on the two files modified by this PR — clean (the lone unrelated complaint about `compute_next_steps` already exists verbatim on `origin/main`)
- [x] Smoke test: created throwaway task, ran `edit-description`, confirmed snapshot updated and `field_updated` event emitted with correct `actor` + `ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)