### PR TITLE
lattice: walk up directories to find .lattice/, like git finds .git

### DIFF
--- a/src/lattice/storage/fs.py
+++ b/src/lattice/storage/fs.py
@@ -103,6 +103,10 @@ def find_root(start: Path | None = None) -> Path | None:
     the path or raises an error (no fallback to walk-up).
 
     Otherwise, walks up from start (defaults to cwd) looking for .lattice/.
+    Mirrors ``git rev-parse --show-toplevel``: when start is inside a git
+    linked worktree, the search jumps to the primary worktree first so the
+    canonical .lattice/ is found rather than any stale snapshot copied into
+    the worktree at creation time. This makes ``lattice`` worktree-transparent.
 
     Returns:
         Path to the directory containing .lattice/, or None if not found.
@@ -126,12 +130,55 @@ def find_root(start: Path | None = None) -> Path | None:
         return env_path
 
     current = (start or Path.cwd()).resolve()
+
+    primary = _git_primary_worktree(current)
+    if primary is not None:
+        current = primary
+
     while True:
         if (current / LATTICE_DIR).is_dir():
             return current
         parent = current.parent
         if parent == current:
             # Reached filesystem root
+            return None
+        current = parent
+
+
+def _git_primary_worktree(start: Path) -> Path | None:
+    """Return the primary worktree root if start is inside a git linked worktree.
+
+    A linked worktree is marked by a ``.git`` *file* (not directory) whose
+    contents are ``gitdir: <abspath>/.git/worktrees/<name>``. The primary
+    worktree's root is the parent of that primary ``.git`` directory.
+
+    Returns None when start is not inside any git tree, when the nearest git
+    marker is a real ``.git`` directory (i.e., already the primary worktree),
+    or when the worktree pointer can't be parsed. In those cases the caller
+    keeps its existing walk-up search from start.
+    """
+    current = start
+    while True:
+        git_path = current / ".git"
+        if git_path.is_dir():
+            return None
+        if git_path.is_file():
+            try:
+                content = git_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                return None
+            prefix = "gitdir:"
+            if not content.startswith(prefix):
+                return None
+            gitdir = Path(content[len(prefix) :].strip())
+            # gitdir points at <primary>/.git/worktrees/<name>; primary root
+            # is two levels up from there.
+            primary_git = gitdir.parent.parent
+            if primary_git.name == ".git" and primary_git.is_dir():
+                return primary_git.parent
+            return None
+        parent = current.parent
+        if parent == current:
             return None
         current = parent
 

--- a/tests/test_storage/test_root_discovery.py
+++ b/tests/test_storage/test_root_discovery.py
@@ -94,3 +94,99 @@ class TestFindRootEnvVar:
 
         with pytest.raises(LatticeRootError, match="empty"):
             find_root(start=tmp_path)
