### PR TITLE
feat(LAT-218): headless single-mode reviews + c11-pane triple mode + full c11 rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,10 +56,10 @@ uv cache clean lattice-tracker && uv tool install -e /Users/atin/Projects/Stage1
 - **`core/`** — pure business logic. No filesystem calls.
 - **`storage/`** — all filesystem I/O. Atomic writes, locking, directory traversal.
 - **`cli/`** — wires core + storage via Click commands. Output formatting.
-- **`integrations/`** — optional, environment-aware backends (cmux, terminal). Loaded lazily; absence never blocks core paths.
+- **`integrations/`** — optional, environment-aware backends (c11, terminal). Loaded lazily; absence never blocks core paths.
 - **`dashboard/`** — read-only. Reads `.lattice/` files, serves JSON + static HTML.
 
-**Spawning fresh-context agents:** `lattice.core.agent_spawn` is the public primitive (`SpawnRequest`, `SpawnResult`, `spawn_one`, `spawn_many`). Backends auto-select cmux → terminal → headless; force via `--backend` / `LATTICE_SPAWN_BACKEND`. Use this for any "open a clean agent for one task" use case (review, summarization, PR description, etc.) rather than rolling a new `subprocess.run`.
+**Spawning fresh-context agents:** `lattice.core.agent_spawn` is the public primitive (`SpawnRequest`, `SpawnResult`, `spawn_one`, `spawn_many`). Backends auto-select c11 → terminal → headless; force via `LATTICE_SPAWN_BACKEND`. Use this for any "open a clean agent for one task" use case (review, summarization, PR description, etc.) rather than rolling a new `subprocess.run`. **Reviews bypass this:** `lattice code-review` / `plan-review` always run headless in single mode (no `--backend` / `--headless` flags); triple mode spawns one new pane in the caller's c11 workspace and hands off to `/trident-{code,plan}-review`.
 
 ## Development Setup
 

--- a/src/lattice/agent_runner.py
+++ b/src/lattice/agent_runner.py
@@ -292,9 +292,9 @@ def _maybe_set_c11_metadata(label: str, *, status: str) -> None:
 
     Called from inside c11 panes so the sidebar reflects per-pane state.
     """
-    if not (os.environ.get("C11_WORKSPACE_ID") or os.environ.get("CMUX_WORKSPACE_ID")):
+    if not os.environ.get("C11_WORKSPACE_ID"):
         return
-    surface = os.environ.get("C11_SURFACE_ID") or os.environ.get("CMUX_SURFACE_ID")
+    surface = os.environ.get("C11_SURFACE_ID")
     if not surface:
         return
     try:

--- a/src/lattice/agent_runner.py
+++ b/src/lattice/agent_runner.py
@@ -22,7 +22,7 @@ Two modes selected by ``--mode {agent,merge-waiter}`` (default ``agent``).
 - Writes its own sentinel + err sidecar on exit.
 
 This wrapper is the single canonical invocation shape across backends so
-the cmux / terminal / headless paths differ only in *how* they launch it.
+the c11 / terminal / headless paths differ only in *how* they launch it.
 """
 
 from __future__ import annotations
@@ -82,7 +82,7 @@ def _run_agent_mode() -> int:
     out_path = Path(output_file)
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    _maybe_set_cmux_metadata(label, status="running")
+    _maybe_set_c11_metadata(label, status="running")
 
     # Resolve the agent CLI command. Importing inside main keeps this
     # script importable even when lattice is partially built.
@@ -91,7 +91,7 @@ def _run_agent_mode() -> int:
     cmd = _agent_cli_command(agent_type, prompt_file, output_file)
     if cmd is None:
         _emit_failure(out_path, f"unknown agent type: {agent_type}", code=2)
-        _maybe_set_cmux_metadata(label, status="failed")
+        _maybe_set_c11_metadata(label, status="failed")
         return 2
 
     print(f"[agent_runner] type={agent_type} label={label} timeout={timeout_s}s")
@@ -100,11 +100,11 @@ def _run_agent_mode() -> int:
     env = os.environ.copy()
     env.pop("CLAUDECODE", None)
 
-    # Stream stdout/stderr live so the cmux/terminal pane hosting this
+    # Stream stdout/stderr live so the c11/terminal pane hosting this
     # wrapper shows output as the agent produces it, rather than dumping
     # a block after the subprocess exits. The old capture_output=True
     # path hid the agent entirely until completion, which nullified the
-    # visibility motivation of the cmux/terminal backends.
+    # visibility motivation of the c11/terminal backends.
     start = time.monotonic()
     try:
         proc = subprocess.Popen(
@@ -118,7 +118,7 @@ def _run_agent_mode() -> int:
         )
     except OSError as exc:
         _emit_failure(out_path, f"failed to spawn: {exc}", code=2)
-        _maybe_set_cmux_metadata(label, status="failed")
+        _maybe_set_c11_metadata(label, status="failed")
         return 2
 
     captured: list[str] = []
@@ -146,7 +146,7 @@ def _run_agent_mode() -> int:
             pass
         reader_t.join(timeout=1)
         _emit_failure(out_path, f"timed out after {timeout_s}s", code=124)
-        _maybe_set_cmux_metadata(label, status="failed")
+        _maybe_set_c11_metadata(label, status="failed")
         return 124
 
     # Drain any trailing buffered output before we print the finished marker.
@@ -159,7 +159,7 @@ def _run_agent_mode() -> int:
         combined = "".join(captured).strip().splitlines()
         first_line = combined[0] if combined else f"exit {rc}"
         _emit_failure(out_path, first_line, code=rc)
-        _maybe_set_cmux_metadata(label, status="failed")
+        _maybe_set_c11_metadata(label, status="failed")
         return rc
 
     # Make sure the output file has content. Fall back to captured stdout
@@ -170,11 +170,11 @@ def _run_agent_mode() -> int:
             out_path.write_text(captured_text + "\n", encoding="utf-8")
         else:
             _emit_failure(out_path, "no output produced", code=2)
-            _maybe_set_cmux_metadata(label, status="failed")
+            _maybe_set_c11_metadata(label, status="failed")
             return 2
 
     _write_sentinel(out_path)
-    _maybe_set_cmux_metadata(label, status="done")
+    _maybe_set_c11_metadata(label, status="done")
     return 0
 
 
@@ -203,7 +203,7 @@ def _run_merge_waiter_mode() -> int:
     out_path = Path(output_file)
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    _maybe_set_cmux_metadata(label, status="waiting")
+    _maybe_set_c11_metadata(label, status="waiting")
 
     deadline = time.monotonic() + timeout_s
     pending = list(upstream_dirs)
@@ -222,7 +222,7 @@ def _run_merge_waiter_mode() -> int:
 
     if not landed:
         _emit_failure(out_path, "no upstream sentinels landed before timeout", code=124)
-        _maybe_set_cmux_metadata(label, status="failed")
+        _maybe_set_c11_metadata(label, status="failed")
         return 124
 
     if pending:
@@ -287,19 +287,19 @@ def _emit_failure(output_file: Path, message: str, *, code: int) -> None:
     sys.stderr.write(f"[agent_runner] FAILED ({code}): {message}\n")
 
 
-def _maybe_set_cmux_metadata(label: str, *, status: str) -> None:
-    """Best-effort surface metadata update — silent if cmux is unavailable.
+def _maybe_set_c11_metadata(label: str, *, status: str) -> None:
+    """Best-effort surface metadata update — silent if c11 is unavailable.
 
-    Called from inside cmux panes so the sidebar reflects per-pane state.
+    Called from inside c11 panes so the sidebar reflects per-pane state.
     """
-    if not os.environ.get("CMUX_WORKSPACE_ID"):
+    if not (os.environ.get("C11_WORKSPACE_ID") or os.environ.get("CMUX_WORKSPACE_ID")):
         return
-    surface = os.environ.get("CMUX_SURFACE_ID")
+    surface = os.environ.get("C11_SURFACE_ID") or os.environ.get("CMUX_SURFACE_ID")
     if not surface:
         return
     try:
         subprocess.run(
-            ["cmux", "set-metadata", "--surface", surface, "--key", "status", "--value", status],
+            ["c11", "set-metadata", "--surface", surface, "--key", "status", "--value", status],
             capture_output=True,
             timeout=2,
         )

--- a/src/lattice/cli/c11_bridge.py
+++ b/src/lattice/cli/c11_bridge.py
@@ -11,10 +11,9 @@ Design principles:
 - Graceful degradation: failures are warnings, not errors.
 - CLI layer only: core knows nothing about c11.
 
-The c11 binary still accepts ``cmux`` as an OS-layer compat alias and sets
-both ``C11_*`` and ``CMUX_*`` env vars on every surface; this module is the
-single canonical place we acknowledge that fact, by reading both names with
-``C11_*`` taking precedence.
+The c11 binary still accepts ``cmux`` as an OS-layer compat alias, but it
+always sets ``C11_*`` env vars on every surface, so reading ``C11_*`` alone
+is sufficient — we never reach for the legacy ``CMUX_*`` names in our code.
 """
 
 from __future__ import annotations
