### PR TITLE
chore: ruff format src/ tests/ (LAT-215)

### DIFF
--- a/src/lattice/cli/cmux_bridge.py
+++ b/src/lattice/cli/cmux_bridge.py
@@ -24,15 +24,15 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 STATUS_VISUALS: dict[str, dict[str, str]] = {
-    "backlog":     {"icon": "tray.full.fill",                    "color": "#888888"},
-    "in_planning": {"icon": "map.fill",                          "color": "#9B59B6"},
-    "planned":     {"icon": "checkmark.seal.fill",               "color": "#3498DB"},
-    "in_progress": {"icon": "play.fill",                         "color": "#E67E22"},
-    "review":      {"icon": "eye.fill",                          "color": "#FFD700"},
-    "done":        {"icon": "checkmark.circle.fill",             "color": "#2ECC71"},
-    "blocked":     {"icon": "exclamationmark.triangle.fill",     "color": "#E74C3C"},
-    "needs_human": {"icon": "person.fill.questionmark",          "color": "#E74C3C"},
-    "cancelled":   {"icon": "xmark.circle.fill",                 "color": "#95A5A6"},
+    "backlog": {"icon": "tray.full.fill", "color": "#888888"},
+    "in_planning": {"icon": "map.fill", "color": "#9B59B6"},
+    "planned": {"icon": "checkmark.seal.fill", "color": "#3498DB"},
+    "in_progress": {"icon": "play.fill", "color": "#E67E22"},
+    "review": {"icon": "eye.fill", "color": "#FFD700"},
+    "done": {"icon": "checkmark.circle.fill", "color": "#2ECC71"},
+    "blocked": {"icon": "exclamationmark.triangle.fill", "color": "#E74C3C"},
+    "needs_human": {"icon": "person.fill.questionmark", "color": "#E74C3C"},
+    "cancelled": {"icon": "xmark.circle.fill", "color": "#95A5A6"},
 }
 
 # Display labels used in tab titles for each status

--- a/src/lattice/cli/dashboard_cmd.py
+++ b/src/lattice/cli/dashboard_cmd.py
@@ -48,7 +48,12 @@ def _find_free_port(host: str, near: int) -> int | None:
 
 @cli.command("dashboard")
 @click.option("--host", default="127.0.0.1", help="Host to bind to.")
-@click.option("--port", default=None, type=int, help="Port to bind to. Defaults to dashboard_port in config, or 8799.")
+@click.option(
+    "--port",
+    default=None,
+    type=int,
+    help="Port to bind to. Defaults to dashboard_port in config, or 8799.",
+)
 @click.option("--json", "output_json", is_flag=True, help="Output structured JSON.")
 def dashboard_cmd(host: str, port: int | None, output_json: bool) -> None:
     """Launch a read-only local web dashboard.
@@ -147,7 +152,12 @@ def dashboard_cmd(host: str, port: int | None, output_json: bool) -> None:
 
 
 @cli.command("restart")
-@click.option("--port", default=None, type=int, help="Port of the dashboard to restart. Defaults to dashboard_port in config, or 8799.")
+@click.option(
+    "--port",
+    default=None,
+    type=int,
+    help="Port of the dashboard to restart. Defaults to dashboard_port in config, or 8799.",
+)
 def restart_cmd(port: int | None) -> None:
     """Send a restart signal to a running Lattice dashboard.
 

--- a/src/lattice/cli/file_cmds.py
+++ b/src/lattice/cli/file_cmds.py
@@ -44,16 +44,12 @@ def _resolve_to_relative(lattice_dir: Path, filepath: str) -> str:
         try:
             rel = str(path.resolve().relative_to(project_root.resolve()))
         except ValueError:
-            raise ValueError(
-                f"Path '{filepath}' is outside the project root."
-            ) from None
+            raise ValueError(f"Path '{filepath}' is outside the project root.") from None
     else:
         # Collapse ../  segments and check for traversal
         normalized = os.path.normpath(filepath)
         if normalized.startswith(".."):
-            raise ValueError(
-                f"Path '{filepath}' escapes the project root."
-            )
+            raise ValueError(f"Path '{filepath}' escapes the project root.")
         rel = normalized
 
     # Strip leading ./ if present