+
+
+class TestFindRootWorktreeTransparent:
+    """find_root() jumps to the primary worktree when called from a git linked
+    worktree, so ``lattice`` resolves to the canonical .lattice/ rather than
+    a stale snapshot copied into the worktree at creation time.
+    """
+
+    @staticmethod
+    def _build_primary(tmp_path: Path) -> Path:
+        primary = tmp_path / "primary"
+        primary.mkdir()
+        (primary / ".git").mkdir()
+        return primary
+
+    @staticmethod
+    def _build_linked_worktree(primary: Path, name: str, location: Path) -> Path:
+        worktree_meta = primary / ".git" / "worktrees" / name
+        worktree_meta.mkdir(parents=True)
+        location.mkdir(parents=True, exist_ok=True)
+        (location / ".git").write_text(f"gitdir: {worktree_meta}\n", encoding="utf-8")
+        return location
+
+    def test_worktree_resolves_to_primary_lattice(self, tmp_path: Path) -> None:
+        """A linked worktree finds the primary's .lattice/, even when the
+        worktree also has its own (stale) copy."""
+        primary = self._build_primary(tmp_path)
+        (primary / LATTICE_DIR).mkdir()
+
+        worktree = self._build_linked_worktree(primary, "wt1", tmp_path / "worktrees" / "wt1")
+        (worktree / LATTICE_DIR).mkdir()  # stale snapshot — must be skipped
+
+        result = find_root(start=worktree)
+        assert result == primary
+
+    def test_worktree_resolves_to_primary_from_subdir(self, tmp_path: Path) -> None:
+        primary = self._build_primary(tmp_path)
+        (primary / LATTICE_DIR).mkdir()
+
+        worktree = self._build_linked_worktree(primary, "wt1", tmp_path / "worktrees" / "wt1")
+        deep = worktree / "src" / "deep"
+        deep.mkdir(parents=True)
+
+        result = find_root(start=deep)
+        assert result == primary
+
+    def test_worktree_walks_up_past_primary_when_lattice_higher(self, tmp_path: Path) -> None:
+        """If the primary worktree has no .lattice/, the walk continues up
+        from the primary root — not from the worktree dir."""
+        outer = tmp_path / "outer"
+        outer.mkdir()
+        (outer / LATTICE_DIR).mkdir()
+
+        primary = outer / "primary"
+        primary.mkdir()
+        (primary / ".git").mkdir()
+
+        worktree = self._build_linked_worktree(primary, "wt1", tmp_path / "worktrees" / "wt1")
+
+        result = find_root(start=worktree)
+        assert result == outer
+
+    def test_primary_worktree_unchanged(self, tmp_path: Path) -> None:
+        """When start is inside the primary worktree itself (.git is a dir),
+        behavior is the existing walk-up — no special-case redirect."""
+        primary = self._build_primary(tmp_path)
+        (primary / LATTICE_DIR).mkdir()
+        subdir = primary / "src"
+        subdir.mkdir()
+
+        result = find_root(start=subdir)
+        assert result == primary
+
+    def test_non_git_tree_unchanged(self, tmp_path: Path) -> None:
+        """When start isn't inside any git tree, behavior is plain walk-up."""
+        (tmp_path / LATTICE_DIR).mkdir()
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+
+        result = find_root(start=nested)
+        assert result == tmp_path
+
+    def test_malformed_worktree_pointer_falls_back(self, tmp_path: Path) -> None:
+        """A .git file with garbage contents falls back to walk-up from start.
+        This protects against weird user states without dropping into an
+        unrelated lattice install up the tree."""
+        primary = self._build_primary(tmp_path)
+        (primary / LATTICE_DIR).mkdir()
+
+        worktree = tmp_path / "worktrees" / "wt1"
+        worktree.mkdir(parents=True)
+        (worktree / ".git").write_text("not a gitdir pointer\n", encoding="utf-8")
+        (worktree / LATTICE_DIR).mkdir()
+
+        result = find_root(start=worktree)
+        assert result == worktree


### PR DESCRIPTION
## Summary

- `find_root` now jumps to the primary worktree before searching upward for `.lattice/` when called from a `git worktree add` linked worktree, mirroring how `git` itself treats worktrees as transparent windows into the parent repo.
- `lattice` is now worktree-transparent: from any subdir or worktree of any Lattice project, it resolves to the canonical `.lattice/` rather than a stale snapshot.
- Side benefit: `lattice list` (and every other read) now works from any subdirectory of any Lattice project, not just the project root.

## Motivation

The Expanded Cinema v1.1 Lattice orchestration retrospective (`code/ExpandedCinema/.lattice/orchestration/retrospective.md`, § "Worktree `.lattice/` staleness") flagged this as a generalizable failure that every future Lattice-orchestrated run would hit:

> When the Orchestrator creates `git worktree add worktrees/psy-40`, the new worktree's `.lattice/` directory is a snapshot from main as-of the worktree creation. PSY-40 was minted *after* the worktree creation, so `lattice code-review PSY-40` inside the worktree initially fails: "task not found." PSY-40's delegator self-recovered by symlinking `worktrees/psy-40/.lattice -> ../../../.lattice` (parent's). The Orchestrator noted it as a LESSONS candidate, but it'll hit every future run.

The retrospective explicitly proposed the fix this PR implements:

> **Best:** Lattice should follow `.git`-style behavior — the `.lattice/` directory should be a single source of truth at the repo root, transparent across worktrees. Either `.lattice/` becomes a symlinkable directory or `lattice` learns to find the canonical `.lattice/` by walking up the directory tree.

## Approach

`find_root` detects a linked worktree via the `.git` *file* gitdir pointer (`gitdir: <abspath>/.git/worktrees/<name>`) and resolves the primary worktree as the parent of that primary `.git` directory. Behavior is unchanged when:

- `LATTICE_ROOT` env var is set (existing override wins).
- The caller is inside the primary worktree itself (`.git` is a directory).
- The caller is not inside any git tree.
- The `.git` file is malformed (falls back to walk-up from start).

## Tests

6 new tests in `tests/test_storage/test_root_discovery.py::TestFindRootWorktreeTransparent` covering: worktree-to-primary redirect, redirect from a deep subdir, walking past the primary when `.lattice/` is higher, the primary-worktree-unchanged invariant, the non-git-tree invariant, and malformed-pointer fallback. Full suite: 1744 passed, ruff clean.

End-to-end smoke confirmed manually: built a real `git worktree add` against a primary holding `.lattice/`, ran the CLI from a deep subdir of the worktree, and verified resolution to the primary's `.lattice/`.

## Test plan

- [x] `uv run pytest` — 1744 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] End-to-end smoke against a real `git worktree`