@@ -59,17 +58,17 @@ STATUS_LABELS: dict[str, str] = {
 
 def c11_available() -> bool:
     """Return True if we are running inside c11."""
-    return bool(os.environ.get("C11_WORKSPACE_ID") or os.environ.get("CMUX_WORKSPACE_ID"))
+    return bool(os.environ.get("C11_WORKSPACE_ID"))
 
 
 def get_workspace() -> str | None:
     """Return the current c11 workspace ref from the environment."""
-    return os.environ.get("C11_WORKSPACE_ID") or os.environ.get("CMUX_WORKSPACE_ID")
+    return os.environ.get("C11_WORKSPACE_ID")
 
 
 def get_surface() -> str | None:
     """Return the current c11 surface ref from the environment."""
-    return os.environ.get("C11_SURFACE_ID") or os.environ.get("CMUX_SURFACE_ID")
+    return os.environ.get("C11_SURFACE_ID")
 
 
 # ---------------------------------------------------------------------------

--- a/src/lattice/cli/c11_bridge.py
+++ b/src/lattice/cli/c11_bridge.py
@@ -1,14 +1,20 @@
-"""cmux integration bridge for Lattice.
+"""c11 integration bridge for Lattice.
 
-All cmux interaction lives here.  Every function is a no-op when not running
-inside cmux (detected via CMUX_WORKSPACE_ID env var).  All subprocess errors
-are logged as warnings — they never raise and never block Lattice operations.
+All c11 interaction lives here.  Every function is a no-op when not running
+inside c11 (detected via the C11_WORKSPACE_ID env var).  All subprocess
+errors are logged as warnings — they never raise and never block Lattice
+operations.
 
 Design principles:
-- Strictly optional: Lattice works identically without cmux.
-- Detection, not configuration: presence of CMUX_WORKSPACE_ID IS the config.
+- Strictly optional: Lattice works identically without c11.
+- Detection, not configuration: presence of C11_WORKSPACE_ID IS the config.
 - Graceful degradation: failures are warnings, not errors.
-- CLI layer only: core knows nothing about cmux.
+- CLI layer only: core knows nothing about c11.
+
+The c11 binary still accepts ``cmux`` as an OS-layer compat alias and sets
+both ``C11_*`` and ``CMUX_*`` env vars on every surface; this module is the
+single canonical place we acknowledge that fact, by reading both names with
+``C11_*`` taking precedence.
 """
 
 from __future__ import annotations
@@ -51,37 +57,37 @@ STATUS_LABELS: dict[str, str] = {
 # ---------------------------------------------------------------------------
 
 
-def cmux_available() -> bool:
-    """Return True if we are running inside cmux."""
-    return bool(os.environ.get("CMUX_WORKSPACE_ID"))
+def c11_available() -> bool:
+    """Return True if we are running inside c11."""
+    return bool(os.environ.get("C11_WORKSPACE_ID") or os.environ.get("CMUX_WORKSPACE_ID"))
 
 
 def get_workspace() -> str | None:
-    """Return the current cmux workspace ref from the environment."""
-    return os.environ.get("CMUX_WORKSPACE_ID")
+    """Return the current c11 workspace ref from the environment."""
+    return os.environ.get("C11_WORKSPACE_ID") or os.environ.get("CMUX_WORKSPACE_ID")
 
 
 def get_surface() -> str | None:
-    """Return the current cmux surface ref from the environment."""
-    return os.environ.get("CMUX_SURFACE_ID")
+    """Return the current c11 surface ref from the environment."""
+    return os.environ.get("C11_SURFACE_ID") or os.environ.get("CMUX_SURFACE_ID")
 
 
 # ---------------------------------------------------------------------------
-# Low-level cmux CLI wrappers
+# Low-level c11 CLI wrappers
 # ---------------------------------------------------------------------------
 
 
-def _run_cmux(*args: str) -> bool:
-    """Run a cmux CLI command.  Returns True on success, False on failure."""
+def _run_c11(*args: str) -> bool:
+    """Run a c11 CLI command.  Returns True on success, False on failure."""
     try:
         result = subprocess.run(
-            ["cmux", *args],
+            ["c11", *args],
             capture_output=True,
             timeout=10,
         )
         if result.returncode != 0:
             logger.warning(
-                "cmux command failed (exit %d): cmux %s\nstderr: %s",
+                "c11 command failed (exit %d): c11 %s\nstderr: %s",
                 result.returncode,
                 " ".join(args),
                 result.stderr.decode(errors="replace"),
@@ -89,65 +95,65 @@ def _run_cmux(*args: str) -> bool:
             return False
         return True
     except FileNotFoundError:
-        logger.warning("cmux binary not found — cmux integration unavailable")
+        logger.warning("c11 binary not found — c11 integration unavailable")
         return False
     except subprocess.TimeoutExpired:
-        logger.warning("cmux command timed out: cmux %s", " ".join(args))
+        logger.warning("c11 command timed out: c11 %s", " ".join(args))
         return False
     except Exception as exc:  # noqa: BLE001
-        logger.warning("cmux command error: %s", exc)
+        logger.warning("c11 command error: %s", exc)
         return False
 
 
 def rename_tab(surface: str, title: str) -> bool:
-    """Rename a cmux surface tab.  Returns True on success."""
-    if not cmux_available():
+    """Rename a c11 surface tab.  Returns True on success."""
+    if not c11_available():
         return False
     workspace = get_workspace()
     args = ["rename-tab", "--surface", surface, title]
     if workspace:
         args = ["rename-tab", "--workspace", workspace, "--surface", surface, title]
-    return _run_cmux(*args)
+    return _run_c11(*args)
 
 
 def set_status(key: str, value: str, icon: str | None = None, color: str | None = None) -> bool:
-    """Update a cmux sidebar status entry.  Returns True on success."""
-    if not cmux_available():
+    """Update a c11 sidebar status entry.  Returns True on success."""
+    if not c11_available():
         return False
     args = ["set-status", key, value]
     if icon:
         args += ["--icon", icon]
     if color:
         args += ["--color", color]
-    return _run_cmux(*args)
+    return _run_c11(*args)
 
 
 def clear_status(key: str) -> bool:
-    """Remove a cmux sidebar status entry.  Returns True on success."""
-    if not cmux_available():
+    """Remove a c11 sidebar status entry.  Returns True on success."""
+    if not c11_available():
         return False
-    return _run_cmux("clear-status", key)
+    return _run_c11("clear-status", key)
 
 
 def trigger_flash(surface: str) -> bool:
-    """Flash a cmux surface.  Returns True on success."""
-    if not cmux_available():
+    """Flash a c11 surface.  Returns True on success."""
+    if not c11_available():
         return False
     workspace = get_workspace()
     args = ["trigger-flash", "--surface", surface]
     if workspace:
         args = ["trigger-flash", "--workspace", workspace, "--surface", surface]
-    return _run_cmux(*args)
+    return _run_c11(*args)
 
 
 def notify(title: str, body: str | None = None) -> bool:
-    """Send a cmux notification.  Returns True on success."""
-    if not cmux_available():
+    """Send a c11 notification.  Returns True on success."""
+    if not c11_available():
         return False
     args = ["notify", "--title", title]
     if body:
         args += ["--body", body]
-    return _run_cmux(*args)
+    return _run_c11(*args)
 
 
 # ---------------------------------------------------------------------------
@@ -156,18 +162,18 @@ def notify(title: str, body: str | None = None) -> bool:
 
 
 def on_status_changed(snapshot: dict, old_status: str, new_status: str) -> None:
-    """React to a task status transition inside cmux.
+    """React to a task status transition inside c11.
 
-    Reads ``cmux_surface`` and ``cmux_workspace`` from the snapshot.
+    Reads ``c11_surface`` and ``c11_workspace`` from the snapshot.
     Does nothing if the task has no surface binding.
 
     Called from task_cmds.py after write_task_event succeeds.  Must
     never raise — all errors are logged as warnings.
     """
-    if not cmux_available():
+    if not c11_available():
         return
 
-    surface = snapshot.get("cmux_surface")
+    surface = snapshot.get("c11_surface")
     if not surface:
         return  # task not bound to any surface
 

--- a/src/lattice/cli/claim_cmd.py
+++ b/src/lattice/cli/claim_cmd.py
@@ -1,10 +1,10 @@
-"""Claim/unclaim commands: bind a task to a cmux surface."""
+"""Claim/unclaim commands: bind a task to a c11 surface."""
 
 from __future__ import annotations
 
 import click
 
-from lattice.cli.cmux_bridge import cmux_available, get_surface, get_workspace, rename_tab
+from lattice.cli.c11_bridge import c11_available, get_surface, get_workspace, rename_tab
 from lattice.cli.helpers import (
     common_options,
     load_project_config,
@@ -27,7 +27,7 @@ from lattice.core.tasks import apply_event_to_snapshot
     "--surface",
     "surface_id",
     default=None,
-    help="cmux surface ref (e.g. surface:153). Defaults to CMUX_SURFACE_ID env var.",
+    help="c11 surface ref (e.g. surface:153). Defaults to C11_SURFACE_ID env var.",
 )
 @common_options
 def claim_cmd(
@@ -41,12 +41,12 @@ def claim_cmd(
     on_behalf_of: str | None,
     provenance_reason: str | None,
 ) -> None:
-    """Bind a task to a cmux surface.
+    """Bind a task to a c11 surface.
 
     Records a surface_bound event and stores the binding in the snapshot.
-    If inside cmux, renames the tab to the task's short code and title.
+    If inside c11, renames the tab to the task's short code and title.
 
-    The surface defaults to CMUX_SURFACE_ID from the environment, or can be
+    The surface defaults to C11_SURFACE_ID from the environment, or can be
     specified explicitly with --surface.
 
     Examples:
@@ -67,8 +67,8 @@ def claim_cmd(
     resolved_surface = surface_id or get_surface()
     if not resolved_surface:
         output_error(
-            "No surface specified. Provide --surface or run inside cmux "
-            "(CMUX_SURFACE_ID must be set).",
+            "No surface specified. Provide --surface or run inside c11 "
+            "(C11_SURFACE_ID must be set).",
             "MISSING_SURFACE",
             is_json,
         )
@@ -93,8 +93,8 @@ def claim_cmd(
     updated_snapshot = apply_event_to_snapshot(snapshot, event)
     write_task_event(lattice_dir, task_id, [event], updated_snapshot, config)
 
-    # Rename tab if inside cmux
-    if cmux_available():
+    # Rename tab if inside c11
+    if c11_available():
         short_id = updated_snapshot.get("short_id") or task_id
         title = updated_snapshot.get("title") or ""
         rename_tab(resolved_surface, f"{short_id}: {title}")
@@ -127,9 +127,9 @@ def unclaim_cmd(
     on_behalf_of: str | None,
     provenance_reason: str | None,
 ) -> None:
-    """Remove a task's cmux surface binding.
+    """Remove a task's c11 surface binding.
 
-    Records a surface_unbound event and clears cmux_surface / cmux_workspace
+    Records a surface_unbound event and clears c11_surface / c11_workspace
     from the snapshot.
 
     Examples:
@@ -144,7 +144,7 @@ def unclaim_cmd(
     task_id = resolve_task_id(lattice_dir, task_id, is_json)
     snapshot = read_snapshot_or_exit(lattice_dir, task_id, is_json)
 
-    old_surface = snapshot.get("cmux_surface")
+    old_surface = snapshot.get("c11_surface")
 
     event = create_event(
         type="surface_unbound",

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -139,7 +139,7 @@ def _claim_or_refuse(
 )
 @click.option(
     "--backend",
-    type=click.Choice(["cmux", "terminal", "headless"]),
+    type=click.Choice(["c11", "terminal", "headless"]),
     default=None,
     help="Force a specific spawn backend. Raises if unavailable instead of falling through.",
 )
@@ -304,7 +304,7 @@ def code_review(
 )
 @click.option(
     "--backend",
-    type=click.Choice(["cmux", "terminal", "headless"]),
+    type=click.Choice(["c11", "terminal", "headless"]),
     default=None,
     help="Force a specific spawn backend. Raises if unavailable instead of falling through.",
 )

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -131,25 +131,11 @@ def _claim_or_refuse(
     help="Review mode (overrides config). One of: inline, single, triple.",
 )
 @click.option("--base", default=None, help="Base git ref for diff (branch or commit).")
-@click.option(
-    "--headless",
-    is_flag=True,
-    default=False,
-    help="Force the headless spawn backend (subprocess.run; no panes/windows).",
-)
-@click.option(
-    "--backend",
-    type=click.Choice(["c11", "terminal", "headless"]),
-    default=None,
-    help="Force a specific spawn backend. Raises if unavailable instead of falling through.",
-)
 @common_options
 def code_review(
     task_id: str,
     mode: str | None,
     base: str | None,
-    headless: bool,
-    backend: str | None,
     model: str | None,
     session: str | None,
     output_json: bool,
@@ -262,8 +248,6 @@ def code_review(
             model=model,
             session=session,
             timeout=timeout,
-            headless=headless,
-            backend_force=backend,
         )
 
     elif mode == "triple":
@@ -278,8 +262,6 @@ def code_review(
             model=model,
             session=session,
             timeout=timeout,
-            headless=headless,
-            backend_force=backend,
         )
 
 
@@ -296,24 +278,10 @@ def code_review(
     default=None,
     help="Review mode (overrides config). One of: inline, single, triple.",
 )
-@click.option(
-    "--headless",
-    is_flag=True,
-    default=False,
-    help="Force the headless spawn backend (subprocess.run; no panes/windows).",
-)
-@click.option(
-    "--backend",
-    type=click.Choice(["c11", "terminal", "headless"]),
-    default=None,
-    help="Force a specific spawn backend. Raises if unavailable instead of falling through.",
-)
 @common_options
 def plan_review(
     task_id: str,
     mode: str | None,
-    headless: bool,
-    backend: str | None,
     model: str | None,
     session: str | None,
     output_json: bool,
@@ -416,8 +384,6 @@ def plan_review(
             model=model,
             session=session,
             timeout=timeout,
-            headless=headless,
-            backend_force=backend,
         )
         if art_id and plan_approval == "human":
             _move_to_needs_human(lattice_dir, task_id, actor, is_json)
@@ -434,8 +400,6 @@ def plan_review(
             model=model,
             session=session,
             timeout=timeout,
-            headless=headless,
-            backend_force=backend,
         )
         if art_ids and plan_approval == "human":
             _move_to_needs_human(lattice_dir, task_id, actor, is_json)
@@ -534,8 +498,6 @@ def _run_single_and_store(
     model: str | None,
     session: str | None,
     timeout: int = 600,
-    headless: bool = False,
-    backend_force: str | None = None,
 ) -> str | None:
     """Run single-agent review, store artifact, print result. Returns artifact ID or None."""
     click.echo(f"Running {review_type} (single mode)...")
@@ -547,8 +509,6 @@ def _run_single_and_store(
         prompt_content=prompt,
         actor=actor,
         timeout=timeout,
-        headless=headless,
-        backend_force=backend_force,
     )
 
     if not success:
@@ -594,8 +554,6 @@ def _run_triple_and_store(
     model: str | None,
     session: str | None,
     timeout: int = 600,
-    headless: bool = False,
-    backend_force: str | None = None,
 ) -> list[str]:
     """Run triple-agent review, store artifacts, print result. Returns list of artifact IDs."""
     click.echo(f"Running {review_type} (triple mode — spawning claude, codex, gemini)...")
@@ -607,8 +565,6 @@ def _run_triple_and_store(
         prompt_content=prompt,
         actor=actor,
         timeout=timeout,
-        headless=headless,
-        backend_force=backend_force,
     )
 
     artifact_ids: list[str] = []
@@ -643,8 +599,6 @@ def _run_triple_and_store(
         task_id=task_id,
         reviews=results,
         review_type=review_type,
-        headless=headless,
-        backend_force=backend_force,
     )
 
     if merge_success:

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -163,14 +163,10 @@ def code_review(
     if mode == "inline":
         existing = read_review_state(lattice_dir, task_id)
         if isinstance(existing, dict):
-            from lattice.core.review import _pid_alive
+            from lattice.core.review import pid_alive
 
             holder_pid = existing.get("started_by_pid")
-            if (
-                isinstance(holder_pid, int)
-                and holder_pid != os.getpid()
-                and _pid_alive(holder_pid)
-            ):
+            if isinstance(holder_pid, int) and holder_pid != os.getpid() and pid_alive(holder_pid):
                 output_error(
                     (
                         "A review is already in flight for this task "
@@ -314,14 +310,10 @@ def plan_review(
     if mode == "inline":
         existing = read_review_state(lattice_dir, task_id)
         if isinstance(existing, dict):
-            from lattice.core.review import _pid_alive
+            from lattice.core.review import pid_alive
 
             holder_pid = existing.get("started_by_pid")
-            if (
-                isinstance(holder_pid, int)
-                and holder_pid != os.getpid()
-                and _pid_alive(holder_pid)
-            ):
+            if isinstance(holder_pid, int) and holder_pid != os.getpid() and pid_alive(holder_pid):
                 output_error(
                     (
                         "A review is already in flight for this task "

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -25,8 +25,8 @@ from lattice.cli.main import cli
 from lattice.core.review import (
     claim_review_state,
     cleanup_temp_files,
+    clear_review_state,
     read_review_state,
-    run_merge_agent,
     run_single_review,
     run_triple_review,
     resolve_diff,
@@ -251,17 +251,15 @@ def code_review(
         )
 
     elif mode == "triple":
-        _run_triple_and_store(
+        _spawn_triple_pane(
             lattice_dir=lattice_dir,
             task_id=task_id,
+            snapshot=snapshot,
             review_type="code-review",
-            prompt=prompt,
             actor=actor,
             is_json=is_json,
             quiet=quiet,
-            model=model,
-            session=session,
-            timeout=timeout,
+            base=base,
         )
 
 
@@ -389,20 +387,20 @@ def plan_review(
             _move_to_needs_human(lattice_dir, task_id, actor, is_json)
 
     elif mode == "triple":
-        art_ids = _run_triple_and_store(
+        # The pane drives triage and status transitions itself; the CLI
+        # does not move the task to needs_human here even when
+        # plan_approval == "human".  The pane sees the trident artifact
+        # first-hand and is the right place to decide.
+        _spawn_triple_pane(
             lattice_dir=lattice_dir,
             task_id=task_id,
+            snapshot=snapshot,
             review_type="plan-review",
-            prompt=prompt,
             actor=actor,
             is_json=is_json,
             quiet=quiet,
-            model=model,
-            session=session,
-            timeout=timeout,
+            base=None,
         )
-        if art_ids and plan_approval == "human":
-            _move_to_needs_human(lattice_dir, task_id, actor, is_json)
 
 
 # ---------------------------------------------------------------------------
@@ -542,91 +540,65 @@ def _run_single_and_store(
     return art_id
 
 
-def _run_triple_and_store(
+def _spawn_triple_pane(
     *,
     lattice_dir: Path,
     task_id: str,
+    snapshot: dict,
     review_type: str,
-    prompt: str,
     actor: str | dict,
     is_json: bool,
     quiet: bool,
-    model: str | None,
-    session: str | None,
-    timeout: int = 600,
-) -> list[str]:
-    """Run triple-agent review, store artifacts, print result. Returns list of artifact IDs."""
-    click.echo(f"Running {review_type} (triple mode — spawning claude, codex, gemini)...")
+    base: str | None,
+) -> None:
+    """Spawn a c11 pane that runs the trident review. Fire-and-forget.
 
-    overall_success, message, results = run_triple_review(
+    Triple mode in LAT-218 onwards no longer runs three review agents in
+    the CLI — it splits one new pane in the caller's c11 workspace and
+    hands off to ``/trident-{code|plan}-review``. The pane owns trident,
+    artifact storage, triage, and the task-status advance.
+
+    On failure (notably: not running inside c11) this releases the
+    in-flight review claim that ``_claim_or_refuse`` made earlier, prints
+    a clear error, and exits non-zero.
+    """
+    short_id = snapshot.get("short_id") or task_id
+    success, message = run_triple_review(
         lattice_dir=lattice_dir,
         task_id=task_id,
         review_type=review_type,
-        prompt_content=prompt,
         actor=actor,
-        timeout=timeout,
+        base=base,
+        short_id=short_id,
+        worktree=lattice_dir.parent,
     )
 
-    artifact_ids: list[str] = []
-
-    # Store individual reviews
-    for agent, success, text in results:
-        if success:
-            art_id = _attach_review_artifact(
-                lattice_dir=lattice_dir,
-                task_id=task_id,
-                content=text,
-                title=f"{review_type} ({agent})",
-                role="review-individual",
-                actor=actor,
-                is_json=False,  # suppress per-artifact JSON noise
+    if not success:
+        # Release the parent claim so retries aren't blocked by a phantom record.
+        clear_review_state(lattice_dir, task_id)
+        if is_json:
+            click.echo(
+                json.dumps(
+                    {"ok": False, "error": {"code": "TRIPLE_SPAWN_FAILED", "message": message}},
+                    indent=2,
+                ),
+                err=True,
             )
-            if art_id:
-                artifact_ids.append(art_id)
-                click.echo(f"  Stored {agent} review as {art_id}.")
         else:
-            click.echo(f"  {agent} failed: {text}", err=True)
+            click.echo(message, err=True)
+        raise click.exceptions.Exit(code=1)
 
-    # Merge if at least one succeeded
-    if not overall_success:
-        click.echo("All agents failed. No merged review produced.", err=True)
-        cleanup_temp_files(task_id)
-        return artifact_ids
-
-    click.echo("Merging reviews...")
-    merge_success, merged_text = run_merge_agent(
-        lattice_dir=lattice_dir,
-        task_id=task_id,
-        reviews=results,
-        review_type=review_type,
-    )
-
-    if merge_success:
-        role = "review" if review_type == "code-review" else "plan-review"
-        merged_id = _attach_review_artifact(
-            lattice_dir=lattice_dir,
-            task_id=task_id,
-            content=merged_text,
-            title=f"{review_type} (merged)",
-            role=role,
-            actor=actor,
-            is_json=False,
+    if is_json:
+        click.echo(
+            json.dumps(
+                {"ok": True, "data": {"mode": "triple", "task_id": task_id, "message": message}},
+                indent=2,
+            )
         )
-        if merged_id:
-            artifact_ids.append(merged_id)
-            if is_json:
-                click.echo(
-                    json.dumps({"ok": True, "data": {"artifact_ids": artifact_ids}}, indent=2)
-                )
-            elif quiet:
-                click.echo(merged_id)
-            else:
-                click.echo(f"Merged review stored as {merged_id} (role={role}).")
+    elif quiet:
+        click.echo(message)
     else:
-        click.echo(f"Merge agent failed: {merged_text}", err=True)
-
-    cleanup_temp_files(task_id)
-    return artifact_ids
+        click.echo(message)
 
 
 def _attach_review_artifact(

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -932,10 +932,10 @@ def status_cmd(
     if is_backward_transition:
         _append_plan_reset_section(lattice_dir, task_id, actor, event.get("ts"))
 
-    # cmux integration: update tab title / sidebar / flash when task is surface-bound
-    from lattice.cli.cmux_bridge import cmux_available, on_status_changed
+    # c11 integration: update tab title / sidebar / flash when task is surface-bound
+    from lattice.cli.c11_bridge import c11_available, on_status_changed
 
-    if cmux_available():
+    if c11_available():
         on_status_changed(updated_snapshot, current_status, new_status)
 
     # Auto-fire review/plan-review on transitions to review/planned (LAT-211).

--- a/src/lattice/core/agent_spawn.py
+++ b/src/lattice/core/agent_spawn.py
@@ -2,11 +2,11 @@
 
 Public contract: ``spawn_one`` and ``spawn_many`` accept ``SpawnRequest``
 records and return ``SpawnResult`` records, regardless of whether the agent
-ran via cmux panes, a Terminal window, or a headless ``subprocess.run``.
+ran via c11 panes, a Terminal window, or a headless ``subprocess.run``.
 
 Backend selection:
 - ``select_backend()`` inspects environment + platform and returns a
-  ``Backend`` instance from the chain ``cmux -> terminal -> headless``.
+  ``Backend`` instance from the chain ``c11 -> terminal -> headless``.
 - ``LATTICE_SPAWN_BACKEND`` / ``--backend`` force a specific backend; an
   explicit force does NOT fall through (raises ``BackendUnavailableError``).
 
@@ -125,7 +125,7 @@ def sentinel_path(output_file: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
-_VALID_BACKENDS = {"cmux", "terminal", "headless"}
+_VALID_BACKENDS = {"c11", "terminal", "headless"}
 
 
 def select_backend(
@@ -138,11 +138,11 @@ def select_backend(
 
     Selection chain:
     1. Forced/headless/CI/``LATTICE_SPAWN_BACKEND=headless`` -> ``HeadlessBackend``.
-    2. Forced ``cmux`` or auto-detected cmux -> ``CmuxBackend``.
+    2. Forced ``c11`` or auto-detected c11 -> ``C11Backend``.
     3. Forced ``terminal`` or auto-detected terminal -> ``TerminalBackend``.
     4. Otherwise -> ``HeadlessBackend``.
 
-    An explicit ``force`` (or ``LATTICE_SPAWN_BACKEND={cmux,terminal}``) raises
+    An explicit ``force`` (or ``LATTICE_SPAWN_BACKEND={c11,terminal}``) raises
     ``BackendUnavailableError`` rather than falling through, so operators
     detect misconfiguration instead of silently landing on a different backend.
     """
@@ -164,17 +164,17 @@ def select_backend(
             on_progress("backend_selected", f"headless ({reason})")
         return HeadlessBackend()
 
-    if effective_force == "cmux":
-        if not _cmux_available():
+    if effective_force == "c11":
+        if not _c11_available():
             raise BackendUnavailableError(
-                "LATTICE_SPAWN_BACKEND=cmux but cmux is not available "
-                "(no CMUX_SOCKET_PATH, missing cmux binary, or cmux identify failed)"
+                "LATTICE_SPAWN_BACKEND=c11 but c11 is not available "
+                "(no C11_SOCKET_PATH, missing c11 binary, or c11 identify failed)"
             )
-        from lattice.integrations.cmux import CmuxBackend
+        from lattice.integrations.c11 import C11Backend
 
         if on_progress:
-            on_progress("backend_selected", "cmux (forced)")
-        return CmuxBackend()
+            on_progress("backend_selected", "c11 (forced)")
+        return C11Backend()
 
     if effective_force == "terminal":
         if not _terminal_available():
@@ -187,13 +187,13 @@ def select_backend(
             on_progress("backend_selected", "terminal (forced)")
         return TerminalBackend()
 
-    # Auto-detect chain: cmux -> terminal -> headless.
-    if _cmux_available():
-        from lattice.integrations.cmux import CmuxBackend
+    # Auto-detect chain: c11 -> terminal -> headless.
+    if _c11_available():
+        from lattice.integrations.c11 import C11Backend
 
         if on_progress:
-            on_progress("backend_selected", "cmux (auto)")
-        return CmuxBackend()
+            on_progress("backend_selected", "c11 (auto)")
+        return C11Backend()
 
     if sys.stdout.isatty() and _terminal_available():
         from lattice.integrations.terminal import TerminalBackend
@@ -205,19 +205,24 @@ def select_backend(
     from lattice.storage.agent_spawn import HeadlessBackend
 
     if on_progress:
-        on_progress("backend_selected", "headless (auto, no cmux/terminal)")
+        on_progress("backend_selected", "headless (auto, no c11/terminal)")
     return HeadlessBackend()
 
 
-def _cmux_available() -> bool:
-    """Best-effort check that cmux is reachable in this environment."""
-    if not os.environ.get("CMUX_SOCKET_PATH"):
+def _c11_available() -> bool:
+    """Best-effort check that c11 is reachable in this environment.
+
+    Reads ``C11_SOCKET_PATH`` first, falling back to the legacy env var
+    set by the c11 binary for backward compatibility (see
+    ``lattice.cli.c11_bridge`` for the canonical compat-alias note).
+    """
+    if not (os.environ.get("C11_SOCKET_PATH") or os.environ.get("CMUX_SOCKET_PATH")):
         return False
-    if shutil.which("cmux") is None:
+    if shutil.which("c11") is None:
         return False
     try:
         result = subprocess.run(
-            ["cmux", "identify"],
+            ["c11", "identify"],
             capture_output=True,
             timeout=2,
         )
@@ -237,7 +242,7 @@ def _terminal_available() -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Polling helper used by detached backends (cmux / terminal)
+# Polling helper used by detached backends (c11 / terminal)
 # ---------------------------------------------------------------------------
 
 

--- a/src/lattice/core/agent_spawn.py
+++ b/src/lattice/core/agent_spawn.py
@@ -210,13 +210,8 @@ def select_backend(
 
 
 def _c11_available() -> bool:
-    """Best-effort check that c11 is reachable in this environment.
-
-    Reads ``C11_SOCKET_PATH`` first, falling back to the legacy env var
-    set by the c11 binary for backward compatibility (see
-    ``lattice.cli.c11_bridge`` for the canonical compat-alias note).
-    """
-    if not (os.environ.get("C11_SOCKET_PATH") or os.environ.get("CMUX_SOCKET_PATH")):
+    """Best-effort check that c11 is reachable in this environment."""
+    if not os.environ.get("C11_SOCKET_PATH"):
         return False
     if shutil.which("c11") is None:
         return False

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -617,17 +617,16 @@ def run_single_review(
     prompt_content: str,
     actor: str | dict,
     timeout: int = DEFAULT_AGENT_TIMEOUT,
-    *,
-    headless: bool = False,
-    backend_force: str | None = None,
 ) -> tuple[bool, str, str | None]:
     """Run a single-agent review via ``agent_spawn.spawn_one``.
 
-    Returns ``(success, message, output_text_or_None)`` — unchanged from the
-    pre-LAT-205 contract. ``headless`` / ``backend_force`` are pass-through
-    overrides for the new spawn primitive; defaults preserve today's auto
-    selection behavior.
+    Always headless: single-mode reviews never claim a c11 surface or a
+    terminal window. The agent runs in a ``subprocess.run`` and the CLI
+    blocks until it finishes. Returns ``(success, message,
+    output_text_or_None)``.
     """
+    from lattice.storage.agent_spawn import HeadlessBackend
+
     started_at = _now_iso()
     # Preserve fields written by an earlier ``claim_review_state`` call (e.g.
     # by the CLI body — see module docstring). If no record exists or the
@@ -664,8 +663,7 @@ def run_single_review(
         result = spawn_one(
             request,
             workspace_label=f"{review_type}-{task_id}",
-            force=backend_force,
-            headless=headless,
+            backend=HeadlessBackend(),
         )
 
         finished_at = _now_iso()
@@ -692,15 +690,10 @@ def run_triple_review(
     prompt_content: str,
     actor: str | dict,
     timeout: int = DEFAULT_AGENT_TIMEOUT,
-    *,
-    headless: bool = False,
-    backend_force: str | None = None,
 ) -> tuple[bool, str, list[tuple[str, bool, str]]]:
     """Run a triple-agent review (Claude, Codex, Gemini) in parallel via ``spawn_many``.
 
-    Returns ``(overall_success, message, [(agent_name, success, text), ...])``
-    — unchanged from the pre-LAT-205 contract. ``headless`` / ``backend_force``
-    are pass-through overrides for the new spawn primitive.
+    Returns ``(overall_success, message, [(agent_name, success, text), ...])``.
     """
     agents = ["claude", "codex", "gemini"]
     overall_started = _now_iso()
@@ -741,8 +734,6 @@ def run_triple_review(
         spawn_results = spawn_many(
             requests,
             workspace_label=f"{review_type}-{task_id}",
-            force=backend_force,
-            headless=headless,
         )
 
         # Preserve legacy result ordering (claude, codex, gemini).
@@ -819,14 +810,10 @@ def run_merge_agent(
     task_id: str,
     reviews: list[tuple[str, bool, str]],
     review_type: str,
-    *,
-    headless: bool = False,
-    backend_force: str | None = None,
 ) -> tuple[bool, str]:
     """Run the Claude Opus merge agent via ``agent_spawn.spawn_one``.
 
-    Returns ``(success, merged_text_or_error)`` — unchanged contract.
-    ``headless`` / ``backend_force`` pass through to the spawn primitive.
+    Returns ``(success, merged_text_or_error)``.
     """
     prompt = build_merge_prompt(task_id, reviews, review_type)
 
@@ -850,8 +837,6 @@ def run_merge_agent(
         result = spawn_one(
             request,
             workspace_label=f"merge-{task_id}",
-            force=backend_force,
-            headless=headless,
         )
         if result.success:
             return True, result.output_text

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -3,8 +3,15 @@
 The agent-spawning primitive lives in ``lattice.core.agent_spawn`` (with the
 ``HeadlessBackend`` in ``lattice.storage.agent_spawn`` and detached backends
 under ``lattice.integrations``). This module composes that primitive into
-the review-specific orchestration (single + triple + merge) and keeps the
-backward-compatible ``spawn_agent`` shim for any out-of-tree callers.
+the review-specific orchestration:
+
+- Single mode (``run_single_review``): one headless ``claude -p`` subprocess.
+- Triple mode (``run_triple_review``, LAT-218): one new c11 pane sibling to
+  the caller, running ``/trident-{code|plan}-review``. Fire-and-forget — the
+  pane owns trident, triage, and the task-status advance.
+
+The legacy ``spawn_agent`` shim is kept for any out-of-tree callers that
+still expect the pre-LAT-205 contract.
 """
 
 from __future__ import annotations
@@ -22,7 +29,6 @@ from typing import Any
 from lattice.core.agent_spawn import (
     SpawnRequest,
     SpawnResult,
-    spawn_many,
     spawn_one,
 )
 
@@ -683,166 +689,160 @@ def run_single_review(
         shutil.rmtree(tmp, ignore_errors=True)
 
 
+def build_trident_handoff_prompt(
+    task_short_id: str,
+    review_type: str,
+    *,
+    worktree: Path,
+    base_branch: str | None,
+) -> str:
+    """Build the prompt handed to the claude session running inside the c11 pane.
+
+    The pane's job: run ``/trident-{code|plan}-review``, read the resulting
+    artifact, triage findings, and advance the task. See the Review Verdict
+    Routing section in CLAUDE.md for the triage protocol.
+    """
+    review_short = "code" if review_type == "code-review" else "plan"
+    base_line = base_branch or "main"
+    return f"""# Triple {review_type} for {task_short_id}
+
+You're the agent running inside a c11 pane spawned by the LAT-218 review
+primitive. Your job: run the trident review, triage findings, advance the
+task. When you're done, exit cleanly.
+
+## Step 1 — Run trident
+
+Type at the claude prompt:
+
+    /trident-{review_short}-review {task_short_id}
+
+The trident skill will spawn several agents in parallel, merge their
+findings, and store an artifact attached to {task_short_id}. Wait for it
+to complete.
+
+## Step 2 — Read the result
+
+When trident reports done, find the merged artifact under
+`.lattice/artifacts/payload/<id>.md`. Read it — it gives a verdict (PASS,
+FAIL implementation-level, FAIL plan-level) and a list of findings.
+
+## Step 3 — Triage per Review Verdict Routing
+
+Per the Lattice skill section `## Review Verdict Routing`, every finding
+goes into one of three buckets:
+
+  - **Obvious** (missing AC, plan bugs, trivial fixes) → fix inline with
+    Edit/Write.
+  - **Evolutionary** (scope creep, "while we're at it") → skip with
+    `lattice comment {task_short_id} "Skipping [finding]: [reason]" \
+--actor agent:trident-pane-{task_short_id}`.
+  - **Complex** (real design questions) → move task to `needs_human` with
+    a comment.
+
+## Step 4 — Advance task
+
+| Outcome                            | Move task to                          |
+| ---------------------------------- | ------------------------------------- |
+| PASS, fixes done, PR exists        | pr_open                               |
+| PASS, no PR yet                    | open PR (`gh pr create`), then pr_open|
+| FAIL impl-level                    | in_progress (rework, then re-review)  |
+| FAIL plan-level                    | in_planning                           |
+| Complex finding(s)                 | needs_human                           |
+| 3-cycle safety valve tripped       | needs_human                           |
+
+Use `lattice status {task_short_id} <new_status> --actor agent:trident-pane-{task_short_id}`.
+
+## Identity
+
+- Actor: `agent:trident-pane-{task_short_id}`
+- Cwd: `{worktree}` (you share the delegator's worktree)
+- Base branch: `{base_line}`
+
+When you've advanced the task to its terminal state for this cycle, exit cleanly.
+"""
+
+
 def run_triple_review(
     lattice_dir: Path,
     task_id: str,
     review_type: str,
-    prompt_content: str,
     actor: str | dict,
-    timeout: int = DEFAULT_AGENT_TIMEOUT,
-) -> tuple[bool, str, list[tuple[str, bool, str]]]:
-    """Run a triple-agent review (Claude, Codex, Gemini) in parallel via ``spawn_many``.
+    *,
+    base: str | None = None,
+    short_id: str | None = None,
+    worktree: Path | None = None,
+) -> tuple[bool, str]:
+    """Spawn a c11 pane that runs /trident-{type}-review and applies fixes inline.
 
-    Returns ``(overall_success, message, [(agent_name, success, text), ...])``.
+    Fire-and-forget. The spawned pane owns the trident run, the artifact
+    storage, finding triage, and the task-status advance — this function
+    returns as soon as the pane is up.
+
+    Returns ``(True, message)`` after the pane has been spawned, or
+    ``(False, error_message)`` if anything prevented the spawn (most
+    commonly: not running inside c11).
     """
-    agents = ["claude", "codex", "gemini"]
-    overall_started = _now_iso()
+    from lattice.cli.c11_bridge import c11_available
+    from lattice.integrations.c11 import spawn_one_in_current_workspace
+
+    if not c11_available():
+        return (
+            False,
+            "triple mode requires c11 — run from inside a c11 surface, or use --mode single.",
+        )
+
+    display_id = short_id or task_id
+    wt = worktree if worktree is not None else lattice_dir.parent
+
+    prompt_text = build_trident_handoff_prompt(
+        display_id,
+        review_type,
+        worktree=wt,
+        base_branch=base,
+    )
+    tab_title = f"{display_id} :: trident {review_type}"
+    description = (
+        f"Trident {review_type} for {display_id}. The pane drives /trident-"
+        f"{'code' if review_type == 'code-review' else 'plan'}-review, triages findings, "
+        f"and advances task status. Sibling pane spawned by Lattice (LAT-218)."
+    )
+
+    ok, ref = spawn_one_in_current_workspace(
+        prompt_text,
+        tab_title=tab_title,
+        description=description,
+        cwd=wt,
+    )
+    if not ok:
+        return False, f"failed to spawn c11 pane: {ref}"
+
+    started_at = _now_iso()
     existing = read_review_state(lattice_dir, task_id) or {}
     state: dict[str, Any] = {
         "task_id": task_id,
-        "mode": "triple",
+        "mode": "triple_pane",
         "review_type": review_type,
-        "started_at": overall_started,
+        "started_at": started_at,
         "started_by_pid": existing.get("started_by_pid", os.getpid()),
         "auto_fired": existing.get("auto_fired", False),
+        "pane_ref": ref,
         "agents": [
-            {"name": a, "status": "running", "started_at": overall_started, "artifact_id": None}
-            for a in agents
+            {
+                "name": "trident-pane",
+                "status": "running",
+                "started_at": started_at,
+                "pane_ref": ref,
+            }
         ],
     }
     write_review_state(lattice_dir, state)
 
-    tmp = _make_prompt_dir(lattice_dir, prefix=f"{review_type}-")
-    try:
-        requests: list[SpawnRequest] = []
-        for agent in agents:
-            agent_dir = tmp / agent
-            agent_dir.mkdir()
-            prompt_file = agent_dir / "prompt.md"
-            output_file = agent_dir / "output.md"
-            prompt_file.write_text(prompt_content, encoding="utf-8")
-            requests.append(
-                SpawnRequest(
-                    agent=agent,
-                    prompt_file=prompt_file,
-                    output_file=output_file,
-                    label=f"{review_type} :: {agent}",
-                    timeout_seconds=timeout,
-                )
-            )
+    _ = _extract_actor_str(actor)  # touch for symmetry with single-mode
 
-        spawn_results = spawn_many(
-            requests,
-            workspace_label=f"{review_type}-{task_id}",
-        )
-
-        # Preserve legacy result ordering (claude, codex, gemini).
-        by_agent = {r.agent: r for r in spawn_results}
-        results: list[tuple[str, bool, str]] = []
-        finished_at = _now_iso()
-        for idx, agent in enumerate(agents):
-            r = by_agent.get(agent)
-            if r is None:
-                results.append((agent, False, "no result returned"))
-                state["agents"][idx]["status"] = "failed"
-            elif r.success:
-                results.append((agent, True, r.output_text))
-                state["agents"][idx]["status"] = "done"
-            else:
-                results.append((agent, False, r.error))
-                state["agents"][idx]["status"] = "failed"
-            state["agents"][idx]["finished_at"] = finished_at
-        write_review_state(lattice_dir, state)
-
-        actor_str = _extract_actor_str(actor)
-        for agent, success, _text in results:
-            if not success:
-                _handle_agent_failure(lattice_dir, agent, task_id, actor_str)
-
-        any_success = any(r[1] for r in results)
-        clear_review_state(lattice_dir, task_id)
-        return any_success, "Triple review complete.", results
-    finally:
-        shutil.rmtree(tmp, ignore_errors=True)
-
-
-def build_merge_prompt(
-    task_id: str,
-    reviews: list[tuple[str, bool, str]],
-    review_type: str,
-) -> str:
-    """Build the merge prompt for the Opus consolidation agent."""
-    sections = []
-    for agent, success, text in reviews:
-        if success:
-            sections.append(f"## Review from {agent}\n\n{text}")
-        else:
-            sections.append(f"## Review from {agent}\n\n*(failed or timed out)*")
-
-    reviews_text = "\n\n---\n\n".join(sections)
-
-    return f"""# Merge Review: {task_id}
-
-You are consolidating three independent code reviews into one authoritative summary.
-Your job is to synthesize the findings, surface the most important issues, and produce
-a clear verdict. Do not simply concatenate — identify patterns, prioritize by severity,
-and resolve any contradictions between reviewers.
-
-## Individual Reviews
-
-{reviews_text}
-
-## Output Format
-
-Produce a merged review with these sections:
-1. **Verdict**: PASS / FAIL (implementation-level) / FAIL (plan-level)
-2. **Synthesis**: 3-5 sentences covering overall quality, patterns across reviews, key findings
-3. **Issues**: Consolidated list ordered by severity. For issues found by multiple reviewers, merge them.
-4. **Positive Observations**: What all or most reviewers praised.
-5. **Reviewer Agreement**: Brief note on where reviewers agreed and disagreed.
-
-Write the merged review to: {{output_path}}
-"""
-
-
-def run_merge_agent(
-    lattice_dir: Path,
-    task_id: str,
-    reviews: list[tuple[str, bool, str]],
-    review_type: str,
-) -> tuple[bool, str]:
-    """Run the Claude Opus merge agent via ``agent_spawn.spawn_one``.
-
-    Returns ``(success, merged_text_or_error)``.
-    """
-    prompt = build_merge_prompt(task_id, reviews, review_type)
-
-    tmp = _make_prompt_dir(lattice_dir, prefix="merge-")
-    try:
-        agent_dir = tmp / "merge"
-        agent_dir.mkdir()
-        prompt_file = agent_dir / "prompt.md"
-        output_file = agent_dir / "output.md"
-
-        filled = prompt.replace("{output_path}", str(output_file))
-        prompt_file.write_text(filled, encoding="utf-8")
-
-        request = SpawnRequest(
-            agent="claude",
-            prompt_file=prompt_file,
-            output_file=output_file,
-            label=f"{review_type} :: merge",
-            timeout_seconds=DEFAULT_AGENT_TIMEOUT,
-        )
-        result = spawn_one(
-            request,
-            workspace_label=f"merge-{task_id}",
-        )
-        if result.success:
-            return True, result.output_text
-        return False, _format_legacy_error("claude", result, DEFAULT_AGENT_TIMEOUT)
-    finally:
-        shutil.rmtree(tmp, ignore_errors=True)
+    return (
+        True,
+        f"Triple review running in {ref} — task status is the sync primitive.",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -161,7 +161,7 @@ def clear_review_state(lattice_dir: Path, task_id: str) -> None:
     path.unlink(missing_ok=True)
 
 
-def _pid_alive(pid: int) -> bool:
+def pid_alive(pid: int) -> bool:
     """Return True if ``pid`` refers to a live process on this machine.
 
     Uses ``os.kill(pid, 0)`` (signal 0) which performs the kernel's existence
@@ -211,7 +211,7 @@ def claim_review_state(
     existing = read_review_state(lattice_dir, task_id)
     if existing is not None:
         holder = existing.get("started_by_pid")
-        if isinstance(holder, int) and holder != started_by_pid and _pid_alive(holder):
+        if isinstance(holder, int) and holder != started_by_pid and pid_alive(holder):
             return False, existing
         # Otherwise: stale (no PID field, dead PID, or our own PID) — reclaim.
 
@@ -820,10 +820,11 @@ def run_triple_review(
     existing = read_review_state(lattice_dir, task_id) or {}
     state: dict[str, Any] = {
         "task_id": task_id,
-        "mode": "triple_pane",
+        "mode": "triple",
         "review_type": review_type,
         "started_at": started_at,
         "started_by_pid": existing.get("started_by_pid", os.getpid()),
+        "started_by_actor": _extract_actor_str(actor),
         "auto_fired": existing.get("auto_fired", False),
         "pane_ref": ref,
         "agents": [
@@ -836,8 +837,6 @@ def run_triple_review(
         ],
     }
     write_review_state(lattice_dir, state)
-
-    _ = _extract_actor_str(actor)  # touch for symmetry with single-mode
 
     return (
         True,

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -571,7 +571,7 @@ def spawn_agent(
     ``lattice.core.agent_spawn.spawn_one`` directly.
 
     Always uses the headless backend so existing call sites (which build
-    their own per-agent scratch dirs and don't expect a cmux/terminal pane)
+    their own per-agent scratch dirs and don't expect a c11/terminal pane)
     behave identically to the legacy implementation.
     """
     from lattice.storage.agent_spawn import HeadlessBackend

--- a/src/lattice/core/tasks.py
+++ b/src/lattice/core/tasks.py
@@ -392,18 +392,18 @@ def _mut_comment_deleted(snap: dict, event: dict) -> None:
 @_register_mutation("surface_bound")
 def _mut_surface_bound(snap: dict, event: dict) -> None:
     data = event["data"]
-    snap["cmux_surface"] = data.get("surface")
+    snap["c11_surface"] = data.get("surface")
     workspace = data.get("workspace")
     if workspace is not None:
-        snap["cmux_workspace"] = workspace
+        snap["c11_workspace"] = workspace
     else:
-        snap.setdefault("cmux_workspace", None)
+        snap.setdefault("c11_workspace", None)
 
 
 @_register_mutation("surface_unbound")
 def _mut_surface_unbound(snap: dict, event: dict) -> None:
-    snap["cmux_surface"] = None
-    snap["cmux_workspace"] = None
+    snap["c11_surface"] = None
+    snap["c11_workspace"] = None
 
 
 def get_artifact_roles(snapshot: dict) -> dict[str, str | None]:

--- a/src/lattice/integrations/__init__.py
+++ b/src/lattice/integrations/__init__.py
@@ -5,10 +5,10 @@ that drives an agent runner via something other than ``subprocess.run``:
 
 - ``terminal`` opens macOS Terminal.app / iTerm2 windows or
   ``gnome-terminal`` / ``xterm`` on Linux.
-- ``cmux`` opens a dedicated workspace and 2x2 pane grid inside the c11mux
+- ``c11`` opens a dedicated workspace and 2x2 pane grid inside the c11
   multiplexer.
 
 Backends are loaded lazily by ``lattice.core.agent_spawn.select_backend``
-so that the absence of cmux or a usable terminal launcher never breaks
+so that the absence of c11 or a usable terminal launcher never breaks
 import time.
 """

--- a/src/lattice/integrations/c11.py
+++ b/src/lattice/integrations/c11.py
@@ -201,8 +201,8 @@ def spawn_one_in_current_workspace(
 
     Sequence:
 
-    1. Resolve current workspace from ``C11_WORKSPACE_ID`` (fallback
-       ``CMUX_WORKSPACE_ID``). If unset → return failure with a clear message.
+    1. Resolve current workspace from ``C11_WORKSPACE_ID``. If unset →
+       return failure with a clear message.
     2. ``c11 new-pane --workspace <ws> --direction right --title <tab_title>``
        → parse the new surface ref out of the response.
     3. ``c11 set-description`` to ``description``.
@@ -212,9 +212,9 @@ def spawn_one_in_current_workspace(
        instructions."``) followed by ``c11 send-key enter`` to submit it.
     6. Return ``(True, surface_ref)``.
     """
-    ws_ref = os.environ.get("C11_WORKSPACE_ID") or os.environ.get("CMUX_WORKSPACE_ID")
+    ws_ref = os.environ.get("C11_WORKSPACE_ID")
     if not ws_ref:
-        return False, "not inside c11 — set C11_WORKSPACE_ID or run from a c11 surface"
+        return False, "not inside c11 — run from a c11 surface (C11_WORKSPACE_ID unset)"
 
     pane = _new_pane(ws_ref, direction="right", title=tab_title)
     if pane is None:

--- a/src/lattice/integrations/c11.py
+++ b/src/lattice/integrations/c11.py
@@ -1,8 +1,8 @@
-"""cmux backend: spawn agents in a dedicated c11mux workspace.
+"""c11 backend: spawn agents in a dedicated c11 workspace.
 
 For each ``spawn_many`` call this backend:
 
-1. Creates a new workspace via ``cmux new-workspace`` and renames it to
+1. Creates a new workspace via ``c11 new-workspace`` and renames it to
    the workspace label (typically ``review:<short-id>``).
 2. Builds a 2x2 pane grid: top-left = first agent (default ``claude``),
    top-right = second (``codex``), bottom-left = third (``gemini``),
@@ -10,15 +10,16 @@ For each ``spawn_many`` call this backend:
    has three entries — the orchestrator drives the merge fan-in via the
    wrapper, not this backend).
 3. Renames each pane's tab to ``<workspace_label> :: <agent>`` per the
-   c11mux skill's lineage convention, sets a one-line description, and
+   c11 skill's lineage convention, sets a one-line description, and
    seeds surface metadata (``role``, ``task``, ``status``).
-4. Sends an ``agent_runner`` invocation to each pane via ``cmux send`` +
-   ``cmux send-key enter``.
+4. Sends an ``agent_runner`` invocation to each pane via ``c11 send`` +
+   ``c11 send-key enter``.
 5. Polls per-agent ``.done`` sentinel files to learn when each finishes —
    identical contract to the terminal/headless backends.
 
-Filename ``cmux.py`` matches the binary the module wraps; the product is
-``c11mux``.
+This module only ever invokes the ``c11`` binary; see
+``lattice.cli.c11_bridge`` for the canonical note on the OS-layer compat
+alias still set by the c11 binary for backward compatibility.
 """
 
 from __future__ import annotations
@@ -32,7 +33,7 @@ import time
 from collections.abc import Sequence
 from pathlib import Path
 
-from lattice.cli.cmux_bridge import _run_cmux as _bridge_run_cmux
+from lattice.cli.c11_bridge import _run_c11 as _bridge_run_c11
 from lattice.core.agent_spawn import (
     Backend,
     BackendUnavailableError,
@@ -48,10 +49,10 @@ logger = logging.getLogger(__name__)
 _REF_RE = re.compile(r"\b(workspace|pane|surface):(\d+)\b")
 
 
-class CmuxBackend(Backend):
-    """Spawn agents in a dedicated c11mux workspace + 2x2 pane grid."""
+class C11Backend(Backend):
+    """Spawn agents in a dedicated c11 workspace + 2x2 pane grid."""
 
-    name = "cmux"
+    name = "c11"
 
     def run(
         self,
@@ -66,7 +67,7 @@ class CmuxBackend(Backend):
         # 1. Create workspace.
         ws_ref = _new_workspace()
         if ws_ref is None:
-            raise BackendUnavailableError("cmux new-workspace failed")
+            raise BackendUnavailableError("c11 new-workspace failed")
         if on_progress:
             on_progress("workspace_created", f"{workspace_label} -> {ws_ref}")
 
@@ -81,7 +82,7 @@ class CmuxBackend(Backend):
             # caller's responsibility (BackendUnavailableError lets the
             # selector route to a different backend).
             raise BackendUnavailableError(
-                f"cmux backend created {len(slots)} panes but {len(requests)} requested"
+                f"c11 backend created {len(slots)} panes but {len(requests)} requested"
             )
 
         # 3. Wire each request to a slot, decorate the pane, send the runner.
@@ -135,7 +136,7 @@ def _build_pane_grid(ws_ref: str, *, slot_count: int) -> list[_Slot]:
     initial_surface = _initial_surface(ws_ref)
     if initial_surface is None:
         raise BackendUnavailableError(
-            "cmux backend: could not resolve initial pane/surface for new workspace"
+            "c11 backend: could not resolve initial pane/surface for new workspace"
         )
     slots.append(_Slot(pane_ref=None, surface_ref=initial_surface))
     if slot_count <= 1:
@@ -175,27 +176,27 @@ def _build_pane_grid(ws_ref: str, *, slot_count: int) -> list[_Slot]:
 
 
 # ---------------------------------------------------------------------------
-# cmux CLI helpers (parse refs out of `OK ...` output)
+# c11 CLI helpers (parse refs out of `OK ...` output)
 # ---------------------------------------------------------------------------
 
 
-def _cmux_capture(*args: str) -> str | None:
-    """Run cmux with ``args`` and return stdout text on success, else None."""
+def _c11_capture(*args: str) -> str | None:
+    """Run c11 with ``args`` and return stdout text on success, else None."""
     import subprocess
 
     try:
         result = subprocess.run(
-            ["cmux", *args],
+            ["c11", *args],
             capture_output=True,
             timeout=10,
             text=True,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
-        logger.warning("cmux capture failed: %s", exc)
+        logger.warning("c11 capture failed: %s", exc)
         return None
     if result.returncode != 0:
         logger.warning(
-            "cmux %s failed (exit %d): %s",
+            "c11 %s failed (exit %d): %s",
             " ".join(args),
             result.returncode,
             result.stderr.strip(),
@@ -205,7 +206,7 @@ def _cmux_capture(*args: str) -> str | None:
 
 
 def _parse_refs(text: str) -> dict[str, str]:
-    """Pull ``workspace:N`` / ``pane:N`` / ``surface:N`` refs from cmux output."""
+    """Pull ``workspace:N`` / ``pane:N`` / ``surface:N`` refs from c11 output."""
     refs: dict[str, str] = {}
     for kind, num in _REF_RE.findall(text or ""):
         refs.setdefault(kind, f"{kind}:{num}")
@@ -213,19 +214,19 @@ def _parse_refs(text: str) -> dict[str, str]:
 
 
 def _new_workspace() -> str | None:
-    out = _cmux_capture("new-workspace")
+    out = _c11_capture("new-workspace")
     if not out:
         return None
     return _parse_refs(out).get("workspace")
 
 
 def _rename_workspace(ws_ref: str, title: str) -> None:
-    _bridge_run_cmux("rename-workspace", "--workspace", ws_ref, title)
+    _bridge_run_c11("rename-workspace", "--workspace", ws_ref, title)
 
 
 def _set_workspace_metadata(ws_ref: str, label: str) -> None:
     """Best-effort workspace-level metadata."""
-    _bridge_run_cmux(
+    _bridge_run_c11(
         "set-workspace-metadata",
         "--workspace",
         ws_ref,
@@ -239,32 +240,32 @@ def _set_workspace_metadata(ws_ref: str, label: str) -> None:
 def _initial_surface(ws_ref: str) -> str | None:
     """Pull the surface ref of the workspace's initial (only) pane.
 
-    Primary path uses ``cmux list-pane-surfaces --workspace <ref>`` — the
-    dedicated command for enumerating surfaces. Verified against the c11mux
-    build shipping on 2026-04-19 (``cmux --help`` lists the command; manual
+    Primary path uses ``c11 list-pane-surfaces --workspace <ref>`` — the
+    dedicated command for enumerating surfaces. Verified against the c11
+    build shipping on 2026-04-19 (``c11 --help`` lists the command; manual
     validation during LAT-205 impl-cycle-1 confirmed it on workspace:14).
 
     If the primary command returns nothing (older builds or future CLI
-    churn), fall back to ``cmux tree --workspace <ref>``, whose text output
+    churn), fall back to ``c11 tree --workspace <ref>``, whose text output
     includes ``surface:<N>`` refs that the shared ``_parse_refs`` helper
     already pulls. The regex grabs the first surface it sees — fresh
     workspaces have exactly one pane with one surface, so this is
     deterministic for our use case.
     """
-    out = _cmux_capture("list-pane-surfaces", "--workspace", ws_ref)
+    out = _c11_capture("list-pane-surfaces", "--workspace", ws_ref)
     if out:
         surface = _parse_refs(out).get("surface")
         if surface:
             return surface
     # Fallback: tree output also contains surface refs.
-    tree_out = _cmux_capture("tree", "--workspace", ws_ref)
+    tree_out = _c11_capture("tree", "--workspace", ws_ref)
     if not tree_out:
         return None
     return _parse_refs(tree_out).get("surface")
 
 
 def _new_pane(ws_ref: str, *, direction: str) -> _Slot | None:
-    out = _cmux_capture(
+    out = _c11_capture(
         "new-pane",
         "--workspace",
         ws_ref,
@@ -281,24 +282,24 @@ def _new_pane(ws_ref: str, *, direction: str) -> _Slot | None:
 
 
 def _focus_pane(ws_ref: str, pane_ref: str) -> None:
-    _bridge_run_cmux("focus-pane", "--workspace", ws_ref, "--pane", pane_ref)
+    _bridge_run_c11("focus-pane", "--workspace", ws_ref, "--pane", pane_ref)
 
 
 def _focus_by_surface(ws_ref: str, surface_ref: str) -> None:
     """Best-effort surface focus — used when we never got a pane ref.
 
-    The cmux ``tab-action`` binary doesn't expose a ``focus`` action, so the
+    The c11 ``tab-action`` binary doesn't expose a ``focus`` action, so the
     fallback is the surface-focus subset that exists today: ``focus-pane`` is
     pane-scoped, but ``send-key`` against a surface raises focus side-effects
     in practice. If the caller has the pane ref, ``_focus_pane`` is preferred.
     """
-    # No safe surface-only focus command in current cmux CLI; the resolved
-    # cmux backend always passes pane refs, so this is a no-op fallback.
+    # No safe surface-only focus command in current c11 CLI; the resolved
+    # c11 backend always passes pane refs, so this is a no-op fallback.
     return
 
 
 def _rename_tab(ws_ref: str, surface_ref: str, title: str) -> None:
-    _bridge_run_cmux(
+    _bridge_run_c11(
         "rename-tab",
         "--workspace",
         ws_ref,
@@ -309,9 +310,9 @@ def _rename_tab(ws_ref: str, surface_ref: str, title: str) -> None:
 
 
 def _set_description(ws_ref: str, surface_ref: str, text: str) -> None:
-    # cmux only accepts --source values explicit|declare|osc|heuristic;
+    # c11 only accepts --source values explicit|declare|osc|heuristic;
     # `explicit` is the right choice for an external CLI driver.
-    _bridge_run_cmux(
+    _bridge_run_c11(
         "set-description",
         "--workspace",
         ws_ref,
@@ -335,7 +336,7 @@ def _set_metadata(
     import json as _json
 
     payload = _json.dumps({"role": role, "task": task, "status": status})
-    _bridge_run_cmux(
+    _bridge_run_c11(
         "set-metadata",
         "--workspace",
         ws_ref,
@@ -366,7 +367,7 @@ def _send_runner(
     cd = f"cd {shlex.quote(str(repo_root))}"
     line = f"{cd} && env {env_str} {python} -m lattice.agent_runner --mode agent"
 
-    _bridge_run_cmux(
+    _bridge_run_c11(
         "send",
         "--workspace",
         ws_ref,
@@ -374,8 +375,8 @@ def _send_runner(
         surface_ref,
         line,
     )
-    # Two-call send: cmux send adds the text, send-key enter submits it.
-    _bridge_run_cmux(
+    # Two-call send: c11 send adds the text, send-key enter submits it.
+    _bridge_run_c11(
         "send-key",
         "--workspace",
         ws_ref,

--- a/src/lattice/integrations/c11.py
+++ b/src/lattice/integrations/c11.py
@@ -30,7 +30,7 @@ import re
 import shlex
 import sys
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from lattice.cli.c11_bridge import _run_c11 as _bridge_run_c11
@@ -176,6 +176,88 @@ def _build_pane_grid(ws_ref: str, *, slot_count: int) -> list[_Slot]:
 
 
 # ---------------------------------------------------------------------------
+# Single-pane primitive (used by triple-mode reviews — LAT-218)
+# ---------------------------------------------------------------------------
+
+
+def spawn_one_in_current_workspace(
+    prompt_text: str,
+    *,
+    tab_title: str,
+    description: str,
+    cwd: Path,
+    on_progress: Callable[[str, str], None] | None = None,
+) -> tuple[bool, str]:
+    """Split a new pane in the caller's c11 workspace and start an interactive claude.
+
+    Distinct from :class:`C11Backend` (which creates its own workspace + grid).
+    This primitive stays *inside* the caller's workspace: the new pane is a
+    sibling of whichever surface invoked Lattice, so the user sees the work
+    appear right next to them.
+
+    Returns ``(True, surface_ref)`` on success, ``(False, error_message)`` on
+    failure. The returned ``surface_ref`` is the ``surface:N`` the caller can
+    surface in a "running in pane:N" message.
+
+    Sequence:
+
+    1. Resolve current workspace from ``C11_WORKSPACE_ID`` (fallback
+       ``CMUX_WORKSPACE_ID``). If unset → return failure with a clear message.
+    2. ``c11 new-pane --workspace <ws> --direction right --title <tab_title>``
+       → parse the new surface ref out of the response.
+    3. ``c11 set-description`` to ``description``.
+    4. Write the prompt to a scratch file under ``<cwd>/.lattice/tmp-prompts/``.
+    5. ``c11 send`` the bootstrap command (``cd <cwd> && claude
+       --dangerously-skip-permissions "Read /path/to/prompt.md and follow the
+       instructions."``) followed by ``c11 send-key enter`` to submit it.
+    6. Return ``(True, surface_ref)``.
+    """
+    ws_ref = os.environ.get("C11_WORKSPACE_ID") or os.environ.get("CMUX_WORKSPACE_ID")
+    if not ws_ref:
+        return False, "not inside c11 — set C11_WORKSPACE_ID or run from a c11 surface"
+
+    pane = _new_pane(ws_ref, direction="right", title=tab_title)
+    if pane is None:
+        return False, "c11 new-pane failed — check `c11 new-pane --help` and the c11 daemon"
+    surface_ref = pane.surface_ref
+    if on_progress:
+        on_progress("pane_created", surface_ref)
+
+    _set_description(ws_ref, surface_ref, description)
+
+    prompt_dir = cwd / ".lattice" / "tmp-prompts" / f"trident-{surface_ref.replace(':', '-')}"
+    prompt_dir.mkdir(parents=True, exist_ok=True)
+    prompt_path = prompt_dir / "prompt.md"
+    prompt_path.write_text(prompt_text, encoding="utf-8")
+
+    cd_cmd = f"cd {shlex.quote(str(cwd))}"
+    instruction = f"Read {shlex.quote(str(prompt_path))} and follow the instructions."
+    claude_cmd = f'claude --dangerously-skip-permissions "{instruction}"'
+    line = f"{cd_cmd} && {claude_cmd}"
+
+    _bridge_run_c11(
+        "send",
+        "--workspace",
+        ws_ref,
+        "--surface",
+        surface_ref,
+        line,
+    )
+    _bridge_run_c11(
+        "send-key",
+        "--workspace",
+        ws_ref,
+        "--surface",
+        surface_ref,
+        "enter",
+    )
+    if on_progress:
+        on_progress("agent_started", surface_ref)
+
+    return True, surface_ref
+
+
+# ---------------------------------------------------------------------------
 # c11 CLI helpers (parse refs out of `OK ...` output)
 # ---------------------------------------------------------------------------
 
@@ -264,14 +346,11 @@ def _initial_surface(ws_ref: str) -> str | None:
     return _parse_refs(tree_out).get("surface")
 
 
-def _new_pane(ws_ref: str, *, direction: str) -> _Slot | None:
-    out = _c11_capture(
-        "new-pane",
-        "--workspace",
-        ws_ref,
-        "--direction",
-        direction,
-    )
+def _new_pane(ws_ref: str, *, direction: str, title: str | None = None) -> _Slot | None:
+    args = ["new-pane", "--workspace", ws_ref, "--direction", direction]
+    if title is not None:
+        args.extend(["--title", title])
+    out = _c11_capture(*args)
     if not out:
         return None
     refs = _parse_refs(out)

--- a/src/lattice/integrations/terminal.py
+++ b/src/lattice/integrations/terminal.py
@@ -2,7 +2,7 @@
 
 Each agent runs in its own Terminal window (macOS) or terminal emulator
 window (Linux). The orchestrator polls per-agent ``.done`` sentinel files
-to learn when each one has finished — same contract as the cmux backend.
+to learn when each one has finished — same contract as the c11 backend.
 
 This backend is opt-in via ``select_backend`` auto-detection or
 ``LATTICE_SPAWN_BACKEND=terminal``. Driving Terminal.app via osascript

--- a/src/lattice/templates/claude_md_block.py
+++ b/src/lattice/templates/claude_md_block.py
@@ -99,8 +99,8 @@ The mode controls *how* the review runs:
 
 | `plan_review_mode` value | What the planner does |
 |--------------------------|----------------------|
-| `single` (default) | Spawns one review agent |
-| `triple` | **Trident plan review** — spawns three agents (claude, codex, gemini) in parallel, merges their findings into one artifact |
+| `single` (default) | One headless `claude -p` subprocess runs the plan review. No c11 surface. |
+| `triple` | Splits one new pane in the caller's c11 workspace and runs `/trident-plan-review` there. The pane owns trident and the task advance. CLI returns immediately. Requires c11. |
 | `inline` | Reviews the plan in-session (use when codex/gemini aren't available, or for small/throwaway projects). Auto-fire is a no-op for inline. |
 
 When `plan_approval` is `human`, the CLI automatically moves the task to `needs_human` after `lattice plan-review` completes. Wait for human approval before proceeding to `in_progress`.
@@ -136,8 +136,8 @@ cat .lattice/config.json | python3 -c "import sys,json; d=json.load(sys.stdin); 
 | `review_mode` value | What the reviewer does |
 |---------------------|----------------------|
 | `inline` | Review the diff yourself in-session. Run `lattice code-review <task> --mode inline` to acknowledge. (Auto-fire is a no-op for inline.) |
-| `single` (default) | Auto-fire on `→ review` spawns one review agent + stores artifact. Manual fallback: `lattice code-review <task>`. |
-| `triple` | Auto-fire spawns three agents + merge, stores artifacts. Manual fallback: `lattice code-review <task>`. |
+| `single` (default) | One headless `claude -p` subprocess runs the review and stores the artifact. No c11 surface, no terminal window. Manual fallback: `lattice code-review <task>`. |
+| `triple` | Splits one new pane in the caller's c11 workspace and runs `/trident-code-review` there. The pane owns trident, finding triage, and the task-status advance. CLI returns immediately. Requires c11 — outside c11, the command exits non-zero with a clear error. Manual fallback: `lattice code-review <task> --mode triple`. |
 
 **Step 2: Perform the review.** The review sub-agent should:
 1. Read the plan file to understand what was supposed to be built.
@@ -208,8 +208,8 @@ Five settings in `.lattice/config.json` control review behavior:
 | `auto_plan_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice plan-review` when a task transitions to `planned` |
 
 **`inline`** — review happens in the same agent session (no subprocess spawned).
-**`single`** — one review agent is spawned; result stored as a `review` or `plan-review` artifact.
-**`triple`** — three agents (claude, codex, gemini) run in parallel; individual results stored as `review-individual` artifacts; a merged result stored as `review` or `plan-review`.
+**`single`** — one headless review agent is spawned; result stored as a `review` or `plan-review` artifact. No c11 surface.
+**`triple`** — one new c11 pane sibling to the caller is spawned; the pane runs `/trident-{code|plan}-review`, which fans out to multiple agents, merges findings, stores the artifact, and advances the task. Requires c11 (the command errors cleanly otherwise).
 
 ### Auto-fire Conventions
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -108,7 +108,7 @@ def test_stdout_streams_to_pane(tmp_path: Path) -> None:
 
     Pre-fix, ``_run_agent_mode`` used ``subprocess.run(..., capture_output=True)``
     which buffered the entire subprocess output until exit, then wrote it
-    AFTER the ``[agent_runner] finished`` marker. That silenced the cmux /
+    AFTER the ``[agent_runner] finished`` marker. That silenced the c11 /
     terminal pane for the whole run — the visibility win that motivated
     LAT-205 was nullified.
 

--- a/tests/test_cli/test_review_cmds.py
+++ b/tests/test_cli/test_review_cmds.py
@@ -461,6 +461,11 @@ class TestCodeReviewTriple:
             )
         assert result.exit_code != 0
         assert "triple mode requires c11" in result.output
+        # Failed spawn must release the in-flight claim so retries aren't
+        # blocked by a phantom review_state record.
+        from lattice.core.review import read_review_state
+
+        assert read_review_state(root / LATTICE_DIR, task_id) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli/test_review_cmds.py
+++ b/tests/test_cli/test_review_cmds.py
@@ -396,64 +396,61 @@ class TestPlanReviewSingle:
 
 
 class TestCodeReviewTriple:
-    def test_triple_mode_stores_individual_and_merged(self, tmp_path):
+    def test_triple_mode_spawns_c11_pane_and_returns(self, tmp_path):
+        """Triple mode is fire-and-forget: ``run_triple_review`` is called once,
+        no artifacts are stored by the CLI (the pane owns them), and the CLI
+        exits 0 with a "running in pane:N" message."""
         root = _make_board(tmp_path, {"review_mode": "triple"})
         runner = CliRunner()
         task_id = _create_task(runner, root)
 
         fake_diff = "diff --git a/foo.py b/foo.py\n+print('hello')"
-        fake_reviews = [
-            ("claude", True, "PASS claude"),
-            ("codex", True, "PASS codex"),
-            ("gemini", False, "timeout"),
-        ]
-        fake_merged = "MERGED PASS"
 
         with (
             patch("lattice.cli.review_cmds.resolve_diff", return_value=(True, fake_diff)),
             patch(
                 "lattice.cli.review_cmds.run_triple_review",
-                return_value=(True, "done", fake_reviews),
-            ),
-            patch(
-                "lattice.cli.review_cmds.run_merge_agent",
-                return_value=(True, fake_merged),
-            ),
-            patch(
-                "lattice.cli.review_cmds._attach_review_artifact",
-                return_value="art_fake",
-            ) as mock_attach,
+                return_value=(
+                    True,
+                    "Triple review running in surface:99 — task status is the sync primitive.",
+                ),
+            ) as mock_run,
+            patch("lattice.cli.review_cmds._attach_review_artifact") as mock_attach,
         ):
-            runner.invoke(
+            result = runner.invoke(
                 cli,
                 ["code-review", task_id, "--mode", "triple", "--actor", "agent:test"],
                 env={"LATTICE_ROOT": str(root)},
                 catch_exceptions=False,
             )
 
-        # Two successful individual reviews + 1 merged
-        assert mock_attach.call_count == 3
-        roles_used = [call.kwargs.get("role") for call in mock_attach.call_args_list]
-        assert roles_used.count("review-individual") == 2
-        assert roles_used.count("review") == 1
+        assert result.exit_code == 0, result.output
+        assert "running in surface:99" in result.output
+        # CLI no longer stores artifacts in triple mode — the pane does.
+        assert mock_attach.call_count == 0
+        # run_triple_review is the fire-and-forget primitive.
+        assert mock_run.call_count == 1
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["review_type"] == "code-review"
+        assert kwargs["task_id"] == task_id
 
-    def test_triple_mode_all_fail_reports_error(self, tmp_path):
+    def test_triple_mode_outside_c11_errors(self, tmp_path):
+        """Triple mode outside c11 must fail cleanly with a non-zero exit and
+        release the in-flight claim so retries aren't blocked."""
         root = _make_board(tmp_path, {"review_mode": "triple"})
         runner = CliRunner()
         task_id = _create_task(runner, root)
 
         fake_diff = "diff --git a/foo.py b/foo.py\n+print('hello')"
-        fake_reviews = [
-            ("claude", False, "timeout"),
-            ("codex", False, "timeout"),
-            ("gemini", False, "timeout"),
-        ]
 
         with (
             patch("lattice.cli.review_cmds.resolve_diff", return_value=(True, fake_diff)),
             patch(
                 "lattice.cli.review_cmds.run_triple_review",
-                return_value=(False, "done", fake_reviews),
+                return_value=(
+                    False,
+                    "triple mode requires c11 — run from inside a c11 surface, or use --mode single.",
+                ),
             ),
         ):
             result = runner.invoke(
@@ -462,7 +459,8 @@ class TestCodeReviewTriple:
                 env={"LATTICE_ROOT": str(root)},
                 catch_exceptions=False,
             )
-        assert "All agents failed" in result.output or result.exit_code != 0
+        assert result.exit_code != 0
+        assert "triple mode requires c11" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -749,22 +747,6 @@ class TestSpawnAgent:
                 success, msg = spawn_agent("claude", prompt, output)
 
         assert success is False
-
-
-class TestBuildMergePrompt:
-    def test_includes_all_agents(self):
-        from lattice.core.review import build_merge_prompt
-
-        reviews = [
-            ("claude", True, "PASS claude"),
-            ("codex", False, "timeout"),
-            ("gemini", True, "PASS gemini"),
-        ]
-        prompt = build_merge_prompt("LAT-190", reviews, "code-review")
-        assert "claude" in prompt
-        assert "gemini" in prompt
-        assert "failed or timed out" in prompt
-        assert "LAT-190" in prompt
 
 
 class TestDiffResolution:

--- a/tests/test_core/test_agent_spawn.py
+++ b/tests/test_core/test_agent_spawn.py
@@ -30,6 +30,9 @@ from lattice.core.agent_spawn import (
 def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Remove every env var the selector reads so tests start from a known floor."""
     for name in (
+        "C11_SOCKET_PATH",
+        "C11_WORKSPACE_ID",
+        "C11_SURFACE_ID",
         "CMUX_SOCKET_PATH",
         "CMUX_WORKSPACE_ID",
         "CMUX_SURFACE_ID",
@@ -102,7 +105,7 @@ class TestSelectBackend:
     def test_explicit_headless_kwarg_overrides_everything(
         self, clean_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("CMUX_SOCKET_PATH", "/tmp/cmux.sock")
+        monkeypatch.setenv("C11_SOCKET_PATH", "/tmp/c11.sock")
         backend = select_backend(headless=True)
         assert backend.name == "headless"
 
@@ -120,12 +123,12 @@ class TestSelectBackend:
         with pytest.raises(BackendUnavailableError):
             select_backend()
 
-    def test_force_cmux_unavailable_raises(
+    def test_force_c11_unavailable_raises(
         self, clean_env: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # CMUX_SOCKET_PATH unset → cmux unavailable → forced should raise.
+        # C11_SOCKET_PATH unset → c11 unavailable → forced should raise.
         with pytest.raises(BackendUnavailableError):
-            select_backend(force="cmux")
+            select_backend(force="c11")
 
     def test_force_terminal_unavailable_raises(
         self, clean_env: None, monkeypatch: pytest.MonkeyPatch
@@ -134,12 +137,12 @@ class TestSelectBackend:
         with pytest.raises(BackendUnavailableError):
             select_backend(force="terminal")
 
-    def test_no_tty_no_cmux_falls_back_to_headless(
+    def test_no_tty_no_c11_falls_back_to_headless(
         self,
         clean_env: None,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # No CMUX_SOCKET_PATH, no TTY → headless.
+        # No C11_SOCKET_PATH, no TTY → headless.
         monkeypatch.setattr("sys.stdout.isatty", lambda: False)
         backend = select_backend()
         assert backend.name == "headless"

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -13,7 +13,7 @@ from lattice.core.review import (
     DEFAULT_AGENT_TIMEOUT,
     FAILURE_THRESHOLD,
     _extract_actor_str,
-    _pid_alive,
+    pid_alive,
     claim_review_state,
     cleanup_temp_files,
     clear_review_state,
@@ -64,17 +64,17 @@ class TestReviewState:
 
 class TestPidAlive:
     def test_self_pid_is_alive(self) -> None:
-        assert _pid_alive(os.getpid()) is True
+        assert pid_alive(os.getpid()) is True
 
     def test_known_dead_pid_is_not_alive(self) -> None:
         # 2**31-1 is far above typical PID range; never live in practice.
-        assert _pid_alive(2**31 - 1) is False
+        assert pid_alive(2**31 - 1) is False
 
     def test_zero_pid_is_not_alive(self) -> None:
-        assert _pid_alive(0) is False
+        assert pid_alive(0) is False
 
     def test_negative_pid_is_not_alive(self) -> None:
-        assert _pid_alive(-1) is False
+        assert pid_alive(-1) is False
 
 
 # ---------------------------------------------------------------------------
@@ -416,8 +416,9 @@ class TestTripleReviewSpawn:
         # review_state marker landed.
         state = review_mod.read_review_state(lattice_dir, "task_01ABC")
         assert state is not None
-        assert state["mode"] == "triple_pane"
+        assert state["mode"] == "triple"
         assert state["pane_ref"] == "surface:42"
+        assert state["started_by_actor"] == "agent:test"
 
     def test_fire_and_forget_returns_quickly(
         self, lattice_dir: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -307,3 +307,51 @@ class TestConfigTimeout:
 
     def test_default_agent_timeout_constant(self) -> None:
         assert DEFAULT_AGENT_TIMEOUT == 600
+
+
+# ---------------------------------------------------------------------------
+# Single-mode reviews must always be headless (LAT-218)
+# ---------------------------------------------------------------------------
+
+
+class TestSingleReviewBackend:
+    def test_single_review_is_always_headless(
+        self, lattice_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``run_single_review`` always passes a ``HeadlessBackend`` to ``spawn_one``.
+
+        Pre-LAT-218 the call site honored ``headless`` / ``backend_force``
+        params and could route to the c11 or terminal backend. Post-LAT-218
+        the params are gone and every call to ``run_single_review`` is
+        guaranteed headless — no surface, no window.
+        """
+        from lattice.core import review as review_mod
+        from lattice.core.agent_spawn import SpawnResult
+        from lattice.storage.agent_spawn import HeadlessBackend
+
+        captured: dict = {}
+
+        def _fake_spawn_one(request, **kwargs):
+            captured["kwargs"] = kwargs
+            return SpawnResult(
+                agent=request.agent,
+                success=True,
+                output_text="ok",
+                error="",
+                backend="headless",
+                duration_seconds=0.0,
+            )
+
+        monkeypatch.setattr(review_mod, "spawn_one", _fake_spawn_one)
+
+        success, _msg, _text = review_mod.run_single_review(
+            lattice_dir=lattice_dir,
+            task_id="t1",
+            review_type="code-review",
+            prompt_content="noop",
+            actor="agent:test",
+            timeout=5,
+        )
+
+        assert success is True
+        assert isinstance(captured["kwargs"].get("backend"), HeadlessBackend)

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -355,3 +355,105 @@ class TestSingleReviewBackend:
 
         assert success is True
         assert isinstance(captured["kwargs"].get("backend"), HeadlessBackend)
+
+
+# ---------------------------------------------------------------------------
+# Triple-mode reviews (LAT-218) — fire-and-forget c11 pane spawn
+# ---------------------------------------------------------------------------
+
+
+class TestTripleReviewSpawn:
+    def test_outside_c11_returns_clean_error(
+        self, lattice_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lattice.core import review as review_mod
+
+        monkeypatch.setattr("lattice.cli.c11_bridge.c11_available", lambda: False)
+
+        ok, msg = review_mod.run_triple_review(
+            lattice_dir=lattice_dir,
+            task_id="t1",
+            review_type="code-review",
+            actor="agent:test",
+        )
+        assert ok is False
+        assert "triple mode requires c11" in msg
+
+    def test_spawns_pane_and_writes_state(
+        self, lattice_dir: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from lattice.core import review as review_mod
+
+        monkeypatch.setattr("lattice.cli.c11_bridge.c11_available", lambda: True)
+
+        captured: dict = {}
+
+        def _fake_spawn(prompt_text, **kwargs):
+            captured["prompt"] = prompt_text
+            captured["kwargs"] = kwargs
+            return True, "surface:42"
+
+        monkeypatch.setattr(
+            "lattice.integrations.c11.spawn_one_in_current_workspace",
+            _fake_spawn,
+        )
+
+        ok, msg = review_mod.run_triple_review(
+            lattice_dir=lattice_dir,
+            task_id="task_01ABC",
+            review_type="code-review",
+            actor="agent:test",
+            short_id="LAT-218",
+            base="main",
+            worktree=tmp_path,
+        )
+        assert ok is True
+        assert "surface:42" in msg
+        # Pane prompt contains the trident slash command + routing table.
+        assert "/trident-code-review LAT-218" in captured["prompt"]
+        assert "pr_open" in captured["prompt"]
+        assert "needs_human" in captured["prompt"]
+        # review_state marker landed.
+        state = review_mod.read_review_state(lattice_dir, "task_01ABC")
+        assert state is not None
+        assert state["mode"] == "triple_pane"
+        assert state["pane_ref"] == "surface:42"
+
+    def test_fire_and_forget_returns_quickly(
+        self, lattice_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import time as _time
+
+        from lattice.core import review as review_mod
+
+        monkeypatch.setattr("lattice.cli.c11_bridge.c11_available", lambda: True)
+        monkeypatch.setattr(
+            "lattice.integrations.c11.spawn_one_in_current_workspace",
+            lambda _p, **_k: (True, "surface:1"),
+        )
+        start = _time.monotonic()
+        review_mod.run_triple_review(
+            lattice_dir=lattice_dir,
+            task_id="t1",
+            review_type="plan-review",
+            actor="agent:test",
+            short_id="LAT-1",
+        )
+        elapsed = _time.monotonic() - start
+        assert elapsed < 1.0, f"run_triple_review should return immediately, took {elapsed:.3f}s"
+
+    def test_handoff_prompt_includes_routing_table(self) -> None:
+        from lattice.core.review import build_trident_handoff_prompt
+
+        prompt = build_trident_handoff_prompt(
+            "LAT-42",
+            "plan-review",
+            worktree=Path("/tmp/wt"),
+            base_branch="main",
+        )
+        assert "/trident-plan-review LAT-42" in prompt
+        assert "Review Verdict Routing" in prompt
+        # Routing table outcomes
+        for outcome in ("pr_open", "in_progress", "in_planning", "needs_human"):
+            assert outcome in prompt
+        assert "agent:trident-pane-LAT-42" in prompt

--- a/tests/test_integrations_c11_parsing.py
+++ b/tests/test_integrations_c11_parsing.py
@@ -1,13 +1,13 @@
-"""Pinning tests for the cmux backend's ref parser.
+"""Pinning tests for the c11 backend's ref parser.
 
-The cmux CLI returns refs as "OK workspace:N" or "OK surface:N pane:M
+The c11 CLI returns refs as "OK workspace:N" or "OK surface:N pane:M
 workspace:K". The backend depends on stable parsing of those lines —
-exercises the parser directly without touching the cmux socket.
+exercises the parser directly without touching the c11 socket.
 """
 
 from __future__ import annotations
 
-from lattice.integrations.cmux import _parse_refs
+from lattice.integrations.c11 import _parse_refs
 
 
 class TestParseRefs:
@@ -23,8 +23,8 @@ class TestParseRefs:
         }
 
     def test_surface_first(self) -> None:
-        # `cmux list-pane-surfaces` returns "* surface:N  …  [selected]"
-        refs = _parse_refs("* surface:75  …/Stage11/code/cmux  [selected]")
+        # `c11 list-pane-surfaces` returns "* surface:N  …  [selected]"
+        refs = _parse_refs("* surface:75  …/Stage11/code/c11  [selected]")
         assert refs == {"surface": "surface:75"}
 
     def test_picks_first_per_kind(self) -> None:


### PR DESCRIPTION
## Summary

Replaces the workspace-spawning review backend with two clean modes and completes the c11 rename across the spawn integration.

- **Single-mode reviews (default) are always headless.** `claude -p` subprocess; no c11 surface created. `--headless` and `--backend` flags removed from `code-review` / `plan-review` (other commands keep them).
- **Triple-mode reviews split one new pane in the caller's c11 workspace** (not a new workspace) and hand off to `/trident-{code,plan}-review`. CLI is fire-and-forget: prints "Triple review running in surface:N — task status is the sync primitive" and exits 0. Outside c11 → clear error, non-zero exit, in-flight claim released.
- **Full `cmux` → `c11` rename.** Files (`integrations/cmux.py` → `integrations/c11.py`, `cli/cmux_bridge.py` → `cli/c11_bridge.py`, matching tests), symbols (`CmuxBackend` → `C11Backend`, `_cmux_capture` → `_c11_capture`, etc.), env-var values (`LATTICE_SPAWN_BACKEND=cmux` → `=c11`), `--backend` choice values, snapshot field names (`cmux_surface` → `c11_surface`), and every docstring / log / error string. A single canonical OS-layer-alias note remains in `cli/c11_bridge.py`. `CMUX_*` env-var fallbacks were initially kept defensively but removed after code review — the c11 binary always sets `C11_*` on every surface, so reading the legacy names is unnecessary and contradicts Stage11/CLAUDE.md's "never write CMUX_*" rule.
- Templates and the project CLAUDE.md updated. New `lattice init` produces a CLAUDE.md describing the new review behavior.
- The bug that motivated this: an LAT-220 plan-review observed 10 minutes before this work began spawned `workspace:23 "plan-review-task_..."` for what should have been a headless single-mode review. Single mode now produces no visible surface; triple mode produces one pane in the caller's workspace instead of a new sibling workspace in the sidebar.

## Commits

1. `dbaae92` — `refactor(LAT-218): rename cmux → c11 throughout (no behavior change)` — mechanical pass.
2. `b9e2b57` — `refactor(LAT-218): single-mode reviews always headless; drop --backend / --headless flags`.
3. `1d6c4ec` — `feat(LAT-218): triple-mode reviews spawn one c11 pane and hand off to trident` — new `spawn_one_in_current_workspace` primitive, rewritten `run_triple_review`, `build_trident_handoff_prompt` carrying the Review Verdict Routing table, deletion of the old `run_merge_agent` / `build_merge_prompt`.
4. `9e393c7` — `fix(LAT-218): drop CMUX_* env-var fallbacks, unify mode string, tighten test` — applied review findings inline.

## Code review

`art_01KRS48VD2FQJ344SCK80SP662` — verdict PASS (implementation-level). One major and four minor findings, all triaged: major + 3 minor fixed inline (commit `9e393c7`); 1 minor (janitorial cleanup of `.lattice/tmp-prompts/trident-*` dirs) tracked as **LAT-224**.

## Out of scope (filed separately)

- LAT-224 — janitor for stale `tmp-prompts/trident-*` directories.
- LAT-220 (dashboard work, in flight in parallel).

## Test plan

- [x] `uv run pytest` — 1867 passed.
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run ruff format src/ tests/` — clean (1 file reformatted by hook, included).
- [x] `git grep -inE 'cmux|Cmux|CMUX' src/lattice/ tests/` returns only the canonical OS-alias note in `cli/c11_bridge.py` and the sanctioned `CMUX_*`-stripping fixture in `tests/test_core/test_agent_spawn.py`.
- [x] `lattice code-review LAT-218` ran headless via the new path (no c11 surface created) and produced `art_01KRS48VD2FQJ344SCK80SP662` in ~5m.
- [ ] Manual smoke: `lattice code-review <task> --mode triple` from inside a c11 workspace — should split one new pane sharing cwd, run `/trident-code-review`, CLI exits 0. Outside c11 should error cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)