### PR TITLE
chore(LAT-228): relax mypy strict mode to unblock CI type-check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,17 +68,27 @@ markers = [
 
 # mypy: relaxed from strict=true (LAT-228). The codebase was never annotated
 # to the strict bar — 559 errors across 44 files when strict was on, so the
-# gate was nominal-only. Rather than ship hundreds of `dict[str, Any]` and
-# `# type: ignore` for what amounts to "we never typed this," we explicitly
-# disable the noisy categories and keep the cheap, real-signal checks
-# (no_implicit_optional, warn_unused_configs).
+# gate was nominal-only.
 #
-# Re-enable categories or add `[[tool.mypy.overrides]]` per-module as files
-# get cleaned up. A future strict-mode-restoration is its own ticket.
+# Dropping `strict = true` turns off `disallow_any_generics` /
+# `disallow_untyped_decorators` / `disallow_untyped_defs`, which eliminates
+# ~430 of the 559 errors (the type-arg / untyped-decorator / no-untyped-def
+# categories). The remaining ~120 errors are listed in `disable_error_code`
+# below, with per-code rationale.
+#
+# We keep the cheap, real-signal checks: no_implicit_optional (catches
+# `def f(x: int = None)` PEP-484 foot-guns), check_untyped_defs (still
+# type-checks bodies of unannotated functions), warn_return_any,
+# warn_unused_configs.
+#
+# Re-tighten per-module via [[tool.mypy.overrides]] as files get cleaned
+# up. A future strict-mode-restoration is its own ticket.
 [tool.mypy]
 python_version = "3.12"
+warn_return_any = true
 warn_unused_configs = true
 no_implicit_optional = true
+check_untyped_defs = true
 disable_error_code = [
     "arg-type",        # 60 — dict-as-config calls, no precise contract
     "no-any-return",   # 33 — typed funcs returning untyped dicts/JSON

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,11 +66,35 @@ markers = [
     "timeout: marks tests with a timeout",
 ]
 
+# mypy: relaxed from strict=true (LAT-228). The codebase was never annotated
+# to the strict bar — 559 errors across 44 files when strict was on, so the
+# gate was nominal-only. Rather than ship hundreds of `dict[str, Any]` and
+# `# type: ignore` for what amounts to "we never typed this," we explicitly
+# disable the noisy categories and keep the cheap, real-signal checks
+# (no_implicit_optional, warn_unused_configs).
+#
+# Re-enable categories or add `[[tool.mypy.overrides]]` per-module as files
+# get cleaned up. A future strict-mode-restoration is its own ticket.
 [tool.mypy]
 python_version = "3.12"
-strict = true
-warn_return_any = true
 warn_unused_configs = true
+no_implicit_optional = true
+disable_error_code = [
+    "arg-type",        # 60 — dict-as-config calls, no precise contract
+    "no-any-return",   # 33 — typed funcs returning untyped dicts/JSON
+    "index",           #  8 — Click ctx.obj accessed dict-style
+    "union-attr",      #  2 — None-check noise around optional reads
+    "dict-item",       #  2 — TypedDict vs plain dict assignment
+    "assignment",      #  2 — Optional vs non-Optional re-assignment
+    "no-redef",        #  2 — pre-existing variable shadowing
+    "valid-type",      #  2 — `callable` annotations (legacy; cheap future fix)
+    "var-annotated",   #  1 — empty list needs explicit annotation
+    "typeddict-item",  #  1
+    "return-value",    #  1
+    "misc",            #  1
+    "import-untyped",  #  1 — pyyaml stubs not installed
+    "attr-defined",    #  1 — Click ctx.obj attr access
+]
 packages = ["lattice"]
 mypy_path = ["src"]
 


### PR DESCRIPTION
## Summary

Drops `strict = true` from `[tool.mypy]` and explicitly disables the high-noise error categories. CI type-check goes from **559 errors across 44 files** to **green**.

The codebase was never annotated to the strict bar, so the gate was nominal-only — it failed every PR including `.gitignore`-only and docs-only changes (see #18, #20, #22, all blocked). Rather than ship hundreds of `dict[str, Any]` annotations and `# type: ignore` for code we never typed, this disables the noisy categories with an explanatory comment.

Per-category disable list documents why each is silenced. Future contributors can re-tighten module-by-module via `[[tool.mypy.overrides]]` as files get cleaned up. Strict-mode restoration is its own future ticket.

## Verification

- [x] `uv run mypy src/` → `Success: no issues found in 67 source files`
- [x] `uv run pytest` → 1867 passed
- [x] `uv run ruff check src/ tests/` → All checks passed
- [x] Diff is 1 file (pyproject.toml), config-only, no source code touched

## Downstream

Once this merges, the three blocked PRs (#18 LAT-220, #20 LAT-226, #22 LAT-227) need a rebase or merge-from-main to pick up the new config; their CI re-runs should then come back green.