### PR TITLE
docs(LAT-226): sub-agent polling cadence rule (180s/270s)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,14 +222,14 @@ Each sub-agent should use a distinct actor ID (e.g., `agent:claude-opus-4-planne
 
 **Prompt guidance for sub-agents building streaming/realtime features:** When writing implementation prompts for features involving event streams, fswatch, or background process coordination (e.g., `lattice watch`, `lattice wait`), explicitly tell the sub-agent to skip integration tests that require concurrent processes. Test parsing and filtering logic with unit tests. Trust the I/O core from existing proven commands. Agents will otherwise thrash on launching background processes, sleeping, and debugging timing issues in a single-agent sandbox — a known failure mode that wastes significant context.
 
-**Sub-agent polling cadence.** When waiting on a sub-agent you spawned in another tab/pane, schedule the next wake-up explicitly — don't rely on `ScheduleWakeup`'s default idle interval (1200s+, calibrated for operator-paced review/merge waits). Sub-agents are agent-paced and typically finish in 2–15 minutes; a 20-minute check-back leaves the operator staring at stale state.
+**Sub-agent polling cadence.** When waiting on a sub-agent you spawned in another tab/pane, schedule the next wake-up explicitly — don't rely on `ScheduleWakeup`'s default idle interval (1200s–1800s, calibrated for operator-paced review/merge waits). Sub-agents are agent-paced and typically finish in 2–15 minutes; a 20-minute check-back leaves the operator staring at stale state.
 
 | Role | `ScheduleWakeup` delay | Notes |
 |---|---|---|
 | Sub-agent / delegator | **180s** | Inside the 5-min prompt-cache window — cheap wake-ups, ≤3 min latency on completion |
 | Orchestrator | **270s** | Same cache window; orchestrator transitions are less frequent |
 
-**Don't pick 300s.** It's just past the 5-min cache TTL — pays the cache-miss without amortizing it into a long wait. Either stay ≤270s (cache-warm) or step up to ≥1200s (long-idle amortized).
+**Don't pick 300s.** It's just past the 5-min cache TTL — pays the cache-miss without amortizing it into a long wait. Either stay ≤270s (cache-warm) or step up to ≥1200s (one cache-miss amortized over a longer wait).
 
 **Pair short cadence with brief ticks.** Heartbeat ticks (no state change) get one sentence at most. State-change ticks (sub-agent finished, task transitioned, blocker hit) get as much detail as the situation demands. Short interval + silent-on-no-change keeps the transcript scannable while staying responsive to real events.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,17 @@ Each sub-agent should use a distinct actor ID (e.g., `agent:claude-opus-4-planne
 
 **Prompt guidance for sub-agents building streaming/realtime features:** When writing implementation prompts for features involving event streams, fswatch, or background process coordination (e.g., `lattice watch`, `lattice wait`), explicitly tell the sub-agent to skip integration tests that require concurrent processes. Test parsing and filtering logic with unit tests. Trust the I/O core from existing proven commands. Agents will otherwise thrash on launching background processes, sleeping, and debugging timing issues in a single-agent sandbox — a known failure mode that wastes significant context.
 
+**Sub-agent polling cadence.** When waiting on a sub-agent you spawned in another tab/pane, schedule the next wake-up explicitly — don't rely on `ScheduleWakeup`'s default idle interval (1200s+, calibrated for operator-paced review/merge waits). Sub-agents are agent-paced and typically finish in 2–15 minutes; a 20-minute check-back leaves the operator staring at stale state.
+
+| Role | `ScheduleWakeup` delay | Notes |
+|---|---|---|
+| Sub-agent / delegator | **180s** | Inside the 5-min prompt-cache window — cheap wake-ups, ≤3 min latency on completion |
+| Orchestrator | **270s** | Same cache window; orchestrator transitions are less frequent |
+
+**Don't pick 300s.** It's just past the 5-min cache TTL — pays the cache-miss without amortizing it into a long wait. Either stay ≤270s (cache-warm) or step up to ≥1200s (long-idle amortized).
+
+**Pair short cadence with brief ticks.** Heartbeat ticks (no state change) get one sentence at most. State-change ticks (sub-agent finished, task transitioned, blocker hit) get as much detail as the situation demands. Short interval + silent-on-no-change keeps the transcript scannable while staying responsive to real events.
+
 ### The Planning Gate
 
 The plan file lives at `.lattice/plans/<task_id>.md` — scaffolded on creation, empty until you fill it.

--- a/src/lattice/templates/claude_md_block.py
+++ b/src/lattice/templates/claude_md_block.py
@@ -81,14 +81,14 @@ Each sub-agent should use a distinct actor ID (e.g., `agent:claude-opus-4-planne
 
 **Prompt guidance for sub-agents building streaming/realtime features:** When writing implementation prompts for features involving event streams, fswatch, or background process coordination (e.g., `lattice watch`, `lattice wait`), explicitly tell the sub-agent to skip integration tests that require concurrent processes. Test parsing and filtering logic with unit tests. Trust the I/O core from existing proven commands. Agents will otherwise thrash on launching background processes, sleeping, and debugging timing issues in a single-agent sandbox — a known failure mode that wastes significant context.
 
-**Sub-agent polling cadence.** When waiting on a sub-agent you spawned in another tab/pane, schedule the next wake-up explicitly — don't rely on `ScheduleWakeup`'s default idle interval (1200s+, calibrated for operator-paced review/merge waits). Sub-agents are agent-paced and typically finish in 2–15 minutes; a 20-minute check-back leaves the operator staring at stale state.
+**Sub-agent polling cadence.** When waiting on a sub-agent you spawned in another tab/pane, schedule the next wake-up explicitly — don't rely on `ScheduleWakeup`'s default idle interval (1200s–1800s, calibrated for operator-paced review/merge waits). Sub-agents are agent-paced and typically finish in 2–15 minutes; a 20-minute check-back leaves the operator staring at stale state.
 
 | Role | `ScheduleWakeup` delay | Notes |
 |---|---|---|
 | Sub-agent / delegator | **180s** | Inside the 5-min prompt-cache window — cheap wake-ups, ≤3 min latency on completion |
 | Orchestrator | **270s** | Same cache window; orchestrator transitions are less frequent |
 
-**Don't pick 300s.** It's just past the 5-min cache TTL — pays the cache-miss without amortizing it into a long wait. Either stay ≤270s (cache-warm) or step up to ≥1200s (long-idle amortized).
+**Don't pick 300s.** It's just past the 5-min cache TTL — pays the cache-miss without amortizing it into a long wait. Either stay ≤270s (cache-warm) or step up to ≥1200s (one cache-miss amortized over a longer wait).
 
 **Pair short cadence with brief ticks.** Heartbeat ticks (no state change) get one sentence at most. State-change ticks (sub-agent finished, task transitioned, blocker hit) get as much detail as the situation demands. Short interval + silent-on-no-change keeps the transcript scannable while staying responsive to real events.
 

--- a/src/lattice/templates/claude_md_block.py
+++ b/src/lattice/templates/claude_md_block.py
@@ -81,6 +81,17 @@ Each sub-agent should use a distinct actor ID (e.g., `agent:claude-opus-4-planne
 
 **Prompt guidance for sub-agents building streaming/realtime features:** When writing implementation prompts for features involving event streams, fswatch, or background process coordination (e.g., `lattice watch`, `lattice wait`), explicitly tell the sub-agent to skip integration tests that require concurrent processes. Test parsing and filtering logic with unit tests. Trust the I/O core from existing proven commands. Agents will otherwise thrash on launching background processes, sleeping, and debugging timing issues in a single-agent sandbox — a known failure mode that wastes significant context.
 
+**Sub-agent polling cadence.** When waiting on a sub-agent you spawned in another tab/pane, schedule the next wake-up explicitly — don't rely on `ScheduleWakeup`'s default idle interval (1200s+, calibrated for operator-paced review/merge waits). Sub-agents are agent-paced and typically finish in 2–15 minutes; a 20-minute check-back leaves the operator staring at stale state.
+
+| Role | `ScheduleWakeup` delay | Notes |
+|---|---|---|
+| Sub-agent / delegator | **180s** | Inside the 5-min prompt-cache window — cheap wake-ups, ≤3 min latency on completion |
+| Orchestrator | **270s** | Same cache window; orchestrator transitions are less frequent |
+
+**Don't pick 300s.** It's just past the 5-min cache TTL — pays the cache-miss without amortizing it into a long wait. Either stay ≤270s (cache-warm) or step up to ≥1200s (long-idle amortized).
+
+**Pair short cadence with brief ticks.** Heartbeat ticks (no state change) get one sentence at most. State-change ticks (sub-agent finished, task transitioned, blocker hit) get as much detail as the situation demands. Short interval + silent-on-no-change keeps the transcript scannable while staying responsive to real events.
+
 ### The Planning Gate
 
 The plan file lives at `.lattice/plans/<task_id>.md` — scaffolded on creation, empty until you fill it.


### PR DESCRIPTION
## Summary

Adds explicit `ScheduleWakeup` cadence guidance to the **Sub-Agent Execution Model** section of the Lattice `CLAUDE.md` template (and the live root `CLAUDE.md`).

Without this rule, delegators were falling back to `ScheduleWakeup`'s documented idle default (1200s+), which is calibrated for *operator-paced* review/merge waits — not *agent-paced* sub-agent polling. Result: a delegator would schedule its next check-back at ~20 min for a sub-agent that finished in ~10 min, leaving the operator staring at stale state.

Surfaced during LAT-220 dispatch.

## The rule

| Role | `ScheduleWakeup` delay | Notes |
|---|---|---|
| Sub-agent / delegator | **180s** | Inside the 5-min prompt-cache window — cheap wake-ups, ≤3 min latency on completion |
| Orchestrator | **270s** | Same cache window; orchestrator transitions are less frequent |

Plus the cache-cliff guidance: don't pick 300s (worst-of-both-worlds), either stay ≤270s or step up to ≥1200s.

Plus a tick-output discipline note: heartbeat ticks (no state change) → one sentence; state-change ticks → as much detail as needed. Short interval + silent-on-no-change keeps the transcript scannable.

## What this PR does NOT touch

- `~/Projects/Stage11/.claude/skills/lattice-orchestrator/references/orchestrator.md` — harmonized in a separate env-layer edit (file isn't in any git repo). Active-dispatch cadence updated from 240s → 270s, with a cross-reference to this rule.
- Symlink at `~/.claude/skills/lattice` — was a broken self-pointing symlink; repointed to canonical source. Env-layer fix.

## Test plan

- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run pytest` — 1867 passed
- [x] Diff is exactly 22 lines insertion across 2 files, no other changes
- [x] Template and live `CLAUDE.md` insertion content matches