@@ -246,7 +242,10 @@ def file_unlink(
 
 
 def _get_decision_comments(
-    lattice_dir: Path, task_id: str, *, is_archived: bool = False,
+    lattice_dir: Path,
+    task_id: str,
+    *,
+    is_archived: bool = False,
 ) -> list[str]:
     """Return body texts of comments with role 'decision' for a task."""
     events = read_task_events(lattice_dir, task_id, is_archived=is_archived)
@@ -300,11 +299,13 @@ def _parse_decisions_md(lattice_dir: Path, filepath: str) -> list[dict]:
         for m in files_line_re.finditer(body):
             paths = [p.strip() for p in m.group(1).split(",")]
             if filepath in paths:
-                matches.append({
-                    "source": "Decisions.md",
-                    "heading": entry["heading"],
-                    "body": body.strip(),
-                })
+                matches.append(
+                    {
+                        "source": "Decisions.md",
+                        "heading": entry["heading"],
+                        "body": body.strip(),
+                    }
+                )
                 break
 
     return matches
@@ -356,7 +357,9 @@ def explain_cmd(
 
             # Collect decision-role comments from event log
             decision_comments = _get_decision_comments(
-                lattice_dir, task_id, is_archived=is_archived,
+                lattice_dir,
+                task_id,
+                is_archived=is_archived,
             )
             if decision_comments:
                 entry["decision_comments"] = decision_comments
@@ -364,10 +367,7 @@ def explain_cmd(
             # Include decision-role comments if verbose or JSON
             if verbose or is_json:
                 evidence_refs = snap.get("evidence_refs", [])
-                decision_refs = [
-                    r for r in evidence_refs
-                    if r.get("role") == "decision"
-                ]
+                decision_refs = [r for r in evidence_refs if r.get("role") == "decision"]
                 entry["decision_evidence"] = decision_refs
 
                 # Check for plan file
@@ -413,7 +413,7 @@ def explain_cmd(
             short_id = task.get("short_id") or task.get("task_id", "?")
             title = task.get("title", "?")
             status = task.get("status", "?")
-            click.echo(f"  {short_id}  \"{title}\"  [{status}]")
+            click.echo(f'  {short_id}  "{title}"  [{status}]')
 
             desc = task.get("description")
             if desc:

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -79,7 +79,9 @@ def code_review(
             f"Task: {display_id}. Review the diff and provide feedback directly."
         )
         if is_json:
-            click.echo(json.dumps({"ok": True, "data": {"mode": "inline", "task_id": task_id}}, indent=2))
+            click.echo(
+                json.dumps({"ok": True, "data": {"mode": "inline", "task_id": task_id}}, indent=2)
+            )
         else:
             click.echo(msg)
         return
@@ -200,7 +202,9 @@ def plan_review(
             f"Task: {display_id}. Review the plan and provide feedback directly."
         )
         if is_json:
-            click.echo(json.dumps({"ok": True, "data": {"mode": "inline", "task_id": task_id}}, indent=2))
+            click.echo(
+                json.dumps({"ok": True, "data": {"mode": "inline", "task_id": task_id}}, indent=2)
+            )
         else:
             click.echo(msg)
         return
@@ -281,9 +285,13 @@ def review_status(task_id: str, output_json: bool) -> None:
             click.echo(json.dumps({"ok": True, "data": data}, indent=2))
         else:
             if has_artifacts:
-                click.echo(f"No in-flight review for {task_id}. Review artifacts exist — review may have already completed.")
+                click.echo(
+                    f"No in-flight review for {task_id}. Review artifacts exist — review may have already completed."
+                )
             else:
-                click.echo(f"No in-flight review found for {task_id}. No review artifacts found either.")
+                click.echo(
+                    f"No in-flight review found for {task_id}. No review artifacts found either."
+                )
         return
 
     now = datetime.now(timezone.utc)
@@ -291,7 +299,9 @@ def review_status(task_id: str, output_json: bool) -> None:
     if is_json:
         # Enrich with elapsed times
         for agent in state.get("agents", []):
-            agent["elapsed"] = _compute_elapsed_str(agent.get("started_at"), agent.get("finished_at"), now)
+            agent["elapsed"] = _compute_elapsed_str(
+                agent.get("started_at"), agent.get("finished_at"), now
+            )
         state["elapsed"] = _compute_elapsed_str(state.get("started_at"), None, now)
         click.echo(json.dumps({"ok": True, "data": state}, indent=2))
         return
@@ -366,7 +376,9 @@ def _run_single_and_store(
 
     if art_id:
         if is_json:
-            click.echo(json.dumps({"ok": True, "data": {"artifact_id": art_id, "role": role}}, indent=2))
+            click.echo(
+                json.dumps({"ok": True, "data": {"artifact_id": art_id, "role": role}}, indent=2)
+            )
         elif quiet:
             click.echo(art_id)
         else:
@@ -448,7 +460,9 @@ def _run_triple_and_store(
         if merged_id:
             artifact_ids.append(merged_id)
             if is_json:
-                click.echo(json.dumps({"ok": True, "data": {"artifact_ids": artifact_ids}}, indent=2))
+                click.echo(
+                    json.dumps({"ok": True, "data": {"artifact_ids": artifact_ids}}, indent=2)
+                )
             elif quiet:
                 click.echo(merged_id)
             else:

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -567,7 +567,11 @@ def compute_next_steps(
 
     if new_status == "in_planning":
         hint = f"Next: write the plan in plans/{task_id}.md, then move to planned."
-        return hint, {"action": "write_plan", "plan_path": f"plans/{task_id}.md", "then": "planned"}
+        return hint, {
+            "action": "write_plan",
+            "plan_path": f"plans/{task_id}.md",
+            "then": "planned",
+        }
 
     if new_status == "planned":
         plan_review_mode = config.get("plan_review_mode", "inline")

--- a/src/lattice/cli/wait_cmd.py
+++ b/src/lattice/cli/wait_cmd.py
@@ -124,9 +124,7 @@ def wait_cmd(
         return
 
     if not quiet and not is_json:
-        click.echo(
-            f"Waiting for {len(pending)}/{total} tasks to reach '{target_status}'..."
-        )
+        click.echo(f"Waiting for {len(pending)}/{total} tasks to reach '{target_status}'...")
         if done:
             done_names = ", ".join(short_id_map.get(t, t) for t in done)
             click.echo(f"  Already {target_status}: {done_names}")
@@ -151,9 +149,7 @@ def wait_cmd(
             done, pending = _check_tasks_status(lattice_dir, task_ids, target_status)
             if not quiet and not is_json:
                 done_names = ", ".join(short_id_map.get(t, t) for t in done)
-                click.echo(
-                    f"  Progress: {len(done)}/{total} ({done_names})"
-                )
+                click.echo(f"  Progress: {len(done)}/{total} ({done_names})")
             if not pending:
                 _emit_result(done, pending, target_status, short_id_map, is_json, quiet)
                 return

--- a/src/lattice/core/event_stream.py
+++ b/src/lattice/core/event_stream.py
@@ -234,7 +234,9 @@ def _stream_with_poll(
 
         sleep_for = min(
             float(poll_interval),
-            float(timeout - (time.monotonic() - start_time)) if timeout > 0 else float(poll_interval),
+            float(timeout - (time.monotonic() - start_time))
+            if timeout > 0
+            else float(poll_interval),
         )
         if sleep_for <= 0:
             return

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -110,11 +110,15 @@ def record_agent_failure(lattice_dir: Path, agent_type: str, task_id: str) -> in
     state_dir = lattice_dir / REVIEW_STATE_DIR
     state_dir.mkdir(exist_ok=True)
     path = _failures_path(lattice_dir)
-    entry = json.dumps({
-        "agent": agent_type,
-        "task_id": task_id,
-        "timestamp": _now_iso(),
-    }, sort_keys=True, separators=(",", ":"))
+    entry = json.dumps(
+        {
+            "agent": agent_type,
+            "task_id": task_id,
+            "timestamp": _now_iso(),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
     with open(path, "a", encoding="utf-8") as f:
         f.write(entry + "\n")
     return count_agent_failures(lattice_dir, agent_type)
@@ -155,8 +159,11 @@ def create_failure_diagnostic_task(
     try:
         result = subprocess.run(
             [
-                "lattice", "create", title,
-                "--actor", actor,
+                "lattice",
+                "create",
+                title,
+                "--actor",
+                actor,
                 "--quiet",
             ],
             capture_output=True,
@@ -171,8 +178,12 @@ def create_failure_diagnostic_task(
         # Move to needs_human
         subprocess.run(
             [
-                "lattice", "status", new_task_id, "needs_human",
-                "--actor", actor,
+                "lattice",
+                "status",
+                new_task_id,
+                "needs_human",
+                "--actor",
+                actor,
             ],
             capture_output=True,
             text=True,
@@ -477,15 +488,11 @@ def _build_agent_command(agent_type: str, prompt_file: str, output_file: str) ->
     read/write without hitting interactive permission prompts in non-attended
     contexts.
     """
-    instruction = (
-        f"Read {prompt_file} and follow the instructions. Write output to {output_file}"
-    )
+    instruction = f"Read {prompt_file} and follow the instructions. Write output to {output_file}"
     if agent_type == "claude":
         return f'env -u CLAUDECODE claude --dangerously-skip-permissions -p "{instruction}"'
     if agent_type == "codex":
-        return (
-            f'codex exec --full-auto --skip-git-repo-check "{instruction}"'
-        )
+        return f'codex exec --full-auto --skip-git-repo-check "{instruction}"'
     if agent_type == "gemini":
         return f'gemini -m gemini-3-pro-preview --yolo "{instruction}"'
     return None
@@ -515,7 +522,9 @@ def run_single_review(
         "mode": "single",
         "review_type": review_type,
         "started_at": started_at,
-        "agents": [{"name": "claude", "status": "running", "started_at": started_at, "artifact_id": None}],
+        "agents": [
+            {"name": "claude", "status": "running", "started_at": started_at, "artifact_id": None}
+        ],
     }
     write_review_state(lattice_dir, state)
 

--- a/src/lattice/update_check.py
+++ b/src/lattice/update_check.py
@@ -40,9 +40,7 @@ def _write_cache(version: str) -> None:
     """Persist latest version to cache file."""
     try:
         _CACHE_DIR.mkdir(parents=True, exist_ok=True)
-        _CACHE_FILE.write_text(
-            json.dumps({"version": version, "ts": time.time()}) + "\n"
-        )
+        _CACHE_FILE.write_text(json.dumps({"version": version, "ts": time.time()}) + "\n")
     except Exception:
         pass
 

--- a/tests/test_cli/test_archive_cmds.py
+++ b/tests/test_cli/test_archive_cmds.py
@@ -58,9 +58,7 @@ class TestArchive:
         ]
         assert len(archived_events) == 1
 
-    def test_archive_when_archive_dirs_missing(
-        self, create_task, invoke, initialized_root
-    ):
+    def test_archive_when_archive_dirs_missing(self, create_task, invoke, initialized_root):
         """Archive should self-heal when archive subdirs don't exist (older projects)."""
         import shutil
 

--- a/tests/test_cli/test_integration.py
+++ b/tests/test_cli/test_integration.py
@@ -122,16 +122,16 @@ class TestFullLifecycleWorkflow:
         expected_types = [
             "task_created",
             "assignment_changed",  # auto-assign on transition to in_planning
-            "status_changed",      # backlog -> in_planning
-            "status_changed",      # in_planning -> planned
-            "status_changed",      # planned -> in_progress (already assigned)
+            "status_changed",  # backlog -> in_planning
+            "status_changed",  # in_planning -> planned
+            "status_changed",  # planned -> in_progress (already assigned)
             "assignment_changed",  # explicit assign to agent:bot
             "comment_added",
             "relationship_added",
             "artifact_attached",
-            "status_changed",      # in_progress -> review
-            "comment_added",       # review evidence
-            "status_changed",      # review -> done
+            "status_changed",  # in_progress -> review
+            "comment_added",  # review evidence
+            "status_changed",  # review -> done
             "task_archived",
         ]
         assert event_types == expected_types
@@ -541,8 +541,8 @@ class TestShowAfterMultipleOperations:
         assert event_types == [
             "task_created",
             "assignment_changed",  # auto-assign on transition to in_planning
-            "status_changed",      # backlog -> in_planning
-            "status_changed",      # in_planning -> planned
+            "status_changed",  # backlog -> in_planning
+            "status_changed",  # in_planning -> planned
             "assignment_changed",  # explicit assign to agent:worker
             "comment_added",
             "field_updated",
@@ -580,7 +580,8 @@ class TestAutoAssignOnActiveTransition:
         # assignment_changed should come before the status_changed to in_planning
         assign_idx = event_types.index("assignment_changed")
         status_idx = [
-            i for i, e in enumerate(events)
+            i
+            for i, e in enumerate(events)
             if e["type"] == "status_changed" and e["data"]["to"] == "in_planning"
         ][0]
         assert assign_idx < status_idx

--- a/tests/test_cli/test_review_cmds.py
+++ b/tests/test_cli/test_review_cmds.py
@@ -288,7 +288,10 @@ class TestCodeReviewSingle:
 
         with (
             patch("lattice.cli.review_cmds.resolve_diff", return_value=(True, fake_diff)),
-            patch("lattice.cli.review_cmds.run_single_review", return_value=(True, "Review complete.", fake_review)),
+            patch(
+                "lattice.cli.review_cmds.run_single_review",
+                return_value=(True, "Review complete.", fake_review),
+            ),
         ):
             result = runner.invoke(
                 cli,
@@ -298,7 +301,9 @@ class TestCodeReviewSingle:
             )
         # Should not error (may warn if lattice attach subprocess fails in test env)
         # The key assertion: no unhandled exception and diff was attempted
-        assert result.exit_code == 0 or "Review stored" in result.output or "failed" in result.output
+        assert (
+            result.exit_code == 0 or "Review stored" in result.output or "failed" in result.output
+        )
 
     def test_single_mode_agent_failure_reports_error(self, tmp_path):
         root = _make_board(tmp_path, {"review_mode": "single"})
@@ -309,7 +314,9 @@ class TestCodeReviewSingle:
 
         with (
             patch("lattice.cli.review_cmds.resolve_diff", return_value=(True, fake_diff)),
-            patch("lattice.cli.review_cmds.run_single_review", return_value=(False, "timeout", None)),
+            patch(
+                "lattice.cli.review_cmds.run_single_review", return_value=(False, "timeout", None)
+            ),
         ):
             result = runner.invoke(
                 cli,
@@ -335,7 +342,9 @@ class TestPlanReviewSingle:
 
         fake_review = "### 1. Verdict\n**PASS**\n\nSolid plan."
 
-        with patch("lattice.cli.review_cmds.run_single_review", return_value=(True, "ok", fake_review)):
+        with patch(
+            "lattice.cli.review_cmds.run_single_review", return_value=(True, "ok", fake_review)
+        ):
             result = runner.invoke(
                 cli,
                 ["plan-review", task_id, "--mode", "single", "--actor", "agent:test"],
@@ -355,7 +364,9 @@ class TestPlanReviewSingle:
         fake_art_id = "art_fakeid123"
 
         with (
-            patch("lattice.cli.review_cmds.run_single_review", return_value=(True, "ok", fake_review)),
+            patch(
+                "lattice.cli.review_cmds.run_single_review", return_value=(True, "ok", fake_review)
+            ),
             patch(
                 "lattice.cli.review_cmds._attach_review_artifact",
                 return_value=fake_art_id,

--- a/tests/test_cli/test_review_config.py
+++ b/tests/test_cli/test_review_config.py
@@ -70,7 +70,8 @@ class TestInitFlags:
             cli,
             [
                 "init",
-                "--path", str(tmp_path),
+                "--path",
+                str(tmp_path),
                 "--actor",
                 "human:test",
                 "--project-code",
@@ -90,7 +91,8 @@ class TestInitFlags:
             cli,
             [
                 "init",
-                "--path", str(tmp_path),
+                "--path",
+                str(tmp_path),
                 "--actor",
                 "human:test",
                 "--project-code",
@@ -110,7 +112,8 @@ class TestInitFlags:
             cli,
             [
                 "init",
-                "--path", str(tmp_path),
+                "--path",
+                str(tmp_path),
                 "--actor",
                 "human:test",
                 "--project-code",
@@ -130,7 +133,8 @@ class TestInitFlags:
             cli,
             [
                 "init",
-                "--path", str(tmp_path),
+                "--path",
+                str(tmp_path),
                 "--actor",
                 "human:test",
                 "--project-code",
@@ -150,7 +154,8 @@ class TestInitFlags:
             cli,
             [
                 "init",
-                "--path", str(tmp_path),
+                "--path",
+                str(tmp_path),
                 "--actor",
                 "human:test",
                 "--project-code",
@@ -174,7 +179,8 @@ class TestInitFlags:
             cli,
             [
                 "init",
-                "--path", str(tmp_path),
+                "--path",
+                str(tmp_path),
                 "--actor",
                 "human:test",
                 "--project-code",
@@ -191,7 +197,8 @@ class TestInitFlags:
             cli,
             [
                 "init",
-                "--path", str(tmp_path),
+                "--path",
+                str(tmp_path),
                 "--actor",
                 "human:test",
                 "--project-code",

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -447,9 +447,7 @@ class TestValidateCompletionPolicy:
     def test_default_done_policy_passes_with_review(self) -> None:
         """Default done policy is satisfied when review evidence exists."""
         config = default_config()
-        snap = _snap_with_evidence(
-            [{"id": "art_A", "role": "review", "source_type": "artifact"}]
-        )
+        snap = _snap_with_evidence([{"id": "art_A", "role": "review", "source_type": "artifact"}])
         ok, failures = validate_completion_policy(config, snap, "done")
         assert ok is True
         assert failures == []

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -96,9 +96,7 @@ class TestFailureTracking:
 class TestTempCleanup:
     def test_cleanup_removes_matching_files(self) -> None:
         # Create temp files matching the pattern
-        f1 = tempfile.NamedTemporaryFile(
-            prefix="lattice-review-", suffix=".md", delete=False
-        )
+        f1 = tempfile.NamedTemporaryFile(prefix="lattice-review-", suffix=".md", delete=False)
         f1.close()
         p1 = Path(f1.name)
         assert p1.exists()
@@ -140,6 +138,7 @@ class TestExtractActorStr:
 class TestConfigTimeout:
     def test_default_timeout_in_config(self) -> None:
         from lattice.core.config import default_config
+
         cfg = default_config()
         assert cfg["review_timeout_seconds"] == 600
 

--- a/tests/test_dashboard/test_structure_api.py
+++ b/tests/test_dashboard/test_structure_api.py
@@ -114,9 +114,7 @@ class TestStructureApi:
         assert len(events) <= 3
         assert body["data"]["truncated"] is True
 
-    def test_structure_events_missing_file_returns_empty(
-        self, tmp_path: Path
-    ) -> None:
+    def test_structure_events_missing_file_returns_empty(self, tmp_path: Path) -> None:
         ld = _make_project(tmp_path, project_type="structure", with_fixtures=False)
         # structure.json exists? no. Write an empty structure.json so /api/structure
         # test isn't the one hitting this path — we're only exercising events here.

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -44,9 +44,7 @@ class TestCache:
         monkeypatch.setattr("lattice.update_check._CACHE_DIR", tmp_path)
 
         # Write a cache entry that's older than TTL
-        cache_file.write_text(
-            json.dumps({"version": "1.2.3", "ts": time.time() - _CACHE_TTL - 1})
-        )
+        cache_file.write_text(json.dumps({"version": "1.2.3", "ts": time.time() - _CACHE_TTL - 1}))
         assert _read_cache() is None
 
     def test_missing_cache_returns_none(self, tmp_path, monkeypatch):
@@ -99,9 +97,7 @@ class TestMaybePrintUpdateNotice:
                 create=True,
             ),
             patch("lattice.update_check._fetch_latest", return_value="0.3.0"),
-            patch(
-                "importlib.metadata.version", return_value="0.1.0"
-            ),
+            patch("importlib.metadata.version", return_value="0.1.0"),
         ):
             maybe_print_update_notice()
 
@@ -131,9 +127,7 @@ class TestMaybePrintUpdateNotice:
         monkeypatch.setattr("lattice.update_check._CACHE_DIR", tmp_path)
 
         # Pre-populate fresh cache
-        cache_file.write_text(
-            json.dumps({"version": "0.2.0", "ts": time.time()})
-        )
+        cache_file.write_text(json.dumps({"version": "0.2.0", "ts": time.time()}))
 
         fake_stderr = self._tty_stderr()
         with (
@@ -153,9 +147,7 @@ class TestMaybePrintUpdateNotice:
         monkeypatch.setattr("lattice.update_check._CACHE_DIR", tmp_path)
 
         # Write stale cache
-        cache_file.write_text(
-            json.dumps({"version": "0.1.0", "ts": time.time() - _CACHE_TTL - 1})
-        )
+        cache_file.write_text(json.dumps({"version": "0.1.0", "ts": time.time() - _CACHE_TTL - 1}))
 
         fake_stderr = self._tty_stderr()
         with (


### PR DESCRIPTION
## Summary

Mechanical `ruff format` pass over the 17 files that have been silently rotting on main. Pre-existing baseline cleanup tracked in [LAT-215](.lattice/plans/task_01KQZX4TZXZNB2JYA1DV2DGEEH.md).

- 17 files reformatted, no source-code logic changes.
- Test suite: 1738 pass, unchanged.
- Lifts the format-check failure that's been red on every main commit since at least 2026-05-05.

The companion `type-check` job has `continue-on-error: true` ("advisory until codebase is fully typed"), so its 100+ pre-existing mypy errors are not blocking. Those will be addressed in follow-up tickets per-module.

LAT-215 itself stays open until follow-ups are filed for the mypy annotation backfill.

## Test plan

- [x] `uv run ruff format --check src/ tests/` passes locally
- [x] `uv run pytest` — 1738 pass
- [ ] CI green (lint + tests; type-check remains advisory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)