### PR TITLE
feat(workflow): in_validation swimlane between review and pr_open (LAT-233)

### DIFF
--- a/src/lattice/cli/c11_bridge.py
+++ b/src/lattice/cli/c11_bridge.py
@@ -35,7 +35,7 @@ STATUS_VISUALS: dict[str, dict[str, str]] = {
     "in_progress": {"icon": "play.fill", "color": "#E67E22"},
     "review": {"icon": "eye.fill", "color": "#FFD700"},
     "in_validation": {"icon": "checkmark.shield.fill", "color": "#1ABC9C"},
-    "pr_open": {"icon": "arrow.triangle.pull", "color": "#3498DB"},
+    "pr_open": {"icon": "arrow.triangle.pull", "color": "#6C5CE7"},
     "done": {"icon": "checkmark.circle.fill", "color": "#2ECC71"},
     "blocked": {"icon": "exclamationmark.triangle.fill", "color": "#E74C3C"},
     # Retained for instances whose config still has the legacy status.

--- a/src/lattice/cli/c11_bridge.py
+++ b/src/lattice/cli/c11_bridge.py
@@ -34,6 +34,8 @@ STATUS_VISUALS: dict[str, dict[str, str]] = {
     "planned": {"icon": "checkmark.seal.fill", "color": "#3498DB"},
     "in_progress": {"icon": "play.fill", "color": "#E67E22"},
     "review": {"icon": "eye.fill", "color": "#FFD700"},
+    "in_validation": {"icon": "checkmark.shield.fill", "color": "#1ABC9C"},
+    "pr_open": {"icon": "arrow.triangle.pull", "color": "#3498DB"},
     "done": {"icon": "checkmark.circle.fill", "color": "#2ECC71"},
     "blocked": {"icon": "exclamationmark.triangle.fill", "color": "#E74C3C"},
     # Retained for instances whose config still has the legacy status.
@@ -51,6 +53,8 @@ NEEDS_HUMAN_VISUALS: dict[str, str] = {
 STATUS_LABELS: dict[str, str] = {
     "in_progress": "on it",
     "review": "review",
+    "in_validation": "validating",
+    "pr_open": "PR up",
     "blocked": "blocked",
     "needs_human": "needs human",
     "done": "done",

--- a/src/lattice/cli/query_cmds.py
+++ b/src/lattice/cli/query_cmds.py
@@ -549,7 +549,14 @@ def next_cmd(
                     "ALREADY_CLAIMED",
                     is_json,
                 )
-            if current_status in ("in_progress", "review", "done", "cancelled"):
+            if current_status in (
+                "in_progress",
+                "review",
+                "in_validation",
+                "pr_open",
+                "done",
+                "cancelled",
+            ):
                 if not _actors_match(current_assigned, resolved_actor):
                     output_error(
                         f"Task already in {current_status}.",

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -637,11 +637,11 @@ def compute_next_steps(
                 "pid": auto_review_result["pid"],
                 "mode": auto_review_result["mode"],
                 "log_path": auto_review_result["log_path"],
-                "then": "done",
+                "then": "in_validation",
             }
         hint = (
             f"Next: run 'lattice code-review {label}' "
-            f"(review_mode: {review_mode}) before opening the PR."
+            f"(review_mode: {review_mode}) before moving to in_validation."
         )
         if auto_review_result and not auto_review_result.get("fired"):
             hint += (
@@ -656,6 +656,22 @@ def compute_next_steps(
             "action": "code_review",
             "command": f"lattice code-review {label}",
             "review_mode": review_mode,
+            "then": "in_validation",
+        }
+
+    if new_status == "in_validation":
+        hint = (
+            "Next: validate end-to-end against a running system — browser "
+            "automation for web, simulator MCP for mobile, curl for APIs. "
+            "Exercise the actual flow this task touched, then record evidence: "
+            f"lattice attach {label} --role validation (or lattice comment "
+            f"{label} --role validation). On pass move to pr_open; on fail "
+            "route back to in_progress (impl-level) or in_planning (plan-level). "
+            "The bar: 'I saw it work,' not 'I think it should work.'"
+        )
+        return hint, {
+            "action": "validate_e2e",
+            "evidence": f"lattice attach {label} --role validation",
             "then": "pr_open",
         }
 
@@ -827,7 +843,7 @@ def status_cmd(
 
     # Review cycle limit: block rework transitions if cycle limit reached
     if (
-        current_status in ("review", "pr_open")
+        current_status in ("review", "in_validation", "pr_open")
         and new_status in ("in_progress", "in_planning")
         and not force
     ):

--- a/src/lattice/cli/weather_cmds.py
+++ b/src/lattice/cli/weather_cmds.py
@@ -205,7 +205,7 @@ def _find_attention_needed(
             )
 
     # Unassigned in-progress tasks
-    in_progress_statuses = {"in_planning", "in_progress", "review"}
+    in_progress_statuses = {"in_planning", "in_progress", "review", "in_validation"}
     for snap in active:
         if snap.get("status") in in_progress_statuses and not snap.get("assigned_to"):
             items.append(
@@ -245,7 +245,7 @@ def _build_weather(lattice_dir: Path, config: dict) -> dict:
     recent_events = _load_recent_events(lattice_dir, hours=24.0)
 
     # In-progress count
-    in_progress_statuses = {"in_planning", "in_progress", "review"}
+    in_progress_statuses = {"in_planning", "in_progress", "review", "in_validation"}
     in_progress_count = sum(1 for snap in active if snap.get("status") in in_progress_statuses)
 
     # Recently completed

--- a/src/lattice/core/config.py
+++ b/src/lattice/core/config.py
@@ -10,6 +10,8 @@ from typing import Literal, TypedDict
 class WipLimits(TypedDict, total=False):
     in_progress: int
     review: int
+    in_validation: int
+    pr_open: int
 
 
 class CompletionPolicy(TypedDict, total=False):
@@ -92,6 +94,7 @@ WORKFLOW_PRESETS: dict[str, dict[str, str]] = {
             "planned": "ready to go",
             "in_progress": "on it",
             "review": "check my work",
+            "in_validation": "seeing it work",
             "pr_open": "PR up",
             "done": "shipped",
             "blocked": "stuck",
@@ -113,8 +116,16 @@ STATUS_DESCRIPTIONS: dict[str, str] = {
     "in_planning": "Design, dialogue, and scoping underway. No implementation code should be written yet.",
     "planned": "Plan is written and approved. Ready for implementation but work has not started.",
     "in_progress": "Implementation is actively underway. Code is being written, tested, or integrated.",
-    "review": "Local review is underway. A review sub-agent is examining the diff before a PR is opened.",
-    "pr_open": "PR is open and awaiting human review, CI, or merge. Local review artifact is recorded.",
+    "review": "Local review is underway. A review sub-agent is examining the diff before validation begins.",
+    "in_validation": (
+        "End-to-end validation is underway. The change is being exercised against a "
+        "running system — browser automation, simulator flows, curl — before the PR "
+        "opens. The bar: 'I saw it work,' not 'I think it should work.'"
+    ),
+    "pr_open": (
+        "PR is open and awaiting human review, CI, or merge. "
+        "Local review and validation artifacts are recorded."
+    ),
     "done": "Work is reviewed, merged, and shipped. No further action needed.",
     "blocked": "Work cannot proceed due to an external dependency or unresolved issue.",
     "cancelled": "Work has been abandoned. No further action will be taken.",
@@ -175,6 +186,7 @@ def default_config(preset: str = "classic") -> LatticeConfig:
             "planned",
             "in_progress",
             "review",
+            "in_validation",
             "pr_open",
             "done",
             "blocked",
@@ -186,10 +198,18 @@ def default_config(preset: str = "classic") -> LatticeConfig:
             "planned": ["in_progress", "review", "blocked", "cancelled"],
             "in_progress": ["review", "blocked", "cancelled"],
             "review": [
+                "in_validation",
                 "pr_open",
                 "done",
                 "in_progress",
                 "in_planning",
+                "cancelled",
+            ],
+            "in_validation": [
+                "pr_open",
+                "in_progress",
+                "in_planning",
+                "blocked",
                 "cancelled",
             ],
             "pr_open": [
@@ -200,18 +220,27 @@ def default_config(preset: str = "classic") -> LatticeConfig:
                 "cancelled",
             ],
             "done": [],
-            "blocked": ["in_planning", "planned", "in_progress", "pr_open", "cancelled"],
+            "blocked": [
+                "in_planning",
+                "planned",
+                "in_progress",
+                "in_validation",
+                "pr_open",
+                "cancelled",
+            ],
             "cancelled": [],
         },
         "universal_targets": ["cancelled"],
-        "roles": ["review", "plan-review", "review-individual"],
+        "roles": ["review", "plan-review", "review-individual", "validation"],
         "wip_limits": {
             "in_progress": 10,
             "review": 5,
+            "in_validation": 5,
             "pr_open": 10,
         },
         "completion_policies": {
             "done": {"require_roles": ["review"]},
+            "pr_open": {"require_roles": ["validation"]},
         },
     }
 

--- a/src/lattice/core/events.py
+++ b/src/lattice/core/events.py
@@ -229,16 +229,17 @@ def get_actor_session(actor: str | dict) -> str | None:
 def count_review_rework_cycles(events: list[dict]) -> int:
     """Count the number of review-to-rework transitions in a task's event log.
 
-    Counts status_changed events where from in ("review", "pr_open") and
-    to in ("in_progress", "in_planning"). This is the number of times
-    a task has been sent back from local review or an open PR for rework.
+    Counts status_changed events where from in ("review", "in_validation",
+    "pr_open") and to in ("in_progress", "in_planning"). This is the number
+    of times a task has been sent back from local review, e2e validation,
+    or an open PR for rework.
     """
     count = 0
     for event in events:
         if event.get("type") != "status_changed":
             continue
         data = event.get("data", {})
-        if data.get("from") in ("review", "pr_open") and data.get("to") in (
+        if data.get("from") in ("review", "in_validation", "pr_open") and data.get("to") in (
             "in_progress",
             "in_planning",
         ):

--- a/src/lattice/core/next.py
+++ b/src/lattice/core/next.py
@@ -10,6 +10,8 @@ URGENCY_ORDER = {"immediate": 0, "high": 1, "normal": 2, "low": 3}
 
 # Statuses that are NOT eligible for next (terminal, waiting, or active).
 # pr_open is waiting on external review/merge, so it is not pickable as next work.
+# in_validation is deliberately NOT excluded: like review, it is actionable
+# agent work (run the e2e validation), not a passive wait.
 EXCLUDED_STATUSES = frozenset({"blocked", "done", "cancelled", "pr_open"})
 
 # Statuses indicating work already in progress (for resume-first logic)

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -744,8 +744,9 @@ goes into one of three buckets:
 
 | Outcome                            | Move task to                          |
 | ---------------------------------- | ------------------------------------- |
-| PASS, fixes done, PR exists        | pr_open                               |
-| PASS, no PR yet                    | open PR (`gh pr create`), then pr_open|
+| PASS, fixes done                   | in_validation (run e2e validation,    |
+|                                    | record `--role validation` evidence,  |
+|                                    | then open the PR and move to pr_open) |
 | FAIL impl-level                    | in_progress (rework, then re-review)  |
 | FAIL plan-level                    | in_planning                           |
 | Complex finding(s)                 | keep status, set needs-human flag     |

--- a/src/lattice/core/tasks.py
+++ b/src/lattice/core/tasks.py
@@ -39,6 +39,7 @@ _DEFAULT_STATUS_ORDER: tuple[str, ...] = (
     "planned",
     "in_progress",
     "review",
+    "in_validation",
     "pr_open",
     "done",
     "blocked",

--- a/src/lattice/skills/lattice/SKILL.md
+++ b/src/lattice/skills/lattice/SKILL.md
@@ -127,7 +127,7 @@ Relationship types for `link`: `blocks`, `blocked_by`, `subtask_of`, `parent_of`
 ## Status Workflow
 
 ```
-backlog → in_planning → planned → in_progress → review → done
+backlog → in_planning → planned → in_progress → review → in_validation → pr_open → done
                                        ↕
                                     blocked
 ```
@@ -135,6 +135,8 @@ backlog → in_planning → planned → in_progress → review → done
 Transitions are enforced. Use `--force --reason "..."` to override when genuinely needed.
 
 **`needs-human` is a flag, not a status.** It rides orthogonally on top of whatever status a task is in — a task can be `in_progress` and flagged, `blocked` and flagged, even `done` and flagged. Set it with `lattice needs-human <task> "<reason>"` (reason required) and clear it with `lattice needs-human <task> --clear`. The flag never moves the task. `blocked` stays a status for generic external dependencies; `needs-human` means "waiting on a human specifically," and the two can coexist.
+
+**`in_validation` is the e2e gate.** After local review passes, prove the change works against a running system — browser automation for web, simulator MCP for mobile, curl flows for APIs. Exercise the actual flow the ticket touched, then record evidence with `lattice attach <task> --role validation` (or `lattice comment <task> --role validation`). Transitioning to `pr_open` is blocked until validation evidence is recorded; if e2e genuinely doesn't apply, record a one-line N/A justification instead — explicit, never silent. Validation failure routes back to `in_progress` (impl-level) or `in_planning` (plan-level), and counts toward the 3-cycle rework valve. The bar: **"I saw it work," not "I think it should work."**
 
 ## Actor IDs
 

--- a/src/lattice/templates/claude_md_block.py
+++ b/src/lattice/templates/claude_md_block.py
@@ -45,7 +45,7 @@ lattice status <task> <status> --actor agent:<your-id>
 ```
 
 ```
-backlog → in_planning → planned → in_progress → review → done
+backlog → in_planning → planned → in_progress → review → in_validation → pr_open → done
                                        ↕
                                     blocked
 ```
@@ -57,7 +57,9 @@ Human attention is NOT a status: any task in any status can carry the orthogonal
 - `planned` — only after the plan file has real content.
 - `in_progress` — before you write the first line of code.
 - `review` — when implementation is complete, before review starts. Then actually review.
-- `done` — only after a review has been performed and recorded.
+- `in_validation` — after local review passes, before e2e validation starts. Then actually validate against a running system.
+- `pr_open` — when the PR is open. Requires recorded validation evidence (`--role validation`).
+- `done` — only after a review has been performed and recorded (and the PR merged, for PR work).
 - Spawning a sub-agent? Update status in the parent context first.
 
 ### Sub-Agent Execution Model
@@ -72,12 +74,14 @@ Each lifecycle stage gets its own sub-agent with fresh context. This is the defa
 |-------|---------------|-------|----------|
 | **Plan** | Explore codebase, write plan, move to `planned` | Task description | Plan file |
 | **Implement** | Read plan, build it, test, commit, move to `review` | Plan file | Committed code |
-| **Review** | Read diff cold, review against acceptance criteria, record findings | Git diff + plan | Review artifact (`--role review`), move to `done` |
+| **Review** | Read diff cold, review against acceptance criteria, record findings | Git diff + plan | Review artifact (`--role review`), move to `in_validation` on pass |
+| **Validate** | Exercise the change end-to-end against a running system | Running app + plan | Validation evidence (`--role validation`), move to `pr_open` on pass |
 
 **The parent orchestrator** (the main agent session) manages the lifecycle:
 1. Move the task to `in_planning` before spawning the planning sub-agent.
 2. After the planner finishes, move to `in_progress` and spawn the implementation sub-agent.
 3. After the implementer finishes, the review sub-agent runs independently.
+4. After review passes, move to `in_validation` and spawn the validation sub-agent to prove the change end-to-end before the PR opens.
 
 Each sub-agent should use a distinct actor ID (e.g., `agent:claude-opus-4-planner`, `agent:claude-opus-4-impl`, `agent:claude-opus-4-reviewer`) so the event log shows who did what.
 
@@ -181,7 +185,7 @@ Every finding must be explicitly routed. No finding may be silently dropped.
 
 When a review agent evaluates work, it produces one of three outcomes:
 
-1. **Pass (with optional minor fix):** The review agent uses vibes-based judgment. If the only issues are trivial (obvious typos, missing semicolons, etc.), fix them inline, record what was changed in the review comment, and move to `done`. No strict line-count threshold — the review agent decides.
+1. **Pass (with optional minor fix):** The review agent uses vibes-based judgment. If the only issues are trivial (obvious typos, missing semicolons, etc.), fix them inline, record what was changed in the review comment, and advance — `in_validation` on the PR path, `done` for non-PR work. No strict line-count threshold — the review agent decides.
 
 2. **Fail — implementation-level:** The plan was sound but the implementation has issues. The review agent explicitly states "implementation-level rework needed" in its comment. The orchestrator transitions the task `review -> in_progress`. Critical findings from the review are appended to the plan file under a new `## Review Cycle N Findings` section. A fresh sub-agent is encouraged (but not mandated) for the rework.
 
@@ -196,17 +200,31 @@ When a review agent evaluates work, it produces one of three outcomes:
 | Route to in_progress vs in_planning | Orchestrator | Follows review agent's recommendation |
 | Whether to spawn fresh sub-agent | Orchestrator | Encouraged by convention, not enforced |
 
-**3-cycle safety valve:** After 3 review-to-rework transitions (any combination of `review -> in_progress` and `review -> in_planning`), the CLI blocks the 4th attempt. The error message instructs the agent to set the `needs_human` flag with a reason explaining the situation. The limit is configurable via `review_cycle_limit` in the workflow config (default: 3). Override with `--force --reason` for genuinely exceptional cases.
+**3-cycle safety valve:** After 3 rework transitions (any combination of `review`/`in_validation`/`pr_open` -> `in_progress` or `in_planning`), the CLI blocks the 4th attempt. The error message instructs the agent to set the `needs_human` flag with a reason explaining the situation. The limit is configurable via `review_cycle_limit` in the workflow config (default: 3). Override with `--force --reason` for genuinely exceptional cases.
 
 **Allowed lifecycle paths:**
 
 ```
-Normal:       in_progress -> review -> done
-Minor fix:    in_progress -> review -> (fix inline) -> done
-1 impl rework: in_progress -> review -> in_progress -> review -> done
-1 plan rework: in_progress -> review -> in_planning -> planned -> in_progress -> review -> done
-Max cycles:   3 review->rework transitions, then CLI blocks -> flag needs-human
+Normal (PR):   in_progress -> review -> in_validation -> pr_open -> done
+Non-PR work:   in_progress -> review -> done
+Minor fix:     in_progress -> review -> (fix inline) -> in_validation -> pr_open -> done
+1 impl rework: in_progress -> review -> in_progress -> review -> in_validation -> ...
+1 e2e rework:  ... review -> in_validation -> in_progress -> review -> in_validation -> ...
+1 plan rework: in_progress -> review -> in_planning -> planned -> in_progress -> review -> ...
+Max cycles:    3 rework transitions, then CLI blocks -> flag needs-human
 ```
+
+### The Validation Gate
+
+Moving to `in_validation` is a commitment to **prove the change works end-to-end** — not to re-run unit tests. The bar: **"I saw it work," not "I think it should work."** A server returning 200 is not a user successfully logging in.
+
+The validating agent:
+1. **Runs the change against a real running system** — browser automation for web, iOS Simulator MCP / Mobile MCP for mobile, curl flows for APIs, the CLI itself for CLI tools.
+2. **Exercises the actual flow the ticket touched** — clicks the buttons, fills the forms, follows the redirects.
+3. **Records evidence:** `lattice attach <task> --role validation` (or `lattice comment <task> --role validation`) — what was run, what was observed, pass/fail.
+4. **Routes the outcome:** pass → `pr_open` (open the PR now). Fail → `in_progress` (implementation-level) or `in_planning` (plan-level), same routing as review rework; the 3-cycle safety valve applies.
+
+The CLI enforces the evidence: transitioning to `pr_open` is blocked until validation-role evidence is recorded. If e2e validation genuinely doesn't apply (docs-only change, pure refactor with no observable behavior), record a one-line N/A justification as the validation evidence — the decision must be explicit, never silent. Do not `--force` past the policy.
 
 ### Review Config Reference
 

--- a/tests/test_cli/test_task_status.py
+++ b/tests/test_cli/test_task_status.py
@@ -651,7 +651,7 @@ class TestNextStepsHints:
         assert ns["action"] == "code_review"
         assert ns["review_mode"] == "single"
         assert "lattice code-review" in ns["command"]
-        assert ns["then"] == "pr_open"
+        assert ns["then"] == "in_validation"
 
     def test_in_progress_human_hint(self, invoke, initialized_root, fill_plan) -> None:
         r = invoke("create", "Impl hint", "--actor", _ACTOR, "--json")
@@ -741,3 +741,99 @@ class TestNextStepsHints:
         assert r.exit_code == 0
         data = json.loads(r.output)["data"]
         assert "next_steps" not in data
+
+
+# ---------------------------------------------------------------------------
+# Validation gate (LAT-233)
+# ---------------------------------------------------------------------------
+
+
+class TestValidationGate:
+    """in_validation swimlane: transitions, hints, evidence gating, rework."""
+
+    def _advance_to_review(self, invoke, fill_plan, title="Validation test") -> str:
+        r = invoke("create", title, "--actor", _ACTOR, "--json")
+        task_id = json.loads(r.output)["data"]["id"]
+        invoke("status", task_id, "in_planning", "--actor", _ACTOR)
+        fill_plan(task_id, title)
+        invoke("status", task_id, "planned", "--actor", _ACTOR)
+        invoke("status", task_id, "in_progress", "--actor", _ACTOR)
+        invoke("status", task_id, "review", "--actor", _ACTOR)
+        return task_id
+
+    def test_review_to_in_validation(self, invoke, initialized_root, fill_plan) -> None:
+        task_id = self._advance_to_review(invoke, fill_plan)
+        r = invoke("status", task_id, "in_validation", "--actor", _ACTOR, "--json")
+        assert r.exit_code == 0
+        assert json.loads(r.output)["ok"] is True
+
+    def test_in_validation_hint_carries_e2e_culture(
+        self, invoke, initialized_root, fill_plan
+    ) -> None:
+        task_id = self._advance_to_review(invoke, fill_plan)
+        r = invoke("status", task_id, "in_validation", "--actor", _ACTOR)
+        assert r.exit_code == 0
+        assert "I saw it work" in r.output
+        assert "--role validation" in r.output
+
+    def test_in_validation_json_next_steps(self, invoke, initialized_root, fill_plan) -> None:
+        task_id = self._advance_to_review(invoke, fill_plan)
+        r = invoke("status", task_id, "in_validation", "--actor", _ACTOR, "--json")
+        ns = json.loads(r.output)["data"]["next_steps"]
+        assert ns["action"] == "validate_e2e"
+        assert ns["then"] == "pr_open"
+        assert "--role validation" in ns["evidence"]
+
+    def test_pr_open_blocked_without_validation_evidence(
+        self, invoke, initialized_root, fill_plan
+    ) -> None:
+        task_id = self._advance_to_review(invoke, fill_plan)
+        invoke("status", task_id, "in_validation", "--actor", _ACTOR)
+        r = invoke("status", task_id, "pr_open", "--actor", _ACTOR, "--json")
+        assert r.exit_code != 0
+        parsed = json.loads(r.output)
+        assert parsed["ok"] is False
+        assert parsed["error"]["code"] == "COMPLETION_BLOCKED"
+        assert "validation" in parsed["error"]["message"]
+
+    def test_pr_open_passes_with_validation_evidence(
+        self, invoke, initialized_root, fill_plan
+    ) -> None:
+        task_id = self._advance_to_review(invoke, fill_plan)
+        invoke("status", task_id, "in_validation", "--actor", _ACTOR)
+        invoke(
+            "comment",
+            task_id,
+            "Validated: exercised the login flow in the browser, saw it work.",
+            "--role",
+            "validation",
+            "--actor",
+            _ACTOR,
+        )
+        r = invoke("status", task_id, "pr_open", "--actor", _ACTOR, "--json")
+        assert r.exit_code == 0
+        assert json.loads(r.output)["ok"] is True
+
+    def test_validation_failure_counts_toward_cycle_limit(
+        self, invoke, initialized_root, fill_plan
+    ) -> None:
+        """in_validation -> in_progress reworks trip the 3-cycle valve."""
+        task_id = self._advance_to_review(invoke, fill_plan)
+        for _ in range(3):
+            invoke("status", task_id, "in_validation", "--actor", _ACTOR)
+            r = invoke("status", task_id, "in_progress", "--actor", _ACTOR, "--json")
+            assert r.exit_code == 0, r.output
+            invoke("status", task_id, "review", "--actor", _ACTOR)
+        invoke("status", task_id, "in_validation", "--actor", _ACTOR)
+        r = invoke("status", task_id, "in_progress", "--actor", _ACTOR, "--json")
+        assert r.exit_code != 0
+        parsed = json.loads(r.output)
+        assert parsed["error"]["code"] == "REVIEW_CYCLE_LIMIT"
+
+    def test_in_validation_to_review_rejected(self, invoke, initialized_root, fill_plan) -> None:
+        """No backflow into review — rework re-enters via in_progress."""
+        task_id = self._advance_to_review(invoke, fill_plan)
+        invoke("status", task_id, "in_validation", "--actor", _ACTOR)
+        r = invoke("status", task_id, "review", "--actor", _ACTOR, "--json")
+        assert r.exit_code != 0
+        assert json.loads(r.output)["ok"] is False

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -51,6 +51,7 @@ class TestDefaultConfig:
             "planned",
             "in_progress",
             "review",
+            "in_validation",
             "pr_open",
             "done",
             "blocked",
@@ -67,6 +68,7 @@ class TestDefaultConfig:
             "planned",
             "in_progress",
             "review",
+            "in_validation",
             "pr_open",
             "done",
             "blocked",
@@ -89,12 +91,15 @@ class TestDefaultConfig:
     def test_wip_limits(self) -> None:
         config = default_config()
         wip = config["workflow"]["wip_limits"]
-        assert wip == {"in_progress": 10, "review": 5, "pr_open": 10}
+        assert wip == {"in_progress": 10, "review": 5, "in_validation": 5, "pr_open": 10}
 
     def test_has_completion_policies(self) -> None:
         config = default_config()
         policies = config["workflow"]["completion_policies"]
-        assert policies == {"done": {"require_roles": ["review"]}}
+        assert policies == {
+            "done": {"require_roles": ["review"]},
+            "pr_open": {"require_roles": ["validation"]},
+        }
 
     def test_has_descriptions(self) -> None:
         config = default_config()
@@ -248,7 +253,7 @@ class TestValidateTransition:
     def test_terminal_status_has_no_explicit_transitions(self) -> None:
         config = default_config()
         # done/cancelled have no explicit transitions, but universal targets
-        # (needs_human, cancelled) are still reachable
+        # (cancelled) are still reachable
         assert validate_transition(config, "done", "backlog") is False
         assert validate_transition(config, "cancelled", "backlog") is False
 
@@ -605,7 +610,12 @@ class TestGetConfiguredRoles:
     def test_default_config_includes_explicit_roles(self) -> None:
         """Default config defines workflow.roles with review roles."""
         config = default_config()
-        assert get_configured_roles(config) == {"review", "plan-review", "review-individual"}
+        assert get_configured_roles(config) == {
+            "review",
+            "plan-review",
+            "review-individual",
+            "validation",
+        }
 
     def test_no_roles_no_policies_returns_empty(self) -> None:
         """Config with neither workflow.roles nor completion policies → empty set."""
@@ -618,6 +628,7 @@ class TestGetConfiguredRoles:
         """workflow.roles alone (no completion policies) is sufficient."""
         config = default_config()
         config["workflow"]["roles"] = ["review", "qa"]
+        config["workflow"].pop("completion_policies", None)
         assert get_configured_roles(config) == {"review", "qa"}
 
     def test_explicit_roles_merged_with_policy_roles(self) -> None:
@@ -768,3 +779,77 @@ class TestProjectType:
         from lattice.core.config import get_project_type
 
         assert get_project_type({"project_type": "bogus"}) == "standard"
+
+
+# ---------------------------------------------------------------------------
+# Validation swimlane (LAT-233)
+# ---------------------------------------------------------------------------
+
+
+class TestValidationSwimlane:
+    """in_validation sits between review and pr_open (LAT-233)."""
+
+    def test_review_to_in_validation_allowed(self) -> None:
+        config = default_config()
+        assert validate_transition(config, "review", "in_validation") is True
+
+    def test_in_validation_to_pr_open_allowed(self) -> None:
+        config = default_config()
+        assert validate_transition(config, "in_validation", "pr_open") is True
+
+    def test_validation_failure_routes_to_rework(self) -> None:
+        config = default_config()
+        assert validate_transition(config, "in_validation", "in_progress") is True
+        assert validate_transition(config, "in_validation", "in_planning") is True
+
+    def test_in_validation_can_block(self) -> None:
+        config = default_config()
+        assert validate_transition(config, "in_validation", "blocked") is True
+
+    def test_review_to_pr_open_still_allowed(self) -> None:
+        """The validation *status* is skippable (evidence is gated separately)."""
+        config = default_config()
+        assert validate_transition(config, "review", "pr_open") is True
+
+    def test_review_to_done_still_allowed(self) -> None:
+        """Non-PR work keeps the direct review -> done path."""
+        config = default_config()
+        assert validate_transition(config, "review", "done") is True
+
+    def test_resume_targets_include_in_validation(self) -> None:
+        config = default_config()
+        assert validate_transition(config, "blocked", "in_validation") is True
+
+    def test_no_in_validation_to_review_backflow(self) -> None:
+        """Rework re-enters via in_progress so the review gate is not bypassed."""
+        config = default_config()
+        assert validate_transition(config, "in_validation", "review") is False
+
+    def test_validation_role_configured(self) -> None:
+        config = default_config()
+        assert "validation" in config["workflow"]["roles"]
+
+    def test_pr_open_policy_blocks_without_validation_evidence(self) -> None:
+        config = default_config()
+        snap = _snap_with_evidence([])
+        ok, failures = validate_completion_policy(config, snap, "pr_open")
+        assert ok is False
+        assert any("validation" in f for f in failures)
+
+    def test_pr_open_policy_passes_with_validation_evidence(self) -> None:
+        config = default_config()
+        snap = _snap_with_evidence(
+            [{"id": "art_V", "role": "validation", "source_type": "artifact"}]
+        )
+        ok, failures = validate_completion_policy(config, snap, "pr_open")
+        assert ok is True
+        assert failures == []
+
+    def test_in_validation_description_carries_the_bar(self) -> None:
+        config = default_config()
+        desc = config["workflow"]["descriptions"]["in_validation"]
+        assert "I saw it work" in desc
+
+    def test_opinionated_display_name(self) -> None:
+        config = default_config("opinionated")
+        assert config["workflow"]["display_names"]["in_validation"] == "seeing it work"

--- a/tests/test_core/test_events.py
+++ b/tests/test_core/test_events.py
@@ -447,3 +447,24 @@ class TestCountReviewReworkCycles:
             _status_event("pr_open", "done"),
         ]
         assert count_review_rework_cycles(events) == 0
+
+    def test_counts_in_validation_to_in_progress(self) -> None:
+        events = [
+            _status_event("review", "in_validation"),
+            _status_event("in_validation", "in_progress"),
+        ]
+        assert count_review_rework_cycles(events) == 1
+
+    def test_counts_in_validation_to_in_planning(self) -> None:
+        events = [
+            _status_event("review", "in_validation"),
+            _status_event("in_validation", "in_planning"),
+        ]
+        assert count_review_rework_cycles(events) == 1
+
+    def test_does_not_count_in_validation_to_pr_open(self) -> None:
+        events = [
+            _status_event("review", "in_validation"),
+            _status_event("in_validation", "pr_open"),
+        ]
+        assert count_review_rework_cycles(events) == 0

--- a/tests/test_core/test_next.py
+++ b/tests/test_core/test_next.py
@@ -159,6 +159,19 @@ class TestSelectNextExclusions:
         snaps = [_snap("task_ip", status="in_progress")]
         assert select_next(snaps) is None
 
+    def test_excludes_pr_open_even_in_custom_ready(self) -> None:
+        """pr_open waits on external review/merge — defensively excluded."""
+        snaps = [_snap("task_pr", status="pr_open")]
+        assert select_next(snaps, ready_statuses=frozenset({"pr_open"})) is None
+
+    def test_in_validation_eligible_with_custom_ready(self) -> None:
+        """in_validation is actionable agent work (run the e2e validation),
+        so unlike pr_open it is NOT in EXCLUDED_STATUSES (LAT-233)."""
+        snaps = [_snap("task_val", status="in_validation")]
+        result = select_next(snaps, ready_statuses=frozenset({"in_validation"}))
+        assert result is not None
+        assert result["id"] == "task_val"
+
 
 class TestSelectNextAssignment:
     """Assignment-based filtering."""

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -454,9 +454,11 @@ class TestTripleReviewSpawn:
         )
         assert "/trident-plan-review LAT-42" in prompt
         assert "Review Verdict Routing" in prompt
-        # Routing table outcomes
-        for outcome in ("pr_open", "in_progress", "in_planning"):
+        # Routing table outcomes — PASS routes to in_validation (LAT-233);
+        # the PR opens only after validation evidence is recorded.
+        for outcome in ("in_validation", "in_progress", "in_planning"):
             assert outcome in prompt
-        # Complex findings route to the needs-human flag, not a status.
+        assert "| PASS, fixes done                   | in_validation" in prompt
+        # Complex findings route to the needs-human flag, not a status (LAT-232).
         assert "lattice needs-human LAT-42" in prompt
         assert "agent:trident-pane-LAT-42" in prompt


### PR DESCRIPTION
## Summary

Adds an **e2e-validation stage** to the default workflow and bakes validate-what-you-ship culture into every surface agents actually read.

```
backlog → in_planning → planned → in_progress → review → in_validation → pr_open → done
```

Local review examines the diff; `in_validation` proves the change works against a **running system** (browser automation, simulator MCP, curl flows) before the PR opens — so the PR humans see has survived both gates. The bar: **"I saw it work," not "I think it should work."**

## Design decisions

- **One status, queue implicit** (`in_validation`), per the ticket's lean-minimal steer — no `ready_for_validation` pair.
- **Status skippable, evidence not.** `review → pr_open` and `review → done` remain legal, but a new completion policy on `pr_open` requires recorded `validation`-role evidence (`lattice attach/comment --role validation`) on *every* path in. Docs-only work records a one-line N/A justification — explicit, never silent. Same teeth as `done: require review`. Escape hatches unchanged (`needs_human`/`cancelled` bypass, `--force --reason`).
- **Validation failure routes like review rework** — `in_progress` (impl-level) or `in_planning` (plan-level) — and counts toward the 3-cycle safety valve (`count_review_rework_cycles` gains `in_validation` as origin). No `in_validation → review` backflow; rework re-enters through the review gate.
- **`lattice next` keeps `in_validation` eligible** (active agent work, unlike passive `pr_open`). WIP limit 5, same as review.
- **Trident handoff reroute** (caught by plan review): the triple-mode reviewer's PASS routing went straight to `pr_open`, which would have hit the new policy with zero evidence — a self-inflicted break. PASS now routes to `in_validation`; opening the PR belongs after validation.
- **No dashboard changes** — board columns derive from `config.workflow.statuses` at runtime.
- **Existing instances unaffected** — config is instance data; new inits get the stage (LAT-213 precedent). The init-interview ticket (depends on this) makes the stage opt-in/out for non-Stage-11 users.
- **Future work:** auto-firing a validation runner on `→ in_validation` is the runner ticket's job; the trigger set in `task_cmds.py` is unchanged.

## Culture surfaces

- `templates/claude_md_block.py`: lifecycle diagram brought current (gains `in_validation` *and* `pr_open`, which it predated), a **Validate** sub-agent row, and a new **"The Validation Gate"** section with tool pointers and the evidence ritual.
- `skills/lattice/SKILL.md`: lifecycle diagram + validation-gate paragraph.
- `STATUS_DESCRIPTIONS` + opinionated preset name `"seeing it work"`; new `in_validation` CLI hint carries the tools and the ritual.

## Adjacent one-line gap fixes (flagged per plan D8)

- `pr_open` c11 visuals/labels (LAT-213 left them out; color made distinct after review nit).
- Claim guard now covers `in_validation`/`pr_open`.
- Auto-fired code-review hint's stale `then: done` reconciled with the manual branch — both now `in_validation`.
- `WipLimits` TypedDict gains `in_validation`/`pr_open` fields.

## Test evidence

- **1896 tests pass**, ruff clean (check + format).
- New coverage: transition matrix, `pr_open` evidence gating both directions (`COMPLETION_BLOCKED` without, passes with), rework-cycle counting from `in_validation`, cycle-limit trip via validation failures, no-backflow, `next` eligibility vs `pr_open` exclusion, trident PASS-routing string, opinionated display name, hint content.
- **E2e-validated** (dogfooding the very culture this ships): fresh `lattice init` in a temp dir with the worktree CLI, task walked through every gate — review hint → `in_validation`, culture hint with evidence ritual, `pr_open` blocked then unblocked by `--role validation` evidence, `done` still gated on review role.

## Coordination

Sibling ticket (needs_human → flag) edits the same workflow-config surfaces concurrently; this diff only *adds* `in_validation` entries and never touches `needs_human` lines — conflicts, if any, reconcile at the merge layer.

Plan + reviews on LAT-233: plan-review PASS (1 major folded in — the trident reroute), code-review PASS (art_01KT7XWJJSMNXJ2W1HXYY6YC4R).

🤖 Generated with [Claude Code](https://claude.com/claude-code)