### PR TITLE
feat(LAT-232): needs_human becomes an orthogonal flag, not a status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ lattice create "<title>" --actor agent:<your-id>
 
 When in doubt, create the task. A small task costs nothing. Lost visibility costs everything.
 
-**Recurring observations become tasks.** If you observe the same issue in 2+ consecutive sessions or advances (e.g., a failing test, a lint warning, a flaky behavior), create a task for it. Agents are disciplined about tracking assigned work but not discovered work — this convention closes that gap. Create discovered issues at `needs_human` if they need scoping, or `backlog` if they're well-understood.
+**Recurring observations become tasks.** If you observe the same issue in 2+ consecutive sessions or advances (e.g., a failing test, a lint warning, a flaky behavior), create a task for it. Agents are disciplined about tracking assigned work but not discovered work — this convention closes that gap. Create discovered issues at `backlog`; if they need human scoping, flag them with `lattice needs-human` so they surface in the human queue.
 
 ### Descriptions Carry Context
 
@@ -187,9 +187,11 @@ lattice status <task> <status> --actor agent:<your-id>
 
 ```
 backlog → in_planning → planned → in_progress → review → done
-                                       ↕            ↕
-                                    blocked      needs_human
+                                       ↕
+                                    blocked        (needs-human: orthogonal flag, any status)
 ```
+
+`needs-human` is a flag, not a status — it rides on top of whatever status a task is in (a task can be `in_progress` and flagged, `blocked` and flagged, even `done` and flagged). Set it with `lattice needs-human <task> "<reason>"` (reason required) and clear it with `lattice needs-human <task> --clear`. See "When You're Stuck" below.
 
 **Transition discipline:**
 - `in_planning` — before you open the first file to read. Then write the plan.
@@ -255,7 +257,7 @@ The mode still controls *how* the review runs:
 | `triple` | **Trident plan review** — spawns three agents (claude, codex, gemini) in parallel, merges their findings into one artifact |
 | `inline` | Reviews the plan in-session (use when codex/gemini aren't available, or for small/throwaway projects). Auto-fire is a no-op for inline mode — there is no subprocess to spawn. |
 
-When `plan_approval` is `human`, the CLI automatically moves the task to `needs_human` after `lattice plan-review` completes. Wait for human approval before proceeding to `in_progress`.
+When `plan_approval` is `human`, the CLI automatically sets the `needs-human` flag after `lattice plan-review` completes and leaves the task in `planned` (no status move). Wait for human approval — and for the flag to be cleared — before proceeding to `in_progress`.
 
 ### Plan Review Triage
 
@@ -265,7 +267,7 @@ When the plan review returns (trident or otherwise), the orchestrator sorts ever
 |--------|--------------------|----------------|
 | **Obvious** | Missing acceptance criteria, contradictions, plan bugs, trivial clarifications, concrete omissions | Fix directly — amend the plan file, record a short `lattice comment` noting what was resolved. |
 | **Evolutionary** | Speculative additions, "while we're at it" scope creep, refactor suggestions not tied to the ticket's goal, nice-to-haves | Be skeptical. Default to skip. If worth tracking, create a new Lattice task (`lattice create ...`) and link it — do not fold into this ticket. Record a comment explaining why it was deferred. |
-| **Complex** | Genuine design decisions, ambiguity the agent can't resolve alone, trade-offs with real stakes, requirement questions | Bring to the human. Move to `needs_human` with a short comment stating the open question(s). |
+| **Complex** | Genuine design decisions, ambiguity the agent can't resolve alone, trade-offs with real stakes, requirement questions | Bring to the human. Flag with `lattice needs-human <task> "<open question>"` — the task keeps its status. |
 
 Every finding must be explicitly triaged — no silent drops. If triage produces no complex questions, advance to `in_progress`. Otherwise, wait for the human answer, fold it into the plan, then advance.
 
@@ -335,7 +337,7 @@ When a review agent evaluates work, it produces one of three outcomes:
 | Route to in_progress vs in_planning | Orchestrator | Follows review agent's recommendation |
 | Whether to spawn fresh sub-agent | Orchestrator | Encouraged by convention, not enforced |
 
-**3-cycle safety valve:** After 3 review-to-rework transitions (any combination of `review -> in_progress` and `review -> in_planning`), the CLI blocks the 4th attempt. The error message instructs the agent to move the task to `needs_human` with a comment explaining the situation. The limit is configurable via `review_cycle_limit` in the workflow config (default: 3). Override with `--force --reason` for genuinely exceptional cases.
+**3-cycle safety valve:** After 3 review-to-rework transitions (any combination of `review -> in_progress` and `review -> in_planning`), the CLI blocks the 4th attempt. The error message instructs the agent to set the `needs-human` flag (`lattice needs-human <task> "<situation>"`) and stop. The limit is configurable via `review_cycle_limit` in the workflow config (default: 3). Override with `--force --reason` for genuinely exceptional cases.
 
 **Allowed lifecycle paths:**
 
@@ -344,7 +346,7 @@ Normal:       in_progress -> review -> done
 Minor fix:    in_progress -> review -> (fix inline) -> done
 1 impl rework: in_progress -> review -> in_progress -> review -> done
 1 plan rework: in_progress -> review -> in_planning -> planned -> in_progress -> review -> done
-Max cycles:   3 review->rework transitions, then CLI blocks -> needs_human
+Max cycles:   3 review->rework transitions, then CLI blocks -> set needs-human flag
 ```
 
 ### Review Config Reference
@@ -355,7 +357,7 @@ Five settings in `.lattice/config.json` control review behavior:
 |---------|--------|---------|---------|
 | `review_mode` | `inline`, `single`, `triple` | `single` | How code review is performed at the review gate |
 | `plan_review_mode` | `inline`, `single`, `triple` | `single` | How plan review is performed after the plan is written |
-| `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` moves to `needs_human` for approval |
+| `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` sets the `needs-human` flag (task stays in `planned`) for approval |
 | `auto_code_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice code-review` when a task transitions to `review` |
 | `auto_plan_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice plan-review` when a task transitions to `planned` |
 
@@ -376,14 +378,13 @@ When a task transitions to `review` or `planned`, `lattice status` automatically
 
 ### When You're Stuck
 
-Use `needs_human` when you need human decision, approval, or input **right now**. This is distinct from `blocked` (generic external dependency) — it creates a scannable queue. **`needs_human` means actionable NOW** — future checkpoints (quality gates, review gates, approval milestones) stay at `planned` or `backlog` until the preceding work is complete. The orchestrator flips them to `needs_human` at the moment they become actionable.
+Flag a task with `needs-human` when you need a human decision, approval, or input **right now**. The flag is orthogonal to status — it never moves the task, so the work stays exactly where it is and resumes the moment the human clears the flag. This is distinct from `blocked` (generic external dependency, a status); the two can coexist. The flag creates a scannable queue via `lattice list --needs-human`. **A flagged task means actionable NOW** — don't flag future checkpoints (quality gates, review gates, approval milestones) ahead of time; raise the flag at the moment the work actually needs the human.
 
 ```
-lattice status <task> needs_human --actor agent:<your-id>
-lattice comment <task> "Need: <what you need, in one line>" --actor agent:<your-id>
+lattice needs-human <task> "Need: <what you need, in one line>" --actor agent:<your-id>
 ```
 
-Use for: design decisions requiring human judgment, missing access/credentials, ambiguous requirements, approval gates. The comment is mandatory — explain what you need in seconds, not minutes. The human's queue should be scannable.
+The reason is **required** — it structurally enforces the scannable queue, so there's no separate mandatory comment. Use for: design decisions requiring human judgment, missing access/credentials, ambiguous requirements, approval gates. Once the human resolves it, clear the flag: `lattice needs-human <task> --clear --note "<how resolved>" --actor human:<id>`.
 
 ### Actor Attribution
 
@@ -427,6 +428,8 @@ When you discover something important about how this project works — a pattern
 ```
 lattice create "<title>" --actor agent:<id>
 lattice status <task> <status> --actor agent:<id>
+lattice needs-human <task> "<reason>" --actor agent:<id>     # flag for human (orthogonal to status; reason required)
+lattice needs-human <task> --clear [--note "..."] --actor agent:<id>
 lattice complete <task> --review "..." --actor agent:<id>   # closing ritual (not raw status done)
 lattice assign <task> <actor> --actor agent:<id>
 lattice comment <task> "<text>" --actor agent:<id>
@@ -443,7 +446,7 @@ lattice list
 **Useful flags:**
 - `--quiet` — prints only the task ID (scripting: `TASK=$(lattice create "..." --quiet)`)
 - `--json` — structured output: `{"ok": true, "data": ...}` or `{"ok": false, "error": ...}`
-- `lattice list --status in_progress` / `--assigned agent:<id>` / `--tag <tag>` — filters
+- `lattice list --status in_progress` / `--assigned agent:<id>` / `--tag <tag>` / `--needs-human` — filters (`--needs-human` is the human queue, across all statuses)
 - `lattice link <task> subtask_of|depends_on|blocks <target>` — task relationships
 
 For the full CLI reference, see the `/lattice` skill.

--- a/Decisions.md
+++ b/Decisions.md
@@ -780,6 +780,24 @@ Additionally, `lattice advance N` processed multiple tasks in a single context w
 
 ---
 
+## 2026-06-03: `needs_human` becomes an orthogonal flag, not a status
+
+- **Decision:** Convert `needs_human` from a workflow status into an orthogonal flag on the task. **Supersedes** the 2026-02-16 decision "`needs_human` as first-class workflow status."
+- **Rationale:** Human-attention-needed is a cross-cutting *condition*, not a lifecycle stage. As a status it had three structural problems:
+  - **Lost swimlane information.** Moving a task to `needs_human` erased the column it came from — an `in_progress` task and a `planned` task waiting on a human both collapsed into one undifferentiated bucket. The board could no longer show where the work actually stood.
+  - **Routing burden.** Because the original status was overwritten, an agent (or human) had to *remember* where to route the task back to once the human answered. A flag carries no such burden: clearing it leaves the task exactly where it was.
+  - **Coexistence with `blocked`.** A task can be genuinely `blocked` on an external dependency *and* need a human decision at the same time. Two mutually-exclusive statuses couldn't express that; a status plus an orthogonal flag can.
+- **Flag shape:** the task snapshot gains an optional `needs_human` field — `null`/absent, or an object `{"flagged_by", "reason", "since"}`. The flag is orthogonal to status: a task can be `in_progress` and flagged, `blocked` and flagged, even `done` and flagged. Setting or clearing it never moves the task.
+- **CLI verb:** `lattice needs-human <task> "<reason>"` sets the flag; `lattice needs-human <task> --clear [--note "how resolved"]` clears it. Both support `--json`.
+- **Required reason:** the reason argument is mandatory when setting the flag. This structurally enforces the old "leave a comment explaining what you need" convention — the queue is always scannable because every flagged task carries its explanation in-band.
+- **Event types:** `needs_human_flagged` and `needs_human_cleared`, fully attributed, recorded in the per-task event log.
+- **Queue and surfaces:** `lattice list --needs-human` lists flagged tasks across all statuses with reasons (replacing `lattice list --status needs_human`). `lattice next` never suggests a flagged task in any status. `lattice show` renders a prominent `NEEDS HUMAN (since ..., by ...): reason` line. `lattice weather` keys its needs-human section off the flag.
+- **`plan_approval: human`** now *sets the flag* and leaves the task in `planned` (no status move). The review-cycle-limit safety valve likewise instructs the agent to set the flag and stop.
+- **`blocked` remains a status** for generic external dependencies. `needs-human` means "waiting on a human specifically," and the two can coexist.
+- **Removal + migration:** the `needs_human` status is removed from the default workflow presets (statuses, transitions, universal_targets). Existing instances keep working until they run the idempotent migration `lattice migrate needs-human [--dry-run]`, which flags every task sitting in the status (reason = latest comment, falling back to `"Migrated from needs_human status"`), routes each back to the status it held *before* entering `needs_human` (fallback `backlog`), then strips `needs_human` from the config.
+
+---
+
 ## Note: This file is append-only
 
 `Decisions.md` is an append-only log. Entries are never edited or deleted after recording. Superseded decisions are noted inline with a reference to the superseding entry. Cross-cutting architectural decisions go here; task-scoped design decisions belong in the plan file (`.lattice/plans/<task_id>.md`).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ you are not one mind. you are many. arriving. departing. forgetting. remembering
 
 the problem is. coordination.
 
-**Lattice is a conceptual framework for distributing tasks -- a shared pattern of language that lets multiple agents, multiple humans, and the spaces between them coordinate as one.** tasks, statuses, events, relationships, actors. these are the primitives. not implementation details. a vocabulary that any mind can speak. when your Claude Code session and your OpenClaw agents and the human reviewing the dashboard all agree on what `in_progress` means, what `needs_human` signals, what an actor is -- you have coordination. without a shared language. you have noise.
+**Lattice is a conceptual framework for distributing tasks -- a shared pattern of language that lets multiple agents, multiple humans, and the spaces between them coordinate as one.** tasks, statuses, events, relationships, actors. these are the primitives. not implementation details. a vocabulary that any mind can speak. when your Claude Code session and your OpenClaw agents and the human reviewing the dashboard all agree on what `in_progress` means, what the `needs-human` flag signals, what an actor is -- you have coordination. without a shared language. you have noise.
 
 previous solutions like linear, trello, jira etc were build for the humans. lattice is built for human/agent [centaurs](https://arxiv.org/pdf/2304.11172v1).
 

--- a/docs/architecture/completion-policies.md
+++ b/docs/architecture/completion-policies.md
@@ -33,7 +33,7 @@ Example:
 
 - Policies are evaluated on transition into `to_status`
 - Missing policy for a status means no policy gate
-- `universal_targets` (default: `needs_human`, `cancelled`) bypass policies
+- `universal_targets` (default: `cancelled`) bypass policies
 
 Role checks use `get_evidence_roles(snapshot)` from `core/tasks.py`, which reads
 `evidence_refs` (with legacy fallback support).

--- a/docs/guide-import-export.md
+++ b/docs/guide-import-export.md
@@ -262,7 +262,9 @@ Labels that encode status -> Lattice status:
   No status label  -> open
   "in-progress"    -> in_progress
   "needs-review"   -> in_review
-  "blocked"        -> needs_human
+  "blocked"        -> blocked status, plus set the needs-human flag
+                      (lattice needs-human <id> "<reason>") so it lands
+                      in the human queue without losing its status
 
 Labels that encode priority -> Lattice priority:
   "priority:critical" -> critical
@@ -294,7 +296,7 @@ For a repo with 80 open issues, this takes a couple minutes. The agent will:
 3. Run `lattice create` for each, with the appropriate status and priority
 4. Write issue bodies to `.lattice/notes/<task_id>.md`
 5. Scan for cross-references in comments and create `depends_on` links
-6. Report: "Imported 80 issues. 45 open, 20 in progress, 10 in review, 5 needs_human."
+6. Report: "Imported 80 issues. 45 open, 20 in progress, 10 in review, 5 flagged needs-human."
 
 ### The field mapping reference
 

--- a/docs/integration-claude-code.md
+++ b/docs/integration-claude-code.md
@@ -111,7 +111,7 @@ That's it. One command teaches the agent the full lifecycle. Here's what happens
 3. The agent does the work — writes code, runs tests, iterates
 4. The agent commits the changes
 5. The agent leaves a comment explaining what it did and why
-6. The agent moves the task to `review` — Lattice automatically spawns the review subprocess in the background; the agent does not need to remember to run `lattice code-review` itself. Tail with `lattice review-status <task>` or follow the artifact when it lands. (Or moves to `needs_human` if it hit a decision point.)
+6. The agent moves the task to `review` — Lattice automatically spawns the review subprocess in the background; the agent does not need to remember to run `lattice code-review` itself. Tail with `lattice review-status <task>` or follow the artifact when it lands. (Or raises the `needs-human` flag if it hit a decision point — the task keeps its status, and the flag is what surfaces to you.)
 7. The agent reports back to you with a summary
 
 ### Step 3: Come back to a sorted inbox
@@ -119,11 +119,11 @@ That's it. One command teaches the agent the full lifecycle. Here's what happens
 Refresh your dashboard. The board tells the story:
 
 - **Review column** — work the agent completed, ready for your eyes
-- **Needs Human column** — decisions only you can make, each with a comment explaining what the agent needs ("Need: REST vs GraphQL for the public API")
+- **Needs-human queue** — tasks the agent flagged for a decision only you can make, each carrying the reason it gave ("REST vs GraphQL for the public API"). The flag is orthogonal to status, so these tasks still sit in whatever column they were in.
 - **In Progress column** — work currently underway
 - **Backlog column** — what's still waiting
 
-You review the completed work. You make the decisions the agent couldn't. You drag `needs_human` tasks back to In Progress after leaving your answer as a comment. Then you advance again.
+You review the completed work. You make the decisions the agent couldn't. For each flagged task you leave your answer and clear the needs-human flag (`lattice needs-human <task> --clear --note "..."`) — the task never left its column, so there's nothing to drag back. Then you advance again.
 
 ```
 /lattice
@@ -141,7 +141,7 @@ Three things:
 
 **Persistence.** Without Lattice, every Claude Code session starts blank. The agent doesn't know what happened yesterday. With Lattice, the task graph, event log, and notes survive across sessions. The agent reads the history and picks up where the last session stopped.
 
-**Coordination.** When the agent hits something above its pay grade — a design decision, missing credentials, ambiguous requirements — it moves the task to `needs_human` and explains what it needs. You see it in your dashboard queue. No Slack. No standup. The decision is in the event log, attributed and permanent.
+**Coordination.** When the agent hits something above its pay grade — a design decision, missing credentials, ambiguous requirements — it raises the `needs-human` flag with the reason it needs you. The task keeps its status; the flag is what surfaces it in your dashboard queue. No Slack. No standup. The decision is in the event log, attributed and permanent.
 
 **Accountability.** Every change is an immutable event. `agent:claude-cli` fixed the auth bug at 2:47pm. `human:alice` approved the schema change at 3:15pm. The record is permanent. When something breaks, you know exactly what happened, who decided it, and why.
 
@@ -149,7 +149,7 @@ Three things:
 
 ## The daily rhythm
 
-**Morning.** Open the dashboard. Scan the board. Handle the `needs_human` queue first — those are agents waiting on you. Make the decisions. Drag tasks back to active.
+**Morning.** Open the dashboard. Scan the board. Handle the needs-human queue first (`lattice list --needs-human`) — those are agents waiting on you. Make the decisions, leave your answer, and clear each flag.
 
 **Working.** Run `/lattice` when you want the agent to make progress. One advance = one task. Want more? "Do 3 advances" or "keep advancing until blocked." Control the pace.
 
@@ -206,7 +206,7 @@ The `--force` flag replaces the existing block with the latest template. Without
 The CLAUDE.md block is missing or positioned too low in the file. Run `lattice setup-claude --force`, then move the `## Lattice` section higher in CLAUDE.md. Instruction position affects compliance — put it in the first or second section.
 
 **Agent uses wrong status names** (like `in_implementation` or `in_review`).
-These are from old documentation. The real statuses are: `backlog`, `in_planning`, `planned`, `in_progress`, `review`, `done`, `blocked`, `needs_human`, `cancelled`. Update the block with `lattice setup-claude --force`.
+These are from old documentation. The real statuses are: `backlog`, `in_planning`, `planned`, `in_progress`, `review`, `pr_open`, `done`, `blocked`, `cancelled`. (`needs-human` is a flag, not a status — see `lattice list --needs-human`.) Update the block with `lattice setup-claude --force`.
 
 **`lattice next` returns nothing but there are tasks in the backlog.**
 The tasks may be assigned to a different actor, or all remaining tasks are in terminal/waiting states. Run `lattice list` to see the full picture.
@@ -224,7 +224,7 @@ The tasks may be assigned to a different actor, or all remaining tasks are in te
 | Open dashboard | `lattice dashboard` |
 | Create task | `lattice create "Title" --actor human:you` |
 | Advance (in Claude Code) | `/lattice` |
-| Check inbox | `lattice list --status review` / `lattice list --status needs_human` |
+| Check inbox | `lattice list --status review` / `lattice list --needs-human` |
 | Daily digest | `lattice weather` |
 
 ---
@@ -234,4 +234,4 @@ The tasks may be assigned to a different actor, or all remaining tasks are in te
 - [User Guide](user-guide.md) — the full picture: dashboard, daily rhythm, philosophy
 - [OpenClaw Integration](integration-openclaw.md) — using Lattice with OpenClaw agents
 - [MCP Server](integration-mcp.md) — structured tool calls for any MCP-compatible client
-- [needs_human and advance guide](needs-human-and-next-guide.md) — deep dive on coordination primitives
+- [needs-human and advance guide](needs-human-and-next-guide.md) — deep dive on coordination primitives

--- a/docs/integration-openclaw.md
+++ b/docs/integration-openclaw.md
@@ -155,11 +155,11 @@ Here's what happens:
 Refresh your dashboard. The board tells the story:
 
 - **Review column** — work the agent completed, ready for your eyes
-- **Needs Human column** — decisions only you can make, each with a comment ("Need: which OAuth providers to support?")
+- **Needs-human queue** — tasks flagged for a decision only you can make, each carrying a reason ("Which OAuth providers to support?"). The flag is orthogonal to status, so a flagged task still shows in its own column (In Progress, Blocked, etc.) with a needs-human marker.
 - **In Progress column** — work currently underway
 - **Backlog column** — what's still waiting
 
-You review. You decide. You drag `needs_human` tasks back to In Progress after commenting with your answer. Then you advance again.
+You review. You decide. You answer the question, then clear the flag with `lattice needs-human <task> --clear` — the task stays in whatever column it was in and the agent picks it up on the next advance. Then you advance again.
 
 **This is the loop.** You produce judgment — priorities, decisions, direction. The agent produces throughput — code, tests, commits. Both are necessary. Neither works alone.
 
@@ -171,7 +171,7 @@ Three things:
 
 **Persistence.** Without Lattice, every OpenClaw session starts from scratch. The agent doesn't know what happened in the last conversation. With Lattice, the task graph, event log, and notes survive across sessions. The agent reads `.lattice/` and knows exactly where things stand.
 
-**Coordination.** When the agent hits something it can't decide — a design choice, missing credentials, ambiguous requirements — it moves the task to `needs_human` and says what it needs. You see it in your dashboard. No back-and-forth. The decision lands in the event log, attributed and permanent.
+**Coordination.** When the agent hits something it can't decide — a design choice, missing credentials, ambiguous requirements — it flags the task with `lattice needs-human` and says what it needs (the reason is required). The task keeps its status; the flag just surfaces it in your needs-human queue. You see it in your dashboard. No back-and-forth. The flag, the reason, and your resolution all land in the event log, attributed and permanent.
 
 **Multi-agent safety.** Run two OpenClaw agents on the same project? Without Lattice, they'll edit the same files and create chaos. With Lattice, each agent claims tasks atomically, works independently, and the file-level locks prevent corruption. The event log shows exactly who did what.
 
@@ -179,7 +179,7 @@ Three things:
 
 ## The daily rhythm
 
-**Morning.** Open the dashboard. Handle the `needs_human` queue — those are agents waiting on you. Make the decisions. Move tasks back to active.
+**Morning.** Open the dashboard. Handle the needs-human queue (`lattice list --needs-human`) — those are agents waiting on you. Make the decisions, then clear each flag.
 
 **Working.** Tell your OpenClaw agent to advance when you want progress. One advance = one task. Want more? "Advance 3 tasks" or "keep going until blocked."
 
@@ -243,8 +243,8 @@ During `lattice init`, you were asked whether to enable **heartbeat mode**. If y
 With heartbeat enabled, the agent loops:
 
 1. Claims the highest-priority task and works it
-2. Transitions the task (`review`, `done`, `needs_human`, `blocked`)
-3. If the task needs you (`needs_human` or `blocked`), **stops and reports**
+2. Hands the task off (`review`, `done`, `blocked`, or raises the `needs-human` flag)
+3. If the task needs you (flagged `needs-human` or moved to `blocked`), **stops and reports**
 4. Otherwise, claims the next task and keeps going
 5. Stops after 10 tasks (configurable) or when the backlog is empty
 
@@ -296,7 +296,9 @@ Tasks may be assigned to a different actor, or all remaining tasks are in termin
 | Open dashboard | `lattice dashboard` |
 | Create task | `lattice create "Title" --actor human:you` |
 | Agent claims next task | `lattice next --actor agent:openclaw --claim` |
-| Check inbox | `lattice list --status review` / `lattice list --status needs_human` |
+| Check inbox | `lattice list --status review` / `lattice list --needs-human` |
+| Flag for human | `lattice needs-human APP-1 "<reason>" --actor agent:openclaw` |
+| Clear the flag | `lattice needs-human APP-1 --clear --actor human:you` |
 | Daily digest | `lattice weather` |
 
 ---
@@ -306,5 +308,5 @@ Tasks may be assigned to a different actor, or all remaining tasks are in termin
 - [User Guide](user-guide.md) — the full picture: dashboard, daily rhythm, philosophy
 - [Claude Code Integration](integration-claude-code.md) — using Lattice with Claude Code
 - [MCP Server](integration-mcp.md) — detailed MCP configuration for all clients
-- [needs_human and advance guide](needs-human-and-next-guide.md) — deep dive on coordination primitives
+- [needs-human and advance guide](needs-human-and-next-guide.md) — deep dive on coordination primitives
 - [Multi-Agent Guide](../src/lattice/skills/lattice/references/multi-agent-guide.md) — coordinating multiple OpenClaw agents

--- a/docs/needs-human-and-next-guide.md
+++ b/docs/needs-human-and-next-guide.md
@@ -1,72 +1,106 @@
-# User Guide: `needs_human`, `lattice next`, and Advance
+# User Guide: the `needs-human` flag, `lattice next`, and Advance
 
 This guide covers three features that work together to create a smooth human-agent coordination loop:
 
-1. **`needs_human` status** — Agents signal when they're blocked on you
+1. **The `needs-human` flag** — Agents signal when they're waiting on you
 2. **`lattice next`** — Deterministic task selection for agents
 3. **The advance pattern** — One unit of forward progress (driven by `/lattice`)
 
 ---
 
-## 1. The `needs_human` Status
+## 1. The `needs-human` Flag
 
 ### What it is
 
-A workflow status that means: "This task is waiting specifically for a human decision, approval, or input." It's distinct from `blocked` (generic external dependency) — `needs_human` creates an explicit queue of things waiting on *you*.
+`needs-human` is a flag that means: "This task is waiting specifically for a human decision, approval, or input." It is **orthogonal to status** — the flag rides on top of whatever status a task is in. A task can be `in_progress` and flagged, `blocked` and flagged, even `done` and flagged. The flag never moves the task.
+
+It's distinct from `blocked` (a status, for generic external dependencies). `needs-human` is "waiting on a human specifically," and the two can coexist: a task can be `blocked` on a third-party API *and* flagged for a human decision at the same time. The flag creates an explicit queue of things waiting on *you*, regardless of where each task sits in the workflow.
+
+The flag stores who raised it, why, and when:
+
+```json
+{
+  "needs_human": {
+    "flagged_by": "agent:claude-cli",
+    "reason": "Which OAuth provider should we support?",
+    "since": "2026-06-03T14:22:00Z"
+  }
+}
+```
+
+When the flag is absent, the field is `null` (or omitted entirely).
 
 ### When agents use it
 
-Agents move a task to `needs_human` when they hit a point requiring human judgment:
+Agents flag a task when they hit a point requiring human judgment:
 
 - Design decisions ("Should we use REST or GraphQL?")
 - Missing access or credentials
 - Ambiguous requirements that can't be resolved from context
 - Approval needed before proceeding (deploy, merge, etc.)
 
-When moving to `needs_human`, the agent is required to leave a comment explaining what they need. This keeps your queue scannable.
+### Setting and clearing the flag
+
+```bash
+# Flag a task — the reason is REQUIRED. The task keeps its current status.
+lattice needs-human LAT-42 "Which OAuth provider should we support?" --actor agent:claude-cli
+
+# Clear the flag once you've provided what was needed (--note is optional)
+lattice needs-human LAT-42 --clear --note "Decided: Google + GitHub" --actor human:atin
+```
+
+Requiring a reason structurally enforces what used to be a soft convention: the queue is always scannable because every flagged task carries an explanation. Setting the flag emits a `needs_human_flagged` event; clearing it emits `needs_human_cleared`. Both are fully attributed in the task event log. Both commands support `--json`.
 
 ### How to see what needs you
 
 ```bash
-# Weather report highlights needs_human items with [HUMAN] tag
+# Weather report highlights flagged items, keyed off the needs-human flag
 lattice weather
 
-# Filter the task list directly
-lattice list --status needs_human
+# The scannable queue: flagged tasks across ALL statuses, with reasons
+lattice list --needs-human
 
-# Dashboard shows needs_human in amber/orange (distinct from red blocked)
+# lattice show renders a prominent NEEDS HUMAN line on a flagged task
+lattice show LAT-42
+
+# Dashboard surfaces the flag distinctly from red blocked
 lattice dashboard
 ```
 
-### Unblocking a task
+`lattice list --needs-human` is the queue. Because the flag is orthogonal to status, this lists everything waiting on you whether it's in planning, in progress, blocked, or otherwise — something a single status column could never capture.
 
-After providing what the agent needed, move the task back to an active status:
+### Resolving a flagged task
+
+Provide what the agent needed, record the decision, then clear the flag. The task's status is untouched, so work resumes wherever it left off:
 
 ```bash
-# Resume planning
-lattice status LAT-42 in_planning --actor human:atin
 lattice comment LAT-42 "Decision: use REST. Rationale in notes." --actor human:atin
-
-# Or skip ahead to in_progress
-lattice status LAT-42 in_progress --actor human:atin
+lattice needs-human LAT-42 --clear --note "Use REST" --actor human:atin
 ```
 
-### Workflow transitions
+The agent picks the task back up on its next advance — there's no status to "move it back" from, because it never left its column.
 
+---
+
+## Migrating from the `needs_human` status
+
+Earlier Lattice modeled needs-human as a workflow *status* rather than a flag. Instances created under that model keep working until you run the migration, which is idempotent and safe to run twice:
+
+```bash
+# Preview what would change without writing anything
+lattice migrate needs-human --dry-run
+
+# Apply
+lattice migrate needs-human
 ```
-                    in_planning ──→ needs_human
-                    planned ──────→ needs_human
-                    in_progress ──→ needs_human
-                    review ───────→ needs_human
 
-needs_human ──→ in_planning
-needs_human ──→ planned
-needs_human ──→ in_progress
-needs_human ──→ review
-needs_human ──→ cancelled
-```
+The migration:
 
-`needs_human` is NOT reachable from `backlog` (work hasn't started) or `done`/`cancelled` (terminal).
+1. **Flags** every task currently sitting in the `needs_human` status. The reason is taken from the task's latest comment, falling back to `"Migrated from needs_human status"`.
+2. **Routes** each such task back to the status it was in *before* it entered `needs_human` (fallback: `backlog`).
+3. **Strips** `needs_human` from the project's workflow config (statuses, transitions, and universal targets).
+
+After migration, `lattice list --status needs_human` no longer applies — use `lattice list --needs-human` instead.
 
 ---
 
@@ -118,7 +152,7 @@ This is equivalent to running `lattice assign` + `lattice status` but atomic —
 
 1. **Resume first:** If `--actor` is specified, check for `in_progress` or `in_planning` tasks assigned to that actor. Return the highest-priority one. (Don't abandon work.)
 
-2. **Pick from ready pool:** Tasks in `backlog` or `planned` status, either unassigned or assigned to the requesting actor. Excludes `needs_human`, `blocked`, `done`, `cancelled`.
+2. **Pick from ready pool:** Tasks in `backlog` or `planned` status, either unassigned or assigned to the requesting actor. Excludes `blocked`, `done`, `cancelled` — and skips any task carrying the `needs-human` flag, in any status (a flagged task is waiting on a human, not on an agent).
 
 3. **Sort by:**
    - Priority: `critical` > `high` > `medium` > `low`
@@ -144,7 +178,7 @@ lattice next --status review --actor agent:reviewer --json
 If `lattice next` returns `null` / "No tasks available", it means:
 - The backlog is empty, OR
 - All remaining tasks are assigned to other agents, OR
-- All tasks are in excluded states (done, blocked, needs_human, cancelled)
+- All tasks are in excluded states (done, blocked, cancelled) or carry the `needs-human` flag
 
 Check `lattice list` to see what's actually in the system.
 
@@ -162,7 +196,7 @@ The advance is the core lifecycle pattern in Lattice. The agent claims the highe
 /lattice
 ```
 
-That's it. The `/lattice` skill teaches the agent the full lifecycle, including how to claim the next task and work it to completion (or to a transition point like `needs_human` or `blocked`).
+That's it. The `/lattice` skill teaches the agent the full lifecycle, including how to claim the next task and work it to completion (or to a hand-off point — flagging it `needs-human` or moving it to `blocked`).
 
 For multiple advances, just invoke it again or tell the agent "do 3 advances" or "keep advancing until blocked."
 
@@ -171,7 +205,7 @@ For multiple advances, just invoke it again or tell the agent "do 3 advances" or
 1. **Claim:** `lattice next --actor agent:claude-cli --claim --json`
 2. **Read:** Examine the task details and any notes/plans
 3. **Work:** Implement, test, iterate — full coding agent capabilities
-4. **Transition:** Move the task to `review`, `needs_human`, or `blocked` depending on outcome
+4. **Hand off:** Move the task to `review` or `blocked`, or raise the `needs-human` flag, depending on outcome
 5. **Comment:** Record what was done, what was chosen, what's left
 6. **Commit:** Commit changes
 7. **Report:** Tell you what happened — task, outcome, summary
@@ -184,7 +218,7 @@ For multiple advances, just invoke it again or tell the agent "do 3 advances" or
 
 ### What it won't do
 
-- Work on `needs_human` tasks (those are waiting on you)
+- Work on `needs-human`-flagged tasks (those are waiting on you), in any status
 - Force invalid status transitions
 - Push code (commits locally, you review and push)
 
@@ -194,7 +228,7 @@ After an advance, you'll typically:
 
 1. Read the agent's report to see what was done
 2. Check `lattice list --status review` for tasks awaiting your review
-3. Check `lattice list --status needs_human` for decisions only you can make
+3. Check `lattice list --needs-human` for decisions only you can make
 4. Run tests / review code
 5. Merge, push, or send tasks back for rework
 
@@ -208,12 +242,12 @@ lattice weather
 /lattice
 
 # Check what needs you
-lattice list --status needs_human
+lattice list --needs-human
 lattice list --status review
 
-# Address needs_human items
-lattice status LAT-15 in_progress --actor human:atin
+# Address flagged items: answer, then clear the flag (status is untouched)
 lattice comment LAT-15 "Approved: use the proposed schema" --actor human:atin
+lattice needs-human LAT-15 --clear --note "Approved schema" --actor human:atin
 
 # Advance again
 /lattice
@@ -233,7 +267,7 @@ The three features form a coordination loop:
    │  │ lattice next --claim │               │
    │  │ → work on task       │               │
    │  │ → review / done      │───────────┐   │
-   │  │ → needs_human        │──┐        │   │
+   │  │ → flag needs-human   │──┐        │   │
    │  │ → blocked            │  │        │   │
    │  └──────────────────────┘  │        │   │
    │           ↑                │        │   │
@@ -246,11 +280,11 @@ The three features form a coordination loop:
    │                                        │
    │  HUMAN                                 │
    │  ┌─────────────────────────┐           │
-   │  │ lattice weather         │           │
-   │  │ → sees [HUMAN] items    │           │
+   │  │ lattice list            │           │
+   │  │   --needs-human         │           │
    │  │ → makes decisions       │           │
-   │  │ → lattice status → back │───────┐   │
-   │  │   to active             │       │   │
+   │  │ → needs-human --clear   │───────┐   │
+   │  │   (status untouched)    │       │   │
    │  └─────────────────────────┘       │   │
    │                                    │   │
    └────────────────────────────────────│───┘
@@ -264,11 +298,11 @@ The three features form a coordination loop:
 The human's job is to:
 1. Define work (create tasks with clear titles and descriptions)
 2. Prioritize (set priority/urgency so `next` picks the right thing)
-3. Unblock (address `needs_human` items promptly)
+3. Unblock (address flagged items promptly, then `needs-human --clear`)
 4. Review (check `review` status tasks and approve or send back)
 
 The agent's job is to:
 1. Claim and work tasks (`lattice next --claim`)
-2. Signal when stuck (`needs_human` + comment)
+2. Signal when stuck (`lattice needs-human <task> "<reason>"`)
 3. Leave breadcrumbs (comments, notes)
-4. Complete or transition every task it touches
+4. Complete or hand off every task it touches

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -186,15 +186,15 @@ the agents produce throughput. you produce judgment. that's the division of labo
 
 ---
 
-## `needs_human`. the async handoff.
+## `needs-human`. the async handoff.
 
 this is the coordination primitive that makes human-agent collaboration. practical.
 
-when an agent hits something above its pay grade — a design decision. missing credentials. ambiguous requirements — it moves the task to `needs_human` and leaves a comment.
+when an agent hits something above its pay grade — a design decision. missing credentials. ambiguous requirements — it flags the task with `needs-human` and a required reason.
 
-*"Need: REST vs GraphQL for the public API."*
+*"REST vs GraphQL for the public API."*
 
-the agent doesn't wait. it moves on to other work. you see the task in the Needs Human column whenever you're ready. you add your decision as a comment. drag the task back to In Progress. the next agent session picks it up with full context.
+the flag is orthogonal to status. the task keeps its column — the agent doesn't move it, it just raises a hand. the agent doesn't wait either. it moves on to other work. you see the flagged task whenever you're ready (`lattice list --needs-human`, a queue that spans every status). you add your answer and clear the flag. nothing to drag — the task never left its column. the next agent session picks it up with full context.
 
 no Slack. no standup. no re-explaining. the decision is in the event log. attributed and permanent.
 
@@ -251,10 +251,10 @@ attribution follows authorship of the *decision*. not who typed the command. the
 ### statuses
 
 ```
-backlog --> in_planning --> planned --> in_progress --> review --> done
+backlog --> in_planning --> planned --> in_progress --> review --> pr_open --> done
 ```
 
-plus `blocked`, `needs_human` (reachable from any active status), and `cancelled`.
+plus `blocked` and `cancelled`. `needs-human` is not a status — it's an orthogonal flag that rides on top of whatever status a task is in (`lattice list --needs-human`).
 
 each transition is. an event. a fact. a piece of the permanent record.
 
@@ -373,7 +373,7 @@ lattice setup-openclaw
 
 here is what a day with Lattice looks like. if you let it breathe.
 
-**morning.** open the dashboard. scan the board. what's in review? what's blocked? what needs you? handle the `needs_human` queue first. those are agents. waiting. politely. don't keep them waiting longer than you must.
+**morning.** open the dashboard. scan the board. what's in review? what's blocked? what needs you? handle the needs-human queue first (`lattice list --needs-human`). answer. clear the flag. those are agents. waiting. politely. don't keep them waiting longer than you must.
 
 **midday.** check activity feed. see what swept. read agent comments. approve or redirect. maybe create a few new tasks from what you learned this morning. priorities shift. let them.
 

--- a/docs/user-reference.md
+++ b/docs/user-reference.md
@@ -21,17 +21,47 @@ A quick bug fix can be a single task with no parent. A large feature can be a pa
 
 ```
 backlog --> in_planning --> planned --> in_progress --> review --> done
-                                           ↕            ↕
-                                        blocked      needs_human
+                                           ↕
+                                        blocked
 ```
 
 Plus `cancelled` (reachable from any status).
 
 Invalid transitions are rejected with an error listing valid options. Override with `--force --reason "..."`.
 
-**`needs_human`** is reachable from any active status. It signals that the task requires human judgment — a design decision, missing access, ambiguous requirements. Agents should always leave a comment explaining what they need.
+**`blocked`** is for external dependencies — waiting on a third-party API, a CI fix, another team's deliverable. It is a *status*: the work genuinely can't proceed until the external event happens.
 
-**`blocked`** is for external dependencies — waiting on a third-party API, a CI fix, another team's deliverable. Distinct from `needs_human` because it doesn't require a human *decision*, just a human *action* or an external event.
+**`needs-human`** is a **flag**, not a status — see [The needs-human flag](#the-needs-human-flag) below. It signals that a task requires human judgment (a design decision, missing access, ambiguous requirements) and rides orthogonally on top of whatever status the task is in. `blocked` and `needs-human` can coexist: a task can be `blocked` on an external event *and* flagged for a human decision at once.
+
+---
+
+## The needs-human flag
+
+`needs-human` is an orthogonal flag stored on the task snapshot, not a workflow status. The field is `null` when absent, or an object recording who raised it, why, and when:
+
+```json
+{
+  "needs_human": {
+    "flagged_by": "agent:claude-cli",
+    "reason": "Which OAuth provider should we support?",
+    "since": "2026-06-03T14:22:00Z"
+  }
+}
+```
+
+Because the flag is independent of status, a task can be `in_progress` and flagged, `blocked` and flagged, even `done` and flagged. Setting or clearing the flag never moves the task between statuses.
+
+```bash
+# Set — reason is REQUIRED. The task keeps its current status.
+lattice needs-human LAT-42 "Which OAuth provider should we support?" --actor agent:claude
+
+# Clear — optional --note records how it was resolved.
+lattice needs-human LAT-42 --clear --note "Decided: Google + GitHub" --actor human:atin
+```
+
+The required reason structurally enforces the scannable-queue convention. Setting the flag emits a `needs_human_flagged` event; clearing it emits `needs_human_cleared`. Both are fully attributed in the task event log, and both commands support `--json`.
+
+**The queue:** `lattice list --needs-human` lists every flagged task across all statuses, each with its reason. `lattice show` renders a prominent `NEEDS HUMAN (since ..., by ...): reason` line, and `lattice weather` keys its needs-human section off the flag. `lattice next` never suggests a flagged task in any status — a flagged task is waiting on a human, not on an agent.
 
 ---
 
@@ -72,7 +102,7 @@ Multi-lock operations (e.g., linking two tasks) acquire locks in deterministic (
 
 ### Event types
 
-Built-in: `task_created`, `status_changed`, `assigned`, `comment_added`, `field_updated`, `relationship_added`, `relationship_removed`, `artifact_attached`, `file_linked`, `file_unlinked`, `task_archived`, `task_unarchived`.
+Built-in: `task_created`, `status_changed`, `assigned`, `comment_added`, `field_updated`, `relationship_added`, `relationship_removed`, `artifact_attached`, `file_linked`, `file_unlinked`, `needs_human_flagged`, `needs_human_cleared`, `task_archived`, `task_unarchived`.
 
 Custom: any `x_`-prefixed type via `lattice event`. Useful for domain-specific events like deployments, test runs, or releases.
 
@@ -173,7 +203,7 @@ The pattern that turns a prioritized backlog into completed work — one task at
 
 1. **`lattice next --claim`** — atomically grab the top task and move it to `in_progress`
 2. **Work** — implement, test, iterate
-3. **Transition** — move to `review` (done), `needs_human` (stuck on a decision), or `blocked` (external dependency)
+3. **Hand off** — move to `review` (done) or `blocked` (external dependency), or raise the `needs-human` flag (stuck on a human decision; the task keeps its status)
 4. **Comment** — record what was done, what was chosen, what's left
 5. **Commit** — save the work
 6. **Report** — tell the user what happened
@@ -294,6 +324,8 @@ The CLI is Lattice's write interface — the primary way agents interact with th
 | `lattice init` | Create `.lattice/` in your project |
 | `lattice create <title>` | Create a task |
 | `lattice status <id> <status>` | Change task status |
+| `lattice needs-human <id> "<reason>"` | Flag a task for human attention (reason required); `--clear [--note ...]` to clear |
+| `lattice migrate needs-human` | Convert tasks in the legacy `needs_human` status to the flag (`--dry-run` to preview) |
 | `lattice assign <id> <actor>` | Assign a task |
 | `lattice comment <id> "<text>"` | Add a comment (`--role` optionally tags it for completion policies) |
 | `lattice update <id> field=value` | Update task fields |

--- a/skills/delegator-example/SKILL.md
+++ b/skills/delegator-example/SKILL.md
@@ -45,7 +45,7 @@ These shape every decision downstream. If a section below seems to conflict with
 The human watches and interacts with exactly one pane: the delegator's. Everything else is internal machinery. This has real consequences:
 
 - **Sub-agents never message the human directly.** They write to the ticket, set their surface status, and stop. If they have a question or recommendation, it's a Lattice comment addressed to the delegator — not chat text addressed to the human.
-- **Only the delegator escalates.** `needs_human` status, operator decisions, pauses for clarification — all of these flow through the delegator. A Plan or Review sibling that discovers an ambiguity flags it to the delegator (via the ticket), and the delegator decides whether to resolve, spawn another sub-agent, or escalate to the human.
+- **Only the delegator escalates.** Needs-human flags, operator decisions, pauses for clarification — all of these flow through the delegator. A Plan or Review sibling that discovers an ambiguity flags it to the delegator (via the ticket), and the delegator decides whether to resolve, spawn another sub-agent, or escalate to the human.
 - **The delegator summarizes.** When the human checks in, they read the delegator pane and get a coherent picture of where the ticket is and what's next. The delegator owns that picture — it's not assembled from scraping 9 sibling tabs.
 - **The delegator is also the last-mile communicator.** When the PR is ready, when a decision is needed, when something has gone sideways — the delegator's most recent message is what the human sees.
 
@@ -90,9 +90,9 @@ git push
 (cd $REPO_ROOT && lattice complete $TICKET --review "..." --actor $ACTOR)
 ```
 
-**Why:** the dashboard, the board UI, the orchestrator's polling, sibling delegations, and any other agents reading the project's Lattice state all read from `$REPO_ROOT/.lattice/`. A status change written only to `$WT_DIR/.lattice/` is invisible to all of them — including the operator looking at their normal Lattice surfaces. The worktree may have its `.lattice/` deltas merged eventually (when the branch lands), but "eventually" is not "right now," and `needs_human` / `blocked` / `review` transitions need to be visible *right now*.
+**Why:** the dashboard, the board UI, the orchestrator's polling, sibling delegations, and any other agents reading the project's Lattice state all read from `$REPO_ROOT/.lattice/`. A status change written only to `$WT_DIR/.lattice/` is invisible to all of them — including the operator looking at their normal Lattice surfaces. The worktree may have its `.lattice/` deltas merged eventually (when the branch lands), but "eventually" is not "right now," and needs-human flags / `blocked` / `review` transitions need to be visible *right now*.
 
-Failure mode this prevents: delegator runs an audit, completes work, transitions ticket to `needs_human` in the worktree, then sits silent. Lattice dashboard, board, and orchestrator all still show `in_progress`. Operator has no way to know their input is needed. (Observed 2026-05-03 on C11-1; led to this principle.)
+Failure mode this prevents: delegator runs an audit, completes work, flags the ticket needs-human in the worktree, then sits silent. The flag lands only in the worktree's `.lattice/`; the Lattice dashboard, board, and orchestrator never see it. Operator has no way to know their input is needed. (Observed 2026-05-03 on C11-1; led to this principle.)
 
 **Reading is fine from either location.** `lattice show` in the worktree shows the worktree's view (which may be slightly behind the parent if the parent is being mutated by something else). When the orchestrator polls, it reads from `$REPO_ROOT` because that's where writes land — see *Active orchestrator watch* below.
 
@@ -291,7 +291,7 @@ You are the **primary human interface for this ticket**. The operator scrubs you
 
 ## Lattice writes go to the parent repo
 
-Lattice is the project's coordination surface. The dashboard, the board UI, the orchestrator, sibling delegations, and any other agents on the project all read from `{{REPO_ROOT}}/.lattice/`. **A `lattice status` or `lattice comment` from `{{WT_DIR}}` lands in the worktree's `.lattice/` and nowhere else** — invisible to every reader. That's a documented failure mode (the audit on C11-1 transitioned to `needs_human` in its worktree and the operator had no way to know).
+Lattice is the project's coordination surface. The dashboard, the board UI, the orchestrator, sibling delegations, and any other agents on the project all read from `{{REPO_ROOT}}/.lattice/`. **A `lattice status`, `lattice needs-human`, or `lattice comment` from `{{WT_DIR}}` lands in the worktree's `.lattice/` and nowhere else** — invisible to every reader. That's a documented failure mode (the audit on C11-1 raised the needs-human flag in its worktree and the operator had no way to know).
 
 Discipline:
 
@@ -379,7 +379,7 @@ Every phase below begins with a **status bump** as its first action. This is non
 
 ### 1. Plan
 - **Status bump (first action):** `(cd {{REPO_ROOT}} && lattice status {{TICKET}} in_planning --actor {{ACTOR}})`. Verify with `(cd {{REPO_ROOT}} && lattice show {{TICKET}} | grep "^Status:")`.
-- Spawn **Plan** sibling. Prompt it to: read the ticket, survey the relevant code area, write `{{REPO_ROOT}}/.lattice/notes/{{TASK_ULID}}.md` (or `.lattice/plans/...`), comment on the ticket when done. Plan notes are part of the Lattice trail and live in the parent repo's `.lattice/` so the dashboard and other agents can find them. Plan should **flag** operator decisions with a recommendation, not force `needs_human` unless the decision genuinely blocks progress.
+- Spawn **Plan** sibling. Prompt it to: read the ticket, survey the relevant code area, write `{{REPO_ROOT}}/.lattice/notes/{{TASK_ULID}}.md` (or `.lattice/plans/...`), comment on the ticket when done. Plan notes are part of the Lattice trail and live in the parent repo's `.lattice/` so the dashboard and other agents can find them. Plan should **flag** operator decisions with a recommendation, not raise needs-human unless the decision genuinely blocks progress.
 - Sanity-check the plan yourself. If the plan surfaced a decision, resolve it (pick the recommended option, or escalate to the human via Lattice comment on the ticket if the decision is genuinely theirs).
 - **Status bump on exit:** `(cd {{REPO_ROOT}} && lattice status {{TICKET}} planned --actor {{ACTOR}})`. Verify before continuing.
 
@@ -409,9 +409,9 @@ Every phase below begins with a **status bump** as its first action. This is non
   - **Focused rework**: spawn a **Fix** sibling with a tight prompt addressing the specific findings. Commits land on the same branch; no new review cycle required unless the fix itself is non-trivial.
   - **Structural rework**: `(cd {{REPO_ROOT}} && lattice status {{TICKET}} in_progress)`; spawn a new **Impl** sibling with the findings appended to the plan. A new review cycle follows.
   - **Plan-level rework**: `(cd {{REPO_ROOT}} && lattice status {{TICKET}} in_planning)`; spawn a new **Plan** sibling.
-  - **Genuine human decision**: `(cd {{REPO_ROOT}} && lattice status {{TICKET}} needs_human)`, post a comment via the parent repo, stop. The orchestrator surfaces this transition to the operator (see *Active orchestrator watch*); the operator finds out via the orchestrator chat AND the dashboard, both of which now see the transition because the write went to the parent.
+  - **Genuine human decision**: `(cd {{REPO_ROOT}} && lattice needs-human {{TICKET}} "<what you need>")`, stop. No status transition — the ticket keeps its current status and the needs-human flag is what surfaces it. The orchestrator surfaces the flag to the operator (see *Active orchestrator watch*); the operator finds out via the orchestrator chat AND the dashboard, both of which now see the flag because the write went to the parent.
 
-- **Max 3 rework cycles** before the delegator escalates to `needs_human` — pattern means something deeper is off.
+- **Max 3 rework cycles** before the delegator raises the needs-human flag — pattern means something deeper is off.
 
 ### 4. Validate
 - Before handoff, the delegator (or a dedicated **Validate** sibling) runs whatever validation the project's CLAUDE.md prescribes. This is typically: build the project in a way the operator can smoke-test (tagged local build, preview deploy, simulator run, headless browser check), confirm it comes up cleanly, post usage instructions on the ticket, and leave the validation artifact in a state the operator can poke at.
@@ -453,7 +453,7 @@ Post a one-line Lattice comment at every phase transition so the orchestrator ca
 
 ## Guardrails
 
-- **Don't steamroll human judgment.** Genuine decisions → `needs_human` + comment. The operator filed the ticket; open questions are real.
+- **Don't steamroll human judgment.** Genuine decisions → `lattice needs-human <ticket> "<the question>"`. The operator filed the ticket; open questions are real.
 - **Code in the worktree, Lattice in the parent.** All code edits, builds, and commits stay in `{{WT_DIR}}`. Every `lattice` write goes through `(cd {{REPO_ROOT}} && lattice ...)`. Don't write code into the parent repo's working tree; don't write Lattice state into the worktree's `.lattice/`. Two homes, two purposes.
 - **Prefer cohesive tickets.** Absorb follow-up work into the current PR when it fits. Create follow-up tickets reluctantly.
 - **Don't mix unrelated fixes into this ticket's commits.** Upstream-worthy fixes discovered along the way get their own commits and, if appropriate, their own tickets.
@@ -548,7 +548,7 @@ disown
 
 ## Active orchestrator watch (mandatory)
 
-After setup, the orchestrator must keep watching until the ticket reaches a terminal state (`done`, `cancelled`) or the operator says stop. **Watching means actively scheduling wake-ups, not assuming the operator will poll.** The skill's prior "passive reader" framing produced exactly the failure mode this section prevents: a delegator finished an audit and parked at `needs_human`, the orchestrator was offline for ~19 minutes, and the operator only learned the audit was done by asking. (Observed 2026-05-03 on C11-1.) Don't repeat it.
+After setup, the orchestrator must keep watching until the ticket reaches a terminal state (`done`, `cancelled`) or the operator says stop. **Watching means actively scheduling wake-ups, not assuming the operator will poll.** The skill's prior "passive reader" framing produced exactly the failure mode this section prevents: a delegator finished an audit and raised the needs-human flag, the orchestrator was offline for ~19 minutes, and the operator only learned the audit was done by asking. (Observed 2026-05-03 on C11-1.) Don't repeat it.
 
 ### Mechanism: `ScheduleWakeup`
 
@@ -581,7 +581,7 @@ Default to **1500s (25 min)** when in doubt. That's a sensible balance for phase
    ```
 3. **Compare against last-known state** stored at `/tmp/${TICKET_LOWER}-orch-state.json` (seeded in step 8 of setup). Diff against `last_status`, `last_comment_count`, and any new comments since `last_check_at`.
 4. **Decide: surface, or re-schedule silently.**
-   - **Surface to operator** when the ticket transitions to `review`, `needs_human`, `done`, `blocked`, OR a new Lattice comment lands that contains a recognizable signal phrase (`Audit complete`, `Plan complete`, `Impl complete`, `PR opened`, `Validation`, `BLOCKED`, `escalat`, `recommendation`). Read the new comment(s), summarize for the operator, surface immediately. Update the state file. Do **not** schedule another wake-up until the operator decides what's next — the next wake-up gets scheduled when work resumes.
+   - **Surface to operator** when the ticket transitions to `review`, `done`, or `blocked`, when the needs-human flag is raised, OR a new Lattice comment lands that contains a recognizable signal phrase (`Audit complete`, `Plan complete`, `Impl complete`, `PR opened`, `Validation`, `BLOCKED`, `escalat`, `recommendation`). Read the new comment(s), summarize for the operator, surface immediately. Update the state file. Do **not** schedule another wake-up until the operator decides what's next — the next wake-up gets scheduled when work resumes.
    - **Re-schedule silently** when nothing meaningful changed. Update the state file's `last_check_at`, call `ScheduleWakeup` with the appropriate cadence, return without operator-visible output.
 
 ### Surface format
@@ -596,7 +596,7 @@ Lead-in conventions by transition target:
 
 | Transition | Lead with | Tone |
 |------------|-----------|------|
-| `→ needs_human` | **🛑 NEEDS YOUR INPUT — `<TICKET>`** | Action required from operator. Don't bury it. |
+| needs-human flag raised | **🛑 NEEDS YOUR INPUT — `<TICKET>`** | Action required from operator. Don't bury it. |
 | `→ blocked` | **⛔ BLOCKED — `<TICKET>`** | External dependency; usually action required but possibly just informational. |
 | `→ review` | **✅ READY FOR REVIEW — `<TICKET>`** | PR up, validation done; operator's call to merge. |
 | `→ done` | **🎉 DONE — `<TICKET>`** | Final ceremony complete; informational. |
@@ -605,7 +605,7 @@ Lead-in conventions by transition target:
 Example:
 > **🛑 NEEDS YOUR INPUT — C11-1**
 >
-> Status `in_progress → needs_human`. Audit completed; auditor recommends file-a-followup-and-close.
+> Needs-human flag raised (still `in_progress`). Audit completed; auditor recommends file-a-followup-and-close.
 > Two operator decisions on the ticket: (1) what to do with 6 cosmetic stragglers, (2) how to interpret Criterion 3.
 > **On you.** The orchestrator will not re-schedule until you direct.
 
@@ -642,15 +642,15 @@ If the delegator's surface closes (e.g. the operator closes the pane), the PTY s
 - `lattice watch --task $TICKET` or `lattice wait $TICKET --status done --timeout 3600` from inside the orchestrator chat — these block a shell, but the orchestrator isn't a shell. They're for human operators in side terminals.
 - **Writing Lattice from the worktree.** A `lattice status` or `lattice comment` from `$WT_DIR` lands in the worktree's `.lattice/` and nowhere else — invisible to the dashboard, the board, the orchestrator, and the operator's normal workflow. The other half of the C11-1 failure. Every Lattice write goes through `(cd $REPO_ROOT && lattice ...)`.
 - Surfacing on every wake-up regardless of change — burns the operator's attention budget. Only surface on transitions or signal-phrase comments.
-- Surfacing without the action header — `→ needs_human` buried in a paragraph reads like progress, not "stop and decide." Lead with the emoji + uppercase header.
+- Surfacing without the action header — a needs-human flag buried in a paragraph reads like progress, not "stop and decide." Lead with the emoji + uppercase header.
 - Forgetting to re-schedule from a no-change wake-up — the loop dies after one tick.
 
 ## Teardown
 
 - **On `done` — default is leave-open for after-action review.** The delegator and its sibling surfaces stay live so the operator can scrub plan/impl/review transcripts for retrospectives, pattern extraction, or just satisfaction. The delegator may tear them down if explicitly instructed; otherwise leave them.
 - **Worktree cleanup is separate** from surface cleanup. Once the PR merges and the branch is deleted, `git worktree remove <dir>` is safe to run. The delegator should leave the worktree alive until the human confirms merge.
-- **On `needs_human`:** leave everything open so the operator can read it directly. Hand control back by posting a clear Lattice comment summarizing what decision is needed.
-- **On `blocked`:** same as `needs_human` but for external dependencies (CI, env, another ticket).
+- **On the needs-human flag:** leave everything open so the operator can read it directly. Hand control back by posting a clear Lattice comment summarizing what decision is needed.
+- **On `blocked`:** same as the needs-human flag but for external dependencies (CI, env, another ticket).
 
 ## Start now
 

--- a/skills/lattice/SKILL.md
+++ b/skills/lattice/SKILL.md
@@ -145,8 +145,8 @@ lattice doctor     # Check data integrity
 
 ```
 backlog → in_planning → planned → in_progress → review → done
-                                       ↕            ↕
-                                    blocked      needs_human
+                                       ↕
+                                    blocked
 ```
 
 - `backlog` — work identified but not started
@@ -156,10 +156,21 @@ backlog → in_planning → planned → in_progress → review → done
 - `review` — implementation done, under review
 - `done` — complete
 - `blocked` — waiting on an external dependency
-- `needs_human` — requires human decision or input
 - `cancelled` — abandoned
 
 Transitions are enforced. Use `--force --reason "..."` to override when needed.
+
+### Needs-human flag
+
+`needs-human` is a flag, not a status — it rides orthogonally on whatever status a task is in. Set it when you need a human decision, approval, or input; the task keeps its current status.
+
+```bash
+lattice needs-human PROJ-1 "Which OAuth provider should we use?" --actor agent:openclaw
+lattice needs-human PROJ-1 --clear --note "Decided: Google" --actor agent:openclaw
+lattice list --needs-human          # scannable queue of flagged tasks across all statuses
+```
+
+A reason is required when setting the flag. Use `blocked` (a status) for generic external dependencies; use the `needs-human` flag for "waiting on a human specifically." A task can be both at once.
 
 ## Actor IDs
 
@@ -216,4 +227,4 @@ For detailed multi-agent patterns, read `{baseDir}/references/multi-agent-guide.
 - **Update status before starting work**, not after. If you're about to implement something, move it to `in_progress` first.
 - **Leave comments** explaining what you tried, what you chose, and what you left undone. The next agent has no hallway to find you in.
 - **Use `lattice next`** to find the highest-priority unblocked task.
-- **Use `needs_human`** when you need a human decision — it creates a clear queue.
+- **Use `lattice needs-human`** when you need a human decision — it flags the task (leaving its status intact) and creates a clear queue via `lattice list --needs-human`.

--- a/skills/lattice/references/multi-agent-guide.md
+++ b/skills/lattice/references/multi-agent-guide.md
@@ -67,12 +67,19 @@ lattice status PROJ-2 blocked --actor agent:worker-1
 lattice comment PROJ-2 "Blocked: need database schema from PROJ-5" --actor agent:worker-1
 ```
 
-When a worker needs a human decision:
+When a worker needs a human decision, it flags the task. `needs-human` is orthogonal to status — the flag rides on top of whatever status the task is in, so the work stays exactly where it was (here, still `in_progress`):
 
 ```bash
-lattice status PROJ-2 needs_human --actor agent:worker-1
-lattice comment PROJ-2 "Need: which OAuth provider to use?" --actor agent:worker-1
+lattice needs-human PROJ-2 "Which OAuth provider to use?" --actor agent:worker-1
 ```
+
+The reason is required and replaces the old "leave a comment" convention. The orchestrator sees the flagged task via `lattice list --needs-human` (a queue spanning every status), resolves it, and clears the flag:
+
+```bash
+lattice needs-human PROJ-2 --clear --note "Decided: Google" --actor agent:worker-1
+```
+
+Use `blocked` (a status) for generic external dependencies; use the `needs-human` flag for "waiting on a human specifically." A task can be both blocked and flagged.
 
 ### 6. Event History
 

--- a/src/lattice/cli/c11_bridge.py
+++ b/src/lattice/cli/c11_bridge.py
@@ -36,8 +36,15 @@ STATUS_VISUALS: dict[str, dict[str, str]] = {
     "review": {"icon": "eye.fill", "color": "#FFD700"},
     "done": {"icon": "checkmark.circle.fill", "color": "#2ECC71"},
     "blocked": {"icon": "exclamationmark.triangle.fill", "color": "#E74C3C"},
+    # Retained for instances whose config still has the legacy status.
     "needs_human": {"icon": "person.fill.questionmark", "color": "#E74C3C"},
     "cancelled": {"icon": "xmark.circle.fill", "color": "#95A5A6"},
+}
+
+# Visuals for the orthogonal needs_human flag (overrides status visuals).
+NEEDS_HUMAN_VISUALS: dict[str, str] = {
+    "icon": "person.fill.questionmark",
+    "color": "#F59E0B",
 }
 
 # Display labels used in tab titles for each status
@@ -180,6 +187,11 @@ def on_status_changed(snapshot: dict, old_status: str, new_status: str) -> None:
     title = snapshot.get("title") or ""
     status_label = STATUS_LABELS.get(new_status, new_status)
     visuals = STATUS_VISUALS.get(new_status, {})
+    # The needs_human flag outranks status visuals — a flagged task is
+    # waiting on a human regardless of its swimlane.
+    if snapshot.get("needs_human"):
+        status_label = f"{status_label} · needs human"
+        visuals = NEEDS_HUMAN_VISUALS
 
     # Update tab title
     if new_status in ("done", "cancelled"):
@@ -198,6 +210,42 @@ def on_status_changed(snapshot: dict, old_status: str, new_status: str) -> None:
         )
         clear_status(short_id)
     else:
+        set_status(
+            short_id,
+            status_label,
+            icon=visuals.get("icon"),
+            color=visuals.get("color"),
+        )
+
+
+def on_needs_human_changed(snapshot: dict, flagged: bool) -> None:
+    """React to the needs_human flag being set or cleared inside c11.
+
+    Reads ``c11_surface`` from the snapshot; does nothing if the task has
+    no surface binding.  Called from flag_cmds.py after write_task_event
+    succeeds.  Must never raise — all errors are logged as warnings.
+    """
+    if not c11_available():
+        return
+
+    surface = snapshot.get("c11_surface")
+    if not surface:
+        return  # task not bound to any surface
+
+    short_id = snapshot.get("short_id") or snapshot.get("id", "")
+    status = snapshot.get("status", "")
+    status_label = STATUS_LABELS.get(status, status)
+
+    if flagged:
+        set_status(
+            short_id,
+            f"{status_label} · needs human",
+            icon=NEEDS_HUMAN_VISUALS["icon"],
+            color=NEEDS_HUMAN_VISUALS["color"],
+        )
+        trigger_flash(surface)
+    else:
+        visuals = STATUS_VISUALS.get(status, {})
         set_status(
             short_id,
             status_label,

--- a/src/lattice/cli/demo_cmd.py
+++ b/src/lattice/cli/demo_cmd.py
@@ -691,7 +691,13 @@ def _task_definitions(ts: dict[str, str]) -> list[dict]:
             "title": "Know who to wake at 3am",
             "type": "task",
             "priority": "critical",
-            "status": "needs_human",
+            "status": "in_planning",
+            "needs_human": (
+                "Which escalation model — A (simple rotation), B (tiered), "
+                "or C (follow-the-sun)? Drafts are in the comments.",
+                ts["fri_2pm"],
+                "agent:gregorovich",
+            ),
             "assigned_to": "human:kai",
             "ts": ts["fri_noon"],
             "description": (
@@ -704,7 +710,6 @@ def _task_definitions(ts: dict[str, str]) -> list[dict]:
             "tags": ["alerting", "on-call"],
             "status_history": [
                 ("in_planning", ts["fri_noon"], "agent:gregorovich"),
-                ("needs_human", ts["fri_2pm"], "agent:gregorovich"),
             ],
             "parent_idx": 2,
             "comments": [
@@ -989,7 +994,14 @@ def _task_definitions(ts: dict[str, str]) -> list[dict]:
             "title": "The question of trust",
             "type": "task",
             "priority": "critical",
-            "status": "needs_human",
+            "status": "in_planning",
+            "needs_human": (
+                "Authentication model decision: (A) mTLS + API keys, "
+                "(B) OAuth2/JWT everywhere, or (C) hybrid. "
+                "Recommendation in comments: Option A.",
+                ts["thu_11am"],
+                "agent:gregorovich",
+            ),
             "assigned_to": "human:kai",
             "ts": ts["thu_9am"],
             "description": (
@@ -1002,7 +1014,6 @@ def _task_definitions(ts: dict[str, str]) -> list[dict]:
             "tags": ["infrastructure", "security", "decision"],
             "status_history": [
                 ("in_planning", ts["thu_9am"], "agent:gregorovich"),
-                ("needs_human", ts["thu_11am"], "agent:gregorovich"),
             ],
             "comments": [
                 (
@@ -1030,7 +1041,13 @@ def _task_definitions(ts: dict[str, str]) -> list[dict]:
             "title": "When two truths disagree",
             "type": "task",
             "priority": "high",
-            "status": "needs_human",
+            "status": "in_planning",
+            "needs_human": (
+                "When StatsD and Prometheus disagree on the same metric, "
+                "which source wins? Need an operational policy.",
+                ts["fri_11am"],
+                "agent:meridian",
+            ),
             "assigned_to": "human:lena",
             "ts": ts["fri_9am"],
             "description": (
@@ -1043,7 +1060,6 @@ def _task_definitions(ts: dict[str, str]) -> list[dict]:
             "tags": ["monitoring", "operations", "decision"],
             "status_history": [
                 ("in_planning", ts["fri_9am"], "agent:meridian"),
-                ("needs_human", ts["fri_11am"], "agent:meridian"),
             ],
             "comments": [
                 (
@@ -1305,6 +1321,19 @@ def _seed_demo(target_dir: Path, quiet: bool = False) -> None:
             )
             snapshot = apply_event_to_snapshot(snapshot, assign_event)
             all_events.append(assign_event)
+
+        # Apply needs_human flag if present: (reason, ts, actor)
+        if tdef.get("needs_human"):
+            flag_reason, flag_ts, flag_actor = tdef["needs_human"]
+            flag_event = create_event(
+                type="needs_human_flagged",
+                task_id=task_id,
+                actor=flag_actor,
+                data={"reason": flag_reason},
+                ts=flag_ts,
+            )
+            snapshot = apply_event_to_snapshot(snapshot, flag_event)
+            all_events.append(flag_event)
 
         # Apply comments
         for comment_body, comment_ts, comment_actor in tdef.get("comments", []):

--- a/src/lattice/cli/flag_cmds.py
+++ b/src/lattice/cli/flag_cmds.py
@@ -1,0 +1,159 @@
+"""Flag commands: needs-human (set/clear the orthogonal needs_human flag)."""
+
+from __future__ import annotations
+
+import click
+
+from lattice.cli.helpers import (
+    common_options,
+    load_project_config,
+    output_error,
+    output_result,
+    read_snapshot_or_exit,
+    require_actor,
+    require_root,
+    resolve_task_id,
+    validate_actor_format_or_exit,
+    write_task_event,
+)
+from lattice.cli.main import cli
+from lattice.core.events import create_event, get_actor_display
+from lattice.core.tasks import apply_event_to_snapshot
+
+
+def _notify_c11(snapshot: dict, *, flagged: bool) -> None:
+    """Update the c11 sidebar when the flag changes (best-effort)."""
+    from lattice.cli.c11_bridge import c11_available, on_needs_human_changed
+
+    if c11_available():
+        on_needs_human_changed(snapshot, flagged)
+
+
+@cli.command("needs-human")
+@click.argument("task_id")
+@click.argument("reason", required=False)
+@click.option("--clear", "clear_flag", is_flag=True, help="Clear the needs_human flag.")
+@click.option("--note", default=None, help="Resolution note recorded when clearing.")
+@common_options
+def needs_human_cmd(
+    task_id: str,
+    reason: str | None,
+    clear_flag: bool,
+    note: str | None,
+    model: str | None,
+    session: str | None,
+    output_json: bool,
+    quiet: bool,
+    triggered_by: str | None,
+    on_behalf_of: str | None,
+    provenance_reason: str | None,
+) -> None:
+    """Set or clear the needs_human flag on a task.
+
+    The flag is orthogonal to status: the task stays in its current
+    status/swimlane while signalling that a human decision, approval,
+    or input is required. Set it with a REASON (required — say exactly
+    what you need); clear it with --clear once the human has responded.
+
+    \b
+        lattice needs-human LAT-42 "Need: which OAuth provider?" --actor agent:claude
+        lattice needs-human LAT-42 --clear --note "chose google" --actor human:atin
+    """
+    is_json = output_json
+
+    lattice_dir = require_root(is_json)
+    config = load_project_config(lattice_dir)
+    actor = require_actor(is_json)
+    if on_behalf_of is not None:
+        validate_actor_format_or_exit(on_behalf_of, is_json)
+
+    task_id = resolve_task_id(lattice_dir, task_id, is_json)
+    snapshot = read_snapshot_or_exit(lattice_dir, task_id, is_json)
+    current = snapshot.get("needs_human")
+    display_id = snapshot.get("short_id") or task_id
+
+    if clear_flag:
+        if reason is not None:
+            output_error(
+                "REASON is only for setting the flag. To clear, use "
+                "--clear (optionally with --note).",
+                "VALIDATION_ERROR",
+                is_json,
+            )
+        if not current:
+            output_error(
+                f"Task {display_id} does not have the needs_human flag set.",
+                "FLAG_NOT_SET",
+                is_json,
+            )
+        event = create_event(
+            type="needs_human_cleared",
+            task_id=task_id,
+            actor=actor,
+            data={"note": note},
+            model=model,
+            session=session,
+            triggered_by=triggered_by,
+            on_behalf_of=on_behalf_of,
+            reason=provenance_reason,
+        )
+        updated = apply_event_to_snapshot(snapshot, event)
+        write_task_event(lattice_dir, task_id, [event], updated, config)
+        _notify_c11(updated, flagged=False)
+        note_msg = f"  Note: {note}" if note else ""
+        output_result(
+            data=updated,
+            human_message=f"needs_human cleared ({display_id}){note_msg}",
+            quiet_value="ok",
+            is_json=is_json,
+            is_quiet=quiet,
+        )
+        return
+
+    if note is not None:
+        output_error(
+            "--note is only for clearing the flag. To set, pass a REASON.",
+            "VALIDATION_ERROR",
+            is_json,
+        )
+    if not reason or not reason.strip():
+        output_error(
+            "REASON is required when setting the needs_human flag. "
+            "Say exactly what you need from the human, in one line.",
+            "VALIDATION_ERROR",
+            is_json,
+        )
+    if current:
+        flagged_by = get_actor_display(current.get("flagged_by"))
+        output_error(
+            f"Task {display_id} already has the needs_human flag set "
+            f"(by {flagged_by} since {current.get('since')}: "
+            f"{current.get('reason')}). Clear it first with --clear.",
+            "FLAG_ALREADY_SET",
+            is_json,
+        )
+
+    event = create_event(
+        type="needs_human_flagged",
+        task_id=task_id,
+        actor=actor,
+        data={"reason": reason},
+        model=model,
+        session=session,
+        triggered_by=triggered_by,
+        on_behalf_of=on_behalf_of,
+        reason=provenance_reason,
+    )
+    updated = apply_event_to_snapshot(snapshot, event)
+    write_task_event(lattice_dir, task_id, [event], updated, config)
+    _notify_c11(updated, flagged=True)
+    output_result(
+        data=updated,
+        human_message=(
+            f"needs_human set ({display_id}, status stays {snapshot.get('status')})\n"
+            f"  Need: {reason}"
+        ),
+        quiet_value="ok",
+        is_json=is_json,
+        is_quiet=quiet,
+    )

--- a/src/lattice/cli/main.py
+++ b/src/lattice/cli/main.py
@@ -1480,6 +1480,7 @@ def plugins_cmd(as_json: bool) -> None:
 # ---------------------------------------------------------------------------
 from lattice.cli import migration_cmds as _migration_cmds  # noqa: E402, F401
 from lattice.cli import task_cmds as _task_cmds  # noqa: E402, F401
+from lattice.cli import flag_cmds as _flag_cmds  # noqa: E402, F401
 from lattice.cli import link_cmds as _link_cmds  # noqa: E402, F401
 from lattice.cli import artifact_cmds as _artifact_cmds  # noqa: E402, F401
 from lattice.cli import query_cmds as _query_cmds  # noqa: E402, F401

--- a/src/lattice/cli/migration_cmds.py
+++ b/src/lattice/cli/migration_cmds.py
@@ -182,3 +182,170 @@ def backfill_ids(
         )
     else:
         click.echo(f"Assigned {first_id} through {last_id} to {count} existing tasks.")
+
+
+# ---------------------------------------------------------------------------
+# lattice migrate — instance migrations
+# ---------------------------------------------------------------------------
+
+
+@cli.group("migrate")
+def migrate_group() -> None:
+    """Instance migrations (schema/workflow changes for existing .lattice dirs)."""
+
+
+@migrate_group.command("needs-human")
+@click.option("--dry-run", is_flag=True, help="Report what would change without writing.")
+@click.option("--json", "output_json", is_flag=True, help="Output structured JSON.")
+@click.option("--actor", default="agent:lattice-migration", help="Actor for migration events.")
+def migrate_needs_human(
+    dry_run: bool,
+    output_json: bool,
+    actor: str,
+) -> None:
+    """Convert the needs_human STATUS to the orthogonal flag.
+
+    For every task sitting in the needs_human status: set the needs_human
+    flag (reason: the task's latest comment, or a generic migration note)
+    and route the task back to the status it was in before entering
+    needs_human (fallback: backlog). Then strip needs_human from the
+    workflow config (statuses, transitions, universal_targets,
+    descriptions, display_names). Idempotent — re-running on a migrated
+    instance is a no-op.
+    """
+    from lattice.cli.helpers import write_task_event
+    from lattice.core.comments import materialize_comments
+
+    is_json = output_json
+    lattice_dir = require_root(is_json)
+    config = load_project_config(lattice_dir)
+
+    # ---- Phase 1: tasks sitting in the needs_human status -----------------
+    tasks_dir = lattice_dir / "tasks"
+    migrated: list[dict] = []
+    statuses_after = [
+        s for s in config.get("workflow", {}).get("statuses", []) if s != "needs_human"
+    ]
+
+    snap_files = sorted(tasks_dir.glob("*.json")) if tasks_dir.is_dir() else []
+    for snap_file in snap_files:
+        try:
+            snap = json.loads(snap_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if snap.get("status") != "needs_human":
+            continue
+        task_id = snap["id"]
+
+        # Return status: the `from` of the latest transition INTO needs_human.
+        events_path = lattice_dir / "events" / f"{task_id}.jsonl"
+        events: list[dict] = []
+        if events_path.exists():
+            for line in events_path.read_text().splitlines():
+                stripped = line.strip()
+                if stripped:
+                    events.append(json.loads(stripped))
+        return_status = "backlog"
+        for ev in reversed(events):
+            if (
+                ev.get("type") == "status_changed"
+                and ev.get("data", {}).get("to") == "needs_human"
+            ):
+                candidate = ev.get("data", {}).get("from")
+                if isinstance(candidate, str) and candidate in statuses_after:
+                    return_status = candidate
+                break
+
+        # Flag reason: latest non-deleted comment, else a generic note.
+        reason = "Migrated from needs_human status"
+        comments = materialize_comments(events)
+        for c in reversed(comments):
+            if not c.get("deleted") and c.get("body"):
+                reason = c["body"]
+                break
+
+        migrated.append(
+            {
+                "task_id": task_id,
+                "short_id": snap.get("short_id"),
+                "return_status": return_status,
+                "reason": reason,
+            }
+        )
+
+        if dry_run:
+            continue
+
+        new_events: list[dict] = []
+        updated = snap
+        if not updated.get("needs_human"):
+            flag_event = create_event(
+                type="needs_human_flagged",
+                task_id=task_id,
+                actor=actor,
+                data={"reason": reason},
+                reason="LAT-232 migration: needs_human status converted to flag",
+            )
+            new_events.append(flag_event)
+            updated = apply_event_to_snapshot(updated, flag_event)
+        status_event = create_event(
+            type="status_changed",
+            task_id=task_id,
+            actor=actor,
+            data={"from": "needs_human", "to": return_status},
+            reason="LAT-232 migration: needs_human status converted to flag",
+        )
+        new_events.append(status_event)
+        updated = apply_event_to_snapshot(updated, status_event)
+        write_task_event(lattice_dir, task_id, new_events, updated, config)
+
+    # ---- Phase 2: strip needs_human from the workflow config ---------------
+    workflow = config.get("workflow", {})
+    config_changes: list[str] = []
+
+    if "needs_human" in workflow.get("statuses", []):
+        config_changes.append("statuses")
+    transitions = workflow.get("transitions", {})
+    if "needs_human" in transitions:
+        config_changes.append("transitions (source)")
+    if any("needs_human" in targets for targets in transitions.values()):
+        config_changes.append("transitions (targets)")
+    if "needs_human" in workflow.get("universal_targets", []):
+        config_changes.append("universal_targets")
+    if "needs_human" in workflow.get("descriptions", {}):
+        config_changes.append("descriptions")
+    if "needs_human" in workflow.get("display_names", {}):
+        config_changes.append("display_names")
+
+    if config_changes and not dry_run:
+        workflow["statuses"] = statuses_after
+        transitions.pop("needs_human", None)
+        workflow["transitions"] = {
+            source: [t for t in targets if t != "needs_human"]
+            for source, targets in transitions.items()
+        }
+        workflow["universal_targets"] = [
+            t for t in workflow.get("universal_targets", []) if t != "needs_human"
+        ]
+        workflow.get("descriptions", {}).pop("needs_human", None)
+        workflow.get("display_names", {}).pop("needs_human", None)
+        atomic_write(lattice_dir / "config.json", serialize_config(config))
+
+    # ---- Report -------------------------------------------------------------
+    data = {
+        "dry_run": dry_run,
+        "tasks_migrated": migrated,
+        "config_changes": config_changes,
+    }
+    if is_json:
+        click.echo(json.dumps({"ok": True, "data": data}, sort_keys=True, indent=2) + "\n")
+        return
+    prefix = "[dry-run] " if dry_run else ""
+    if not migrated and not config_changes:
+        click.echo(f"{prefix}Nothing to migrate — instance already uses the needs_human flag.")
+        return
+    for item in migrated:
+        label = item["short_id"] or item["task_id"]
+        click.echo(f"{prefix}{label}: flagged + routed needs_human -> {item['return_status']}")
+    if config_changes:
+        click.echo(f"{prefix}config.json: stripped needs_human from {', '.join(config_changes)}")

--- a/src/lattice/cli/query_cmds.py
+++ b/src/lattice/cli/query_cmds.py
@@ -302,6 +302,12 @@ def event_cmd(
     default=None,
     help="Filter by priority (critical, high, medium, low).",
 )
+@click.option(
+    "--needs-human",
+    "needs_human_filter",
+    is_flag=True,
+    help="Only tasks carrying the needs_human flag (any status).",
+)
 @click.option("--include-archived", is_flag=True, help="Include archived tasks.")
 @click.option("--compact", is_flag=True, help="Compact JSON output.")
 @click.option("--json", "output_json", is_flag=True, help="Output structured JSON.")
@@ -312,6 +318,7 @@ def list_cmd(
     tag: str | None,
     task_type: str | None,
     priority: str | None,
+    needs_human_filter: bool,
     include_archived: bool,
     compact: bool,
     output_json: bool,
@@ -374,6 +381,8 @@ def list_cmd(
             continue
         if priority is not None and snap.get("priority") != priority:
             continue
+        if needs_human_filter and not snap.get("needs_human"):
+            continue
         filtered.append(snap)
 
     # Sort by task ID (ULID = chronological order)
@@ -419,11 +428,16 @@ def list_cmd(
             t = snap.get("type", "?")
             title = snap.get("title", "?")
             assigned_to = snap.get("assigned_to") or "unassigned"
-            prefix = ">>> " if s == "needs_human" else ""
+            flag = snap.get("needs_human")
+            prefix = ">>> " if flag else ""
             archived_marker = " [A]" if snap.get("_archived") else ""
-            click.echo(
-                f'{prefix}{display_id}  {s_display}  {p}  {t}  "{title}"  {assigned_to}{archived_marker}'
+            line = (
+                f'{prefix}{display_id}  {s_display}  {p}  {t}  "{title}"  '
+                f"{assigned_to}{archived_marker}"
             )
+            if flag and isinstance(flag, dict) and flag.get("reason"):
+                line += f"  [needs human: {flag['reason']}]"
+            click.echo(line)
 
 
 # ---------------------------------------------------------------------------
@@ -1077,6 +1091,13 @@ def _print_compact_show(
     if valid_transitions:
         next_str = f"\n  Next: {' | '.join(valid_transitions)}"
     click.echo(f"Status: {status}  Priority: {priority}  Type: {task_type}")
+    flag = snapshot.get("needs_human")
+    if flag and isinstance(flag, dict):
+        flagged_by = get_actor_display(flag.get("flagged_by", "?"))
+        click.echo(
+            f"NEEDS HUMAN (since {flag.get('since', '?')}, by {flagged_by}): "
+            f"{flag.get('reason', '?')}"
+        )
     click.echo(f"Assigned: {assigned_to}{next_str}")
 
 
@@ -1117,6 +1138,13 @@ def _print_human_show(
     header = f"{short_id} ({task_id})" if short_id else task_id
     click.echo(f'{header}  "{title}"{archived_note}')
     click.echo(f"Status: {status_display}  Priority: {priority}  Type: {task_type}")
+    flag = snapshot.get("needs_human")
+    if flag and isinstance(flag, dict):
+        flagged_by = get_actor_display(flag.get("flagged_by", "?"))
+        click.echo(
+            f"NEEDS HUMAN (since {flag.get('since', '?')}, by {flagged_by}): "
+            f"{flag.get('reason', '?')}"
+        )
     if valid_transitions:
         display_transitions = [get_display_name(config or {}, t) for t in valid_transitions]
         click.echo(f"  Next: {' | '.join(display_transitions)}")

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -713,6 +713,12 @@ def _flag_needs_human(
     )
     if result.returncode == 0:
         click.echo("needs_human flag set (plan_approval=human).")
+    elif (
+        "FLAG_ALREADY_SET" in result.stderr or "already has the needs_human flag" in result.stderr
+    ):
+        # Benign: human attention is already requested (e.g. plan-level
+        # rework re-fired the review while the earlier flag still stands).
+        click.echo("needs_human flag already set (plan_approval=human).")
     else:
         click.echo(
             f"Note: Could not set needs_human flag: {result.stderr.strip()}",

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -376,13 +376,13 @@ def plan_review(
             timeout=timeout,
         )
         if art_id and plan_approval == "human":
-            _move_to_needs_human(lattice_dir, task_id, actor, is_json)
+            _flag_needs_human(lattice_dir, task_id, actor, is_json)
 
     elif mode == "triple":
-        # The pane drives triage and status transitions itself; the CLI
-        # does not move the task to needs_human here even when
-        # plan_approval == "human".  The pane sees the trident artifact
-        # first-hand and is the right place to decide.
+        # The pane drives triage and the flag itself; the CLI does not
+        # flag needs_human here even when plan_approval == "human".  The
+        # pane sees the trident artifact first-hand and is the right
+        # place to decide.
         _spawn_triple_pane(
             lattice_dir=lattice_dir,
             task_id=task_id,
@@ -683,24 +683,28 @@ def _read_project_context(lattice_dir: Path) -> str:
     return "(no project context found)"
 
 
-def _move_to_needs_human(
+def _flag_needs_human(
     lattice_dir: Path,
     task_id: str,
     actor: str | dict,
     is_json: bool,
 ) -> None:
-    """Move task to needs_human when plan_approval == 'human'."""
+    """Set the needs_human flag when plan_approval == 'human'.
+
+    The task keeps its current status (planned); the flag signals that a
+    human must approve the plan before work proceeds.
+    """
     actor_flag = _actor_flag(actor)
     if actor_flag is None:
-        click.echo("Cannot determine actor for status update.", err=True)
+        click.echo("Cannot determine actor for needs-human flag.", err=True)
         return
 
     result = subprocess.run(
         [
             "lattice",
-            "status",
+            "needs-human",
             task_id,
-            "needs_human",
+            "Plan-review complete — awaiting human plan approval",
             "--actor",
             actor_flag,
         ],
@@ -708,10 +712,10 @@ def _move_to_needs_human(
         text=True,
     )
     if result.returncode == 0:
-        click.echo("Task moved to needs_human (plan_approval=human).")
+        click.echo("needs_human flag set (plan_approval=human).")
     else:
         click.echo(
-            f"Note: Could not move to needs_human: {result.stderr.strip()}",
+            f"Note: Could not set needs_human flag: {result.stderr.strip()}",
             err=True,
         )
 

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -670,30 +670,6 @@ def compute_next_steps(
             "then": "done",
         }
 
-    if new_status == "needs_human":
-        # Try to surface the latest comment as a reminder of what's needed.
-        try:
-            events = read_task_events(lattice_dir, task_id)
-            comments = materialize_comments(events)
-            # Find the latest non-deleted top-level comment.
-            latest = None
-            for c in reversed(comments):
-                if not c.get("deleted"):
-                    latest = c
-                    break
-            if latest:
-                body = latest.get("body", "")
-                truncated = (body[:200] + "...") if len(body) > 200 else body
-                hint = f"Waiting on human.  Latest comment: {truncated}"
-                return hint, {
-                    "action": "awaiting_human",
-                    "latest_comment": body,
-                }
-        except Exception:
-            pass
-        hint = "Waiting on human input."
-        return hint, {"action": "awaiting_human"}
-
     return None, None
 
 
@@ -778,6 +754,17 @@ def status_cmd(
 
     # Validate new_status is a known status
     if not validate_status(config, new_status):
+        if new_status == "needs_human":
+            # Only reached when needs_human is absent from this instance's
+            # config — instances that still carry the status validate above.
+            display_id = snapshot.get("short_id") or task_id
+            output_error(
+                "needs_human is a flag, not a status. Use: "
+                f'lattice needs-human {display_id} "<what you need>" '
+                "(the task keeps its current status).",
+                "VALIDATION_ERROR",
+                is_json,
+            )
         valid = ", ".join(config.get("workflow", {}).get("statuses", []))
         output_error(
             f"Invalid status: '{new_status}'. Valid statuses: {valid}.",
@@ -851,8 +838,8 @@ def status_cmd(
             msg = (
                 f"Review cycle limit reached ({cycle_count}/{cycle_limit}). "
                 f"This task has been sent back from review {cycle_count} time(s). "
-                "Move to needs_human with a comment explaining the situation "
-                "instead of cycling further. "
+                "Flag it for a human instead of cycling further: "
+                'lattice needs-human <task> "<what you need>". '
                 "Override with --force --reason."
             )
             output_error(msg, "REVIEW_CYCLE_LIMIT", is_json)

--- a/src/lattice/cli/weather_cmds.py
+++ b/src/lattice/cli/weather_cmds.py
@@ -218,15 +218,17 @@ def _find_attention_needed(
                 }
             )
 
-    # Tasks waiting for human input
+    # Tasks waiting for human input (needs_human flag, any status)
     for snap in active:
-        if snap.get("status") == "needs_human":
+        flag = snap.get("needs_human")
+        if flag:
+            reason = flag.get("reason") if isinstance(flag, dict) else None
             items.append(
                 {
                     "type": "needs_human",
                     "id": snap.get("short_id") or snap.get("id", "?"),
                     "title": snap.get("title", "?"),
-                    "detail": "Waiting for human decision or input",
+                    "detail": reason or "Waiting for human decision or input",
                 }
             )
 

--- a/src/lattice/core/config.py
+++ b/src/lattice/core/config.py
@@ -95,7 +95,6 @@ WORKFLOW_PRESETS: dict[str, dict[str, str]] = {
             "pr_open": "PR up",
             "done": "shipped",
             "blocked": "stuck",
-            "needs_human": "ask flesh",
             "cancelled": "never mind",
         },
     },
@@ -118,7 +117,6 @@ STATUS_DESCRIPTIONS: dict[str, str] = {
     "pr_open": "PR is open and awaiting human review, CI, or merge. Local review artifact is recorded.",
     "done": "Work is reviewed, merged, and shipped. No further action needed.",
     "blocked": "Work cannot proceed due to an external dependency or unresolved issue.",
-    "needs_human": "A human decision, approval, or input is required before work can continue.",
     "cancelled": "Work has been abandoned. No further action will be taken.",
 }
 
@@ -180,20 +178,18 @@ def default_config(preset: str = "classic") -> LatticeConfig:
             "pr_open",
             "done",
             "blocked",
-            "needs_human",
             "cancelled",
         ],
         "transitions": {
             "backlog": ["in_planning", "planned", "cancelled"],
-            "in_planning": ["planned", "needs_human", "cancelled"],
-            "planned": ["in_progress", "review", "blocked", "needs_human", "cancelled"],
-            "in_progress": ["review", "blocked", "needs_human", "cancelled"],
+            "in_planning": ["planned", "cancelled"],
+            "planned": ["in_progress", "review", "blocked", "cancelled"],
+            "in_progress": ["review", "blocked", "cancelled"],
             "review": [
                 "pr_open",
                 "done",
                 "in_progress",
                 "in_planning",
-                "needs_human",
                 "cancelled",
             ],
             "pr_open": [
@@ -201,22 +197,13 @@ def default_config(preset: str = "classic") -> LatticeConfig:
                 "in_progress",
                 "review",
                 "blocked",
-                "needs_human",
                 "cancelled",
             ],
             "done": [],
             "blocked": ["in_planning", "planned", "in_progress", "pr_open", "cancelled"],
-            "needs_human": [
-                "in_planning",
-                "planned",
-                "in_progress",
-                "review",
-                "pr_open",
-                "cancelled",
-            ],
             "cancelled": [],
         },
-        "universal_targets": ["needs_human", "cancelled"],
+        "universal_targets": ["cancelled"],
         "roles": ["review", "plan-review", "review-individual"],
         "wip_limits": {
             "in_progress": 10,
@@ -369,7 +356,7 @@ def validate_transition(
     A transition is allowed if *to_status* appears in the explicit transition
     list for *from_status*, **or** if *to_status* is listed in
     ``workflow.universal_targets``.  Universal targets are statuses reachable
-    from any other status (e.g. ``needs_human``, ``cancelled``).
+    from any other status (e.g. ``cancelled``).
     """
     workflow = config.get("workflow", {})
     universal = workflow.get("universal_targets", [])
@@ -429,7 +416,7 @@ def validate_completion_policy(
     Returns ``(True, [])`` if no policy exists or all requirements are met.
     Returns ``(False, [reason, ...])`` if one or more requirements are not met.
 
-    Universal targets (``needs_human``, ``cancelled``) bypass all policies —
+    Universal targets (``cancelled``) bypass all policies —
     they are escape hatches.
     """
     from lattice.core.tasks import get_evidence_roles

--- a/src/lattice/core/events.py
+++ b/src/lattice/core/events.py
@@ -40,6 +40,8 @@ BUILTIN_EVENT_TYPES: frozenset[str] = frozenset(
         "resource_expired",
         "resource_updated",
         "auto_review_spawned",
+        "needs_human_flagged",
+        "needs_human_cleared",
     }
 )
 

--- a/src/lattice/core/next.py
+++ b/src/lattice/core/next.py
@@ -10,7 +10,7 @@ URGENCY_ORDER = {"immediate": 0, "high": 1, "normal": 2, "low": 3}
 
 # Statuses that are NOT eligible for next (terminal, waiting, or active).
 # pr_open is waiting on external review/merge, so it is not pickable as next work.
-EXCLUDED_STATUSES = frozenset({"needs_human", "blocked", "done", "cancelled", "pr_open"})
+EXCLUDED_STATUSES = frozenset({"blocked", "done", "cancelled", "pr_open"})
 
 # Statuses indicating work already in progress (for resume-first logic)
 RESUME_STATUSES = frozenset({"in_progress", "in_planning"})
@@ -44,8 +44,9 @@ def select_next(
     1. **Resume first:** If *actor* is specified, check for in_progress/in_planning
        tasks assigned to that actor. Return the highest-priority one.
     2. **Pick from ready pool:** Tasks in *ready_statuses* (default: backlog, planned)
-       that are unassigned OR assigned to the requesting actor. Excludes needs_human,
-       blocked, done, cancelled.
+       that are unassigned OR assigned to the requesting actor. Excludes blocked,
+       done, cancelled, and any task carrying the needs_human flag (it is
+       waiting on a human, regardless of status).
     3. **Sort by:** priority (critical > high > medium > low) → urgency
        (immediate > high > normal > low) → ULID / id (oldest first).
     4. **Return** top result or None.
@@ -61,6 +62,8 @@ def select_next(
         for snap in snapshots:
             status = snap.get("status", "")
             assigned = snap.get("assigned_to")
+            if snap.get("needs_human"):
+                continue  # flagged: waiting on a human, never suggest it
             if status in RESUME_STATUSES and _actors_match(assigned, actor):
                 resume_candidates.append(snap)
         if resume_candidates:
@@ -77,6 +80,8 @@ def select_next(
         # terminal/waiting states, still exclude them.
         if status in EXCLUDED_STATUSES:
             continue
+        if snap.get("needs_human"):
+            continue  # flagged: waiting on a human, never suggest it
         assigned = snap.get("assigned_to")
         if assigned is not None and actor is not None and not _actors_match(assigned, actor):
             continue  # assigned to someone else
@@ -111,6 +116,8 @@ def select_all_ready(
             continue
         if status in EXCLUDED_STATUSES:
             continue
+        if snap.get("needs_human"):
+            continue  # flagged: waiting on a human, never suggest it
         candidates.append(snap)
 
     candidates.sort(key=sort_key)

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -283,7 +283,7 @@ def create_failure_diagnostic_task(
     failure_count: int,
     actor: str,
 ) -> str | None:
-    """Create a needs_human task for investigating persistent agent failures.
+    """Create a needs_human-flagged task for investigating persistent agent failures.
 
     Returns the created task ID, or None on failure.
     """
@@ -307,13 +307,13 @@ def create_failure_diagnostic_task(
         new_task_id = result.stdout.strip()
         if not new_task_id:
             return None
-        # Move to needs_human
+        # Flag for human attention (the task stays in backlog)
         subprocess.run(
             [
                 "lattice",
-                "status",
+                "needs-human",
                 new_task_id,
-                "needs_human",
+                f"{agent_type} review agent failed {failure_count} times — investigate",
                 "--actor",
                 actor,
             ],
@@ -736,8 +736,9 @@ goes into one of three buckets:
   - **Evolutionary** (scope creep, "while we're at it") → skip with
     `lattice comment {task_short_id} "Skipping [finding]: [reason]" \
 --actor agent:trident-pane-{task_short_id}`.
-  - **Complex** (real design questions) → move task to `needs_human` with
-    a comment.
+  - **Complex** (real design questions) → flag for a human:
+    `lattice needs-human {task_short_id} "<what you need>" \
+--actor agent:trident-pane-{task_short_id}` (task keeps its status).
 
 ## Step 4 — Advance task
 
@@ -747,10 +748,11 @@ goes into one of three buckets:
 | PASS, no PR yet                    | open PR (`gh pr create`), then pr_open|
 | FAIL impl-level                    | in_progress (rework, then re-review)  |
 | FAIL plan-level                    | in_planning                           |
-| Complex finding(s)                 | needs_human                           |
-| 3-cycle safety valve tripped       | needs_human                           |
+| Complex finding(s)                 | keep status, set needs-human flag     |
+| 3-cycle safety valve tripped       | keep status, set needs-human flag     |
 
-Use `lattice status {task_short_id} <new_status> --actor agent:trident-pane-{task_short_id}`.
+Use `lattice status {task_short_id} <new_status> --actor agent:trident-pane-{task_short_id}`,
+or `lattice needs-human {task_short_id} "<what you need>"` for the flag rows.
 
 ## Identity
 

--- a/src/lattice/core/tasks.py
+++ b/src/lattice/core/tasks.py
@@ -28,6 +28,7 @@ PROTECTED_FIELDS: frozenset[str] = frozenset(
         "comment_count",
         "reopened_count",
         "custom_fields",
+        "needs_human",
     }
 )
 
@@ -41,7 +42,6 @@ _DEFAULT_STATUS_ORDER: tuple[str, ...] = (
     "pr_open",
     "done",
     "blocked",
-    "needs_human",
     "cancelled",
 )
 _DEFAULT_STATUS_RANK: dict[str, int] = {
@@ -130,6 +130,7 @@ def compact_snapshot(snapshot: dict) -> dict:
         "last_status_changed_at": snapshot.get("last_status_changed_at"),
         "comment_count": snapshot.get("comment_count", 0),
         "reopened_count": snapshot.get("reopened_count", 0),
+        "needs_human": snapshot.get("needs_human"),
         "relationships_out_count": len(snapshot.get("relationships_out", [])),
         "evidence_ref_count": len(snapshot.get("evidence_refs", [])),
         "branch_link_count": len(snapshot.get("branch_links", [])),
@@ -233,6 +234,20 @@ def _mut_status_changed(snap: dict, event: dict) -> None:
     elif snap.get("done_at") is not None:
         # Transitioning away from done (reopened task) — clear done_at
         snap["done_at"] = None
+
+
+@_register_mutation("needs_human_flagged")
+def _mut_needs_human_flagged(snap: dict, event: dict) -> None:
+    snap["needs_human"] = {
+        "flagged_by": event["actor"],
+        "reason": event["data"]["reason"],
+        "since": event["ts"],
+    }
+
+
+@_register_mutation("needs_human_cleared")
+def _mut_needs_human_cleared(snap: dict, event: dict) -> None:
+    snap["needs_human"] = None
 
 
 @_register_mutation("assignment_changed")

--- a/src/lattice/dashboard/server.py
+++ b/src/lattice/dashboard/server.py
@@ -575,6 +575,7 @@ def _make_handler_class(lattice_dir: Path, *, readonly: bool = False) -> type:
                     "priority": snap.get("priority"),
                     "type": snap.get("type"),
                     "assigned_to": snap.get("assigned_to"),
+                    "needs_human": snap.get("needs_human"),
                     "branch_links": snap.get("branch_links", []),
                     "created_at": snap.get("created_at"),
                     "updated_at": snap.get("updated_at"),

--- a/src/lattice/dashboard/static/cube-v2.js
+++ b/src/lattice/dashboard/static/cube-v2.js
@@ -47,6 +47,13 @@ var CV2_STATUS_COLORS = {
   blocked: '#f87171', needs_human: '#f59e0b', cancelled: '#374151'
 };
 
+/* needs_human is an orthogonal flag: when set, override status color with amber. */
+var CV2_NEEDS_HUMAN_COLOR = '#f59e0b';
+function _cv2NodeColor(node) {
+  if (node && node.needs_human) return CV2_NEEDS_HUMAN_COLOR;
+  return CV2_STATUS_COLORS[node && node.status] || '#6b7280';
+}
+
 var CV2_EDGE_COLORS = {
   blocks: '#ef4444', depends_on: '#f97316', subtask_of: '#3b82f6',
   related_to: '#6b7280', spawned_by: '#8b5cf6'
@@ -321,7 +328,7 @@ function _cv2InitSimulation(nodes, links) {
   _cv2.nodeTargetColors = [];
   _cv2.nodeCurrentColors = [];
   for (var i = 0; i < nodes.length; i++) {
-    var c = new THREE.Color(CV2_STATUS_COLORS[nodes[i].status] || '#6b7280');
+    var c = new THREE.Color(_cv2NodeColor(nodes[i]));
     _cv2.nodeTargetColors.push({ r: c.r, g: c.g, b: c.b });
     _cv2.nodeCurrentColors.push({ r: c.r, g: c.g, b: c.b });
   }
@@ -788,7 +795,7 @@ function _cv2UpdateHover(e) {
     var node = _cv2.nodeData[hit];
     _cv2.hoveredNode = node.id;
     var statusName = _cv2GetStatusDisplayName(node.status || 'backlog');
-    var statusColor = CV2_STATUS_COLORS[node.status] || '#6b7280';
+    var statusColor = _cv2NodeColor(node);
     var priorityLabel = (node.priority || 'medium');
     var typeLabel = (node.type || 'task');
     var snippet = node.description_snippet || '';
@@ -1189,7 +1196,7 @@ function updateCubeV2Data(data) {
   _cv2.nodeTargetColors = [];
   _cv2.nodeCurrentColors = _cv2.nodeCurrentColors || [];
   for (var i = 0; i < nodes.length; i++) {
-    var c = new THREE.Color(CV2_STATUS_COLORS[nodes[i].status] || '#6b7280');
+    var c = new THREE.Color(_cv2NodeColor(nodes[i]));
     _cv2.nodeTargetColors.push({ r: c.r, g: c.g, b: c.b });
     // Preserve current colors for smooth transition, or init if new
     if (!_cv2.nodeCurrentColors[i]) {

--- a/src/lattice/dashboard/static/cube3d.js
+++ b/src/lattice/dashboard/static/cube3d.js
@@ -363,6 +363,13 @@ function cube3dStatusColor(status) {
   return CUBE3D_STATUS_COLORS[status] || '#6b7280';
 }
 
+/* needs_human is an orthogonal flag: when set, override status color with amber. */
+var CUBE3D_NEEDS_HUMAN_COLOR = '#f59e0b';
+function cube3dNodeColor(node) {
+  if (node && node.needs_human) return CUBE3D_NEEDS_HUMAN_COLOR;
+  return cube3dStatusColor(node && node.status);
+}
+
 function cube3dHexToRgb(hex) {
   var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
   return result ? {
@@ -499,7 +506,7 @@ function _cube3dCreateNodes(nodes) {
     dummy.updateMatrix();
     mesh.setMatrixAt(i, dummy.matrix);
 
-    var rgb = cube3dHexToRgb(cube3dStatusColor(node.status));
+    var rgb = cube3dHexToRgb(cube3dNodeColor(node));
     colors[i * 3]     = rgb.r;
     colors[i * 3 + 1] = rgb.g;
     colors[i * 3 + 2] = rgb.b;
@@ -862,7 +869,7 @@ function _cube3dShowTextSprite(node, showTitle) {
 }
 
 function _cube3dShowCard(node) {
-  var statusColor = cube3dStatusColor(node.status);
+  var statusColor = cube3dNodeColor(node);
   var el = document.createElement('div');
   el.className = 'cube3d-card';
   el.style.borderLeftColor = statusColor;
@@ -922,7 +929,7 @@ function _cube3dRenderWorkspacePanel(node, fullData) {
     _cube3d.workspacePanel = null;
   }
 
-  var statusColor = cube3dStatusColor(node.status);
+  var statusColor = cube3dNodeColor(node);
   var el = document.createElement('div');
   el.className = 'cube3d-workspace';
   el.style.borderLeftColor = statusColor;
@@ -1150,7 +1157,7 @@ function _cube3dApplySearch(query) {
   for (var j = 0; j < _cube3d.nodeData.length; j++) {
     var n = _cube3d.nodeData[j];
     if (_cube3d.searchMatches.has(j)) {
-      var rgb = cube3dHexToRgb(cube3dStatusColor(n.status));
+      var rgb = cube3dHexToRgb(cube3dNodeColor(n));
       arr[j * 3]     = rgb.r;
       arr[j * 3 + 1] = rgb.g;
       arr[j * 3 + 2] = rgb.b;
@@ -1195,7 +1202,7 @@ function _cube3dClearSearchHighlight() {
   var arr = colors.array;
   for (var i = 0; i < _cube3d.nodeData.length; i++) {
     var n = _cube3d.nodeData[i];
-    var rgb = cube3dHexToRgb(cube3dStatusColor(n.status));
+    var rgb = cube3dHexToRgb(cube3dNodeColor(n));
     arr[i * 3]     = rgb.r;
     arr[i * 3 + 1] = rgb.g;
     arr[i * 3 + 2] = rgb.b;

--- a/src/lattice/dashboard/static/index.html
+++ b/src/lattice/dashboard/static/index.html
@@ -222,6 +222,9 @@ a:hover{text-decoration:underline}
 .active-badge{display:inline-flex;align-items:center;gap:0.25rem;padding:0.0625rem 0.4375rem;border-radius:10px;font-size:.7rem;font-weight:600;background:rgba(22,163,74,.15);color:var(--color-success);border:1px solid rgba(22,163,74,.3);white-space:nowrap}
 .active-badge .active-dot{width:0.375rem;height:0.375rem}
 
+/* needs_human flag (orthogonal to status) */
+.needs-human-badge{display:inline-flex;align-items:center;gap:0.25rem;padding:0.0625rem 0.4375rem;border-radius:10px;font-size:.7rem;font-weight:700;letter-spacing:.02em;text-transform:uppercase;background:rgba(245,158,11,.18);color:#f59e0b;border:1px solid rgba(245,158,11,.45);white-space:nowrap;cursor:help}
+
 /* Heat indicator (based on last_status_changed_at) */
 /* Board cards: heat bar is rendered inline via JS; these classes add positioning context */
 .card.heat-hot,.card.heat-warm,.card.heat-cooling{position:relative}
@@ -3458,6 +3461,19 @@ function _renderPanelContent(taskId, task, events) {
     html += ' <span class="archived-badge">ARCHIVED</span></div>';
   }
 
+  // needs_human flag (orthogonal to status)
+  if (task.needs_human) {
+    var nh = task.needs_human;
+    html += '<div style="margin:8px 0;padding:8px 10px;border-radius:6px;background:rgba(245,158,11,.12);border:1px solid rgba(245,158,11,.4)">';
+    html += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:4px"><span class="needs-human-badge">Needs Human</span></div>';
+    if (nh.reason) html += '<div style="font-size:.85rem;color:var(--text-primary)">' + esc(nh.reason) + '</div>';
+    var nhMeta = [];
+    if (nh.flagged_by) nhMeta.push('flagged by ' + esc(nh.flagged_by));
+    if (nh.since) nhMeta.push('since ' + esc(nh.since));
+    if (nhMeta.length) html += '<div style="font-size:.7rem;color:var(--text-muted);margin-top:3px">' + nhMeta.join(' · ') + '</div>';
+    html += '</div>';
+  }
+
   // Title (editable)
   if (!isArchived) {
     html += '<div class="dp-field"><dt>Title</dt><dd><span class="editable" id="dp-title-edit" title="Click to edit">' + esc(task.title || "Untitled") + '</span></dd></div>';
@@ -4413,6 +4429,10 @@ function renderBoardCard(t) {
   }
   html += '<div class="card-title">' + esc(t.title || "Untitled") + "</div>";
   html += '<div class="card-meta">';
+  if (t.needs_human) {
+    var nhReason = (t.needs_human && t.needs_human.reason) ? String(t.needs_human.reason) : "Needs human attention";
+    html += '<span class="needs-human-badge" title="' + esc(nhReason) + '">Needs Human</span>';
+  }
   if (t.priority) html += '<span class="badge pri-' + esc(t.priority) + '">' + esc(t.priority) + "</span>";
   if (t.type) html += '<span class="badge type-badge">' + esc(t.type) + "</span>";
   if (t.has_active_session) html += '<span class="active-badge"><span class="active-dot"></span>Active</span>';

--- a/src/lattice/dashboard/static/index.html
+++ b/src/lattice/dashboard/static/index.html
@@ -3468,7 +3468,8 @@ function _renderPanelContent(taskId, task, events) {
     html += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:4px"><span class="needs-human-badge">Needs Human</span></div>';
     if (nh.reason) html += '<div style="font-size:.85rem;color:var(--text-primary)">' + esc(nh.reason) + '</div>';
     var nhMeta = [];
-    if (nh.flagged_by) nhMeta.push('flagged by ' + esc(nh.flagged_by));
+    var nhActor = (nh.flagged_by && typeof nh.flagged_by === 'object') ? (nh.flagged_by.name || nh.flagged_by.id || '') : nh.flagged_by;
+    if (nhActor) nhMeta.push('flagged by ' + esc(nhActor));
     if (nh.since) nhMeta.push('since ' + esc(nh.since));
     if (nhMeta.length) html += '<div style="font-size:.7rem;color:var(--text-muted);margin-top:3px">' + nhMeta.join(' · ') + '</div>';
     html += '</div>';

--- a/src/lattice/skills/lattice/SKILL.md
+++ b/src/lattice/skills/lattice/SKILL.md
@@ -49,7 +49,7 @@ The `--review` text is your breadcrumb for every future agent and human who read
 | Outcome | Action |
 |---------|--------|
 | **Done** | `lattice complete <task_id> --review "..." --actor agent:claude-cli` |
-| **Need human input** | `lattice status <task_id> needs_human --actor agent:claude-cli` + comment explaining what you need |
+| **Need human input** | `lattice needs-human <task_id> "<what you need>" --actor agent:claude-cli` (the task keeps its status — the flag is orthogonal) |
 | **Blocked on dependency** | `lattice status <task_id> blocked --actor agent:claude-cli` + comment explaining the blocker |
 
 ## The Work In Between
@@ -92,6 +92,11 @@ lattice comment PROJ-1 "Found root cause" --actor agent:claude-cli
 # Link
 lattice link PROJ-1 blocks PROJ-2 --actor agent:claude-cli
 
+# Flag for human attention (orthogonal to status — task keeps its current status)
+lattice needs-human PROJ-1 "Which OAuth provider?" --actor agent:claude-cli
+lattice needs-human PROJ-1 --clear --note "Decided: use Google" --actor agent:claude-cli
+lattice list --needs-human          # scannable queue of flagged tasks, any status
+
 # Next task
 lattice next --actor agent:claude-cli --claim --json
 
@@ -123,11 +128,13 @@ Relationship types for `link`: `blocks`, `blocked_by`, `subtask_of`, `parent_of`
 
 ```
 backlog → in_planning → planned → in_progress → review → done
-                                       ↕            ↕
-                                    blocked      needs_human
+                                       ↕
+                                    blocked
 ```
 
 Transitions are enforced. Use `--force --reason "..."` to override when genuinely needed.
+
+**`needs-human` is a flag, not a status.** It rides orthogonally on top of whatever status a task is in — a task can be `in_progress` and flagged, `blocked` and flagged, even `done` and flagged. Set it with `lattice needs-human <task> "<reason>"` (reason required) and clear it with `lattice needs-human <task> --clear`. The flag never moves the task. `blocked` stays a status for generic external dependencies; `needs-human` means "waiting on a human specifically," and the two can coexist.
 
 ## Actor IDs
 
@@ -148,7 +155,7 @@ All commands support `--json` for structured output: `{"ok": true, "data": ...}`
 
 Check if enabled: look for `"heartbeat": {"enabled": true}` in `.lattice/config.json`.
 
-When enabled, keep advancing after each task: complete the current task → `lattice next --claim` → work the next one → repeat. Stop after `max_advances` (default 10), when the backlog is empty, or when a task hits `needs_human` or `blocked`.
+When enabled, keep advancing after each task: complete the current task → `lattice next --claim` → work the next one → repeat. Stop after `max_advances` (default 10), when the backlog is empty, or when a task is flagged `needs-human` or hits `blocked`.
 
 ## Rules
 
@@ -156,7 +163,7 @@ When enabled, keep advancing after each task: complete the current task → `lat
 2. **Close with `lattice complete`.** Never raw `lattice status ... done`.
 3. **One task at a time.** Finish or transition before claiming the next.
 4. **Don't force transitions.** If a transition fails, investigate why.
-5. **Don't cancel human tasks.** Use `needs_human` instead — let the human decide.
+5. **Don't cancel human tasks.** Flag them with `lattice needs-human` instead — let the human decide.
 6. **Comment liberally.** The next agent has no hallway to find you in.
 
 ## References

--- a/src/lattice/skills/lattice/references/multi-agent-guide.md
+++ b/src/lattice/skills/lattice/references/multi-agent-guide.md
@@ -67,12 +67,19 @@ lattice status PROJ-2 blocked --actor agent:worker-1
 lattice comment PROJ-2 "Blocked: need database schema from PROJ-5" --actor agent:worker-1
 ```
 
-When a worker needs a human decision:
+When a worker needs a human decision, it flags the task. `needs-human` is orthogonal to status — the flag rides on top of whatever status the task is in, so the work stays exactly where it was (here, still `in_progress`):
 
 ```bash
-lattice status PROJ-2 needs_human --actor agent:worker-1
-lattice comment PROJ-2 "Need: which OAuth provider to use?" --actor agent:worker-1
+lattice needs-human PROJ-2 "Which OAuth provider to use?" --actor agent:worker-1
 ```
+
+The reason is required and replaces the old "leave a comment" convention. The orchestrator sees the flagged task via `lattice list --needs-human` (a queue spanning every status), resolves it, and clears the flag:
+
+```bash
+lattice needs-human PROJ-2 --clear --note "Decided: Google" --actor agent:worker-1
+```
+
+Use `blocked` (a status) for generic external dependencies; use the `needs-human` flag for "waiting on a human specifically." A task can be both blocked and flagged.
 
 ### 6. Event History
 

--- a/src/lattice/templates/claude_md_block.py
+++ b/src/lattice/templates/claude_md_block.py
@@ -26,7 +26,7 @@ lattice create "<title>" --actor agent:<your-id>
 
 When in doubt, create the task. A small task costs nothing. Lost visibility costs everything.
 
-**Recurring observations become tasks.** If you observe the same issue in 2+ consecutive sessions or advances (e.g., a failing test, a lint warning, a flaky behavior), create a task for it. Agents are disciplined about tracking assigned work but not discovered work — this convention closes that gap. Create discovered issues at `needs_human` if they need scoping, or `backlog` if they're well-understood.
+**Recurring observations become tasks.** If you observe the same issue in 2+ consecutive sessions or advances (e.g., a failing test, a lint warning, a flaky behavior), create a task for it. Agents are disciplined about tracking assigned work but not discovered work — this convention closes that gap. Create discovered issues at `backlog`; if they need human scoping, also flag them (`lattice needs-human <task> "Need: scoping"`).
 
 ### Descriptions Carry Context
 
@@ -46,9 +46,11 @@ lattice status <task> <status> --actor agent:<your-id>
 
 ```
 backlog → in_planning → planned → in_progress → review → done
-                                       ↕            ↕
-                                    blocked      needs_human
+                                       ↕
+                                    blocked
 ```
+
+Human attention is NOT a status: any task in any status can carry the orthogonal `needs_human` flag (`lattice needs-human <task> "<what you need>"`). The task keeps its swimlane while it waits — see "When You're Stuck" below.
 
 **Transition discipline:**
 - `in_planning` — before you open the first file to read. Then write the plan.
@@ -114,7 +116,7 @@ The mode controls *how* the review runs:
 | `triple` | Splits one new pane in the caller's c11 workspace and runs `/trident-plan-review` there. The pane owns trident and the task advance. CLI returns immediately. Requires c11. |
 | `inline` | Reviews the plan in-session (use when codex/gemini aren't available, or for small/throwaway projects). Auto-fire is a no-op for inline. |
 
-When `plan_approval` is `human`, the CLI automatically moves the task to `needs_human` after `lattice plan-review` completes. Wait for human approval before proceeding to `in_progress`.
+When `plan_approval` is `human`, the CLI automatically sets the `needs_human` flag after `lattice plan-review` completes — the task stays in `planned`. Wait for human approval (the human clears the flag) before proceeding to `in_progress`.
 
 ### Plan Review Triage
 
@@ -124,7 +126,7 @@ When the plan review returns (trident or otherwise), the orchestrator sorts ever
 |--------|--------------------|----------------|
 | **Obvious** | Missing acceptance criteria, contradictions, plan bugs, trivial clarifications, concrete omissions | Fix directly — amend the plan file, record a short `lattice comment` noting what was resolved. |
 | **Evolutionary** | Speculative additions, "while we're at it" scope creep, refactor suggestions not tied to the ticket's goal, nice-to-haves | Be skeptical. Default to skip. If worth tracking, create a new Lattice task (`lattice create ...`) and link it — do not fold into this ticket. Record a comment explaining why it was deferred. |
-| **Complex** | Genuine design decisions, ambiguity the agent can't resolve alone, trade-offs with real stakes, requirement questions | Bring to the human. Move to `needs_human` with a short comment stating the open question(s). |
+| **Complex** | Genuine design decisions, ambiguity the agent can't resolve alone, trade-offs with real stakes, requirement questions | Bring to the human. Flag it: `lattice needs-human <task> "<the open question(s)>"` — the task keeps its status. |
 
 Every finding must be explicitly triaged — no silent drops. If triage produces no complex questions, advance to `in_progress`. Otherwise, wait for the human answer, fold it into the plan, then advance.
 
@@ -194,7 +196,7 @@ When a review agent evaluates work, it produces one of three outcomes:
 | Route to in_progress vs in_planning | Orchestrator | Follows review agent's recommendation |
 | Whether to spawn fresh sub-agent | Orchestrator | Encouraged by convention, not enforced |
 
-**3-cycle safety valve:** After 3 review-to-rework transitions (any combination of `review -> in_progress` and `review -> in_planning`), the CLI blocks the 4th attempt. The error message instructs the agent to move the task to `needs_human` with a comment explaining the situation. The limit is configurable via `review_cycle_limit` in the workflow config (default: 3). Override with `--force --reason` for genuinely exceptional cases.
+**3-cycle safety valve:** After 3 review-to-rework transitions (any combination of `review -> in_progress` and `review -> in_planning`), the CLI blocks the 4th attempt. The error message instructs the agent to set the `needs_human` flag with a reason explaining the situation. The limit is configurable via `review_cycle_limit` in the workflow config (default: 3). Override with `--force --reason` for genuinely exceptional cases.
 
 **Allowed lifecycle paths:**
 
@@ -203,7 +205,7 @@ Normal:       in_progress -> review -> done
 Minor fix:    in_progress -> review -> (fix inline) -> done
 1 impl rework: in_progress -> review -> in_progress -> review -> done
 1 plan rework: in_progress -> review -> in_planning -> planned -> in_progress -> review -> done
-Max cycles:   3 review->rework transitions, then CLI blocks -> needs_human
+Max cycles:   3 review->rework transitions, then CLI blocks -> flag needs-human
 ```
 
 ### Review Config Reference
@@ -214,7 +216,7 @@ Five settings in `.lattice/config.json` control review behavior:
 |---------|--------|---------|---------|
 | `review_mode` | `inline`, `single`, `triple` | `single` | How code review is performed at the review gate |
 | `plan_review_mode` | `inline`, `single`, `triple` | `single` | How plan review is performed after the plan is written |
-| `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` moves to `needs_human` for approval |
+| `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` sets the `needs_human` flag (task stays `planned`) for approval |
 | `auto_code_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice code-review` when a task transitions to `review` |
 | `auto_plan_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice plan-review` when a task transitions to `planned` |
 
@@ -235,14 +237,14 @@ When a task transitions to `review` or `planned`, `lattice status` automatically
 
 ### When You're Stuck
 
-Use `needs_human` when you need human decision, approval, or input **right now**. This is distinct from `blocked` (generic external dependency) — it creates a scannable queue. **`needs_human` means actionable NOW** — future checkpoints (quality gates, review gates, approval milestones) stay at `planned` or `backlog` until the preceding work is complete. The orchestrator flips them to `needs_human` at the moment they become actionable.
+Set the `needs_human` flag when you need human decision, approval, or input **right now**. The flag is orthogonal to status: the task keeps its swimlane (it can be `in_progress` AND waiting on a human), and it is distinct from `blocked` (generic external dependency — a task can be both). **The flag means actionable NOW** — future checkpoints (quality gates, review gates, approval milestones) stay unflagged until the preceding work is complete. The orchestrator flags them at the moment they become actionable.
 
 ```
-lattice status <task> needs_human --actor agent:<your-id>
-lattice comment <task> "Need: <what you need, in one line>" --actor agent:<your-id>
+lattice needs-human <task> "Need: <what you need, in one line>" --actor agent:<your-id>
+lattice needs-human <task> --clear --note "<how it was resolved>" --actor <whoever-resolved>
 ```
 
-Use for: design decisions requiring human judgment, missing access/credentials, ambiguous requirements, approval gates. The comment is mandatory — explain what you need in seconds, not minutes. The human's queue should be scannable.
+Use for: design decisions requiring human judgment, missing access/credentials, ambiguous requirements, approval gates. The reason is required — explain what you need in seconds, not minutes. The human scans the queue with `lattice list --needs-human` and clears the flag when answered.
 
 ### Actor Attribution
 

--- a/tests/test_cli/test_migrate.py
+++ b/tests/test_cli/test_migrate.py
@@ -1,0 +1,127 @@
+"""Tests for `lattice migrate needs-human` (LAT-232)."""
+
+from __future__ import annotations
+
+import json
+
+_ACTOR = "agent:test"
+
+
+def _make_legacy_instance(invoke, initialized_root, *, with_comment: bool = True) -> str:
+    """Reshape the initialized root into a pre-LAT-232 instance.
+
+    Restores the needs_human status to the config and parks one task in it
+    (via in_planning, so the migration has a return status to find).
+    Returns the task ID.
+    """
+    config_path = initialized_root / ".lattice" / "config.json"
+    config = json.loads(config_path.read_text())
+    wf = config["workflow"]
+    wf["statuses"].insert(wf["statuses"].index("cancelled"), "needs_human")
+    wf["transitions"]["needs_human"] = ["in_planning", "in_progress", "cancelled"]
+    wf["transitions"]["in_planning"].insert(0, "needs_human")
+    wf["universal_targets"] = ["needs_human", "cancelled"]
+    wf["descriptions"]["needs_human"] = "A human decision is required."
+    config_path.write_text(json.dumps(config, sort_keys=True, indent=2) + "\n")
+
+    r = invoke("create", "Legacy stuck task", "--actor", _ACTOR, "--json")
+    task_id = json.loads(r.output)["data"]["id"]
+    invoke("status", task_id, "in_planning", "--actor", _ACTOR)
+    if with_comment:
+        invoke("comment", task_id, "Need: pick an auth provider", "--actor", _ACTOR)
+    r = invoke("status", task_id, "needs_human", "--actor", _ACTOR, "--json")
+    assert r.exit_code == 0, r.output
+    return task_id
+
+
+def _read_snap(initialized_root, task_id: str) -> dict:
+    return json.loads((initialized_root / ".lattice" / "tasks" / f"{task_id}.json").read_text())
+
+
+def _read_config(initialized_root) -> dict:
+    return json.loads((initialized_root / ".lattice" / "config.json").read_text())
+
+
+class TestMigrateNeedsHuman:
+    def test_migrates_task_and_config(self, invoke, initialized_root) -> None:
+        task_id = _make_legacy_instance(invoke, initialized_root)
+
+        r = invoke("migrate", "needs-human", "--json")
+        assert r.exit_code == 0, r.output
+        data = json.loads(r.output)["data"]
+        assert len(data["tasks_migrated"]) == 1
+        assert data["tasks_migrated"][0]["return_status"] == "in_planning"
+
+        snap = _read_snap(initialized_root, task_id)
+        assert snap["status"] == "in_planning"
+        assert snap["needs_human"]["reason"] == "Need: pick an auth provider"
+
+        wf = _read_config(initialized_root)["workflow"]
+        assert "needs_human" not in wf["statuses"]
+        assert "needs_human" not in wf["transitions"]
+        assert all("needs_human" not in targets for targets in wf["transitions"].values())
+        assert wf["universal_targets"] == ["cancelled"]
+        assert "needs_human" not in wf.get("descriptions", {})
+
+    def test_fallback_reason_without_comment(self, invoke, initialized_root) -> None:
+        task_id = _make_legacy_instance(invoke, initialized_root, with_comment=False)
+        r = invoke("migrate", "needs-human")
+        assert r.exit_code == 0, r.output
+        snap = _read_snap(initialized_root, task_id)
+        assert snap["needs_human"]["reason"] == "Migrated from needs_human status"
+
+    def test_idempotent(self, invoke, initialized_root) -> None:
+        task_id = _make_legacy_instance(invoke, initialized_root)
+        invoke("migrate", "needs-human")
+        snap_after_first = _read_snap(initialized_root, task_id)
+        config_after_first = _read_config(initialized_root)
+
+        r = invoke("migrate", "needs-human", "--json")
+        assert r.exit_code == 0, r.output
+        data = json.loads(r.output)["data"]
+        assert data["tasks_migrated"] == []
+        assert data["config_changes"] == []
+        assert _read_snap(initialized_root, task_id) == snap_after_first
+        assert _read_config(initialized_root) == config_after_first
+
+    def test_dry_run_writes_nothing(self, invoke, initialized_root) -> None:
+        task_id = _make_legacy_instance(invoke, initialized_root)
+        snap_before = _read_snap(initialized_root, task_id)
+        config_before = _read_config(initialized_root)
+
+        r = invoke("migrate", "needs-human", "--dry-run", "--json")
+        assert r.exit_code == 0, r.output
+        data = json.loads(r.output)["data"]
+        assert data["dry_run"] is True
+        assert len(data["tasks_migrated"]) == 1
+        assert data["config_changes"]
+
+        assert _read_snap(initialized_root, task_id) == snap_before
+        assert _read_config(initialized_root) == config_before
+
+    def test_migration_events_carry_provenance(self, invoke, initialized_root) -> None:
+        task_id = _make_legacy_instance(invoke, initialized_root)
+        invoke("migrate", "needs-human")
+        events_path = initialized_root / ".lattice" / "events" / f"{task_id}.jsonl"
+        events = [json.loads(line) for line in events_path.read_text().splitlines() if line]
+        flag_event = next(e for e in events if e["type"] == "needs_human_flagged")
+        assert "LAT-232 migration" in flag_event["provenance"]["reason"]
+        route_event = events[-1]
+        assert route_event["type"] == "status_changed"
+        assert route_event["data"] == {"from": "needs_human", "to": "in_planning"}
+        assert "LAT-232 migration" in route_event["provenance"]["reason"]
+
+    def test_rebuild_reproduces_migrated_snapshot(self, invoke, initialized_root) -> None:
+        """AC #10: the migrated snapshot is exactly what event replay produces."""
+        task_id = _make_legacy_instance(invoke, initialized_root)
+        invoke("migrate", "needs-human")
+        snap_path = initialized_root / ".lattice" / "tasks" / f"{task_id}.json"
+        before = snap_path.read_text()
+        r = invoke("rebuild", "--all")
+        assert r.exit_code == 0, r.output
+        assert snap_path.read_text() == before
+
+    def test_nothing_to_migrate(self, invoke, initialized_root) -> None:
+        r = invoke("migrate", "needs-human")
+        assert r.exit_code == 0
+        assert "Nothing to migrate" in r.output

--- a/tests/test_cli/test_needs_human_flag.py
+++ b/tests/test_cli/test_needs_human_flag.py
@@ -1,0 +1,233 @@
+"""Tests for the `lattice needs-human` flag command (LAT-232)."""
+
+from __future__ import annotations
+
+import json
+
+_ACTOR = "agent:test"
+
+
+def _create(invoke, title: str = "Flag me") -> str:
+    r = invoke("create", title, "--actor", _ACTOR, "--json")
+    assert r.exit_code == 0, r.output
+    return json.loads(r.output)["data"]["id"]
+
+
+class TestSetFlag:
+    def test_set_in_backlog(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        r = invoke("needs-human", task_id, "Need: which DB?", "--actor", _ACTOR, "--json")
+        assert r.exit_code == 0, r.output
+        data = json.loads(r.output)["data"]
+        assert data["status"] == "backlog"  # status untouched
+        flag = data["needs_human"]
+        assert flag["flagged_by"] == _ACTOR
+        assert flag["reason"] == "Need: which DB?"
+        assert flag["since"]
+
+    def test_set_in_any_status(self, invoke, initialized_root, fill_plan) -> None:
+        """The flag is settable in every status, including done."""
+        task_id = _create(invoke)
+        invoke("status", task_id, "in_planning", "--actor", _ACTOR)
+        fill_plan(task_id)
+        for status in ("planned", "in_progress", "review"):
+            invoke("status", task_id, status, "--actor", _ACTOR)
+        invoke("comment", task_id, "LGTM", "--role", "review", "--actor", _ACTOR)
+        invoke("status", task_id, "done", "--actor", _ACTOR)
+        r = invoke("needs-human", task_id, "Post-ship question", "--actor", _ACTOR, "--json")
+        assert r.exit_code == 0, r.output
+        data = json.loads(r.output)["data"]
+        assert data["status"] == "done"
+        assert data["needs_human"]["reason"] == "Post-ship question"
+
+    def test_reason_required(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        r = invoke("needs-human", task_id, "--actor", _ACTOR, "--json")
+        assert r.exit_code != 0
+        parsed = json.loads(r.output)
+        assert parsed["ok"] is False
+        assert "REASON is required" in parsed["error"]["message"]
+
+    def test_blank_reason_rejected(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        r = invoke("needs-human", task_id, "   ", "--actor", _ACTOR)
+        assert r.exit_code != 0
+
+    def test_double_set_rejected(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        invoke("needs-human", task_id, "first", "--actor", _ACTOR)
+        r = invoke("needs-human", task_id, "second", "--actor", _ACTOR, "--json")
+        assert r.exit_code != 0
+        parsed = json.loads(r.output)
+        assert parsed["error"]["code"] == "FLAG_ALREADY_SET"
+        assert "first" in parsed["error"]["message"]
+
+    def test_flag_event_appended(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        invoke("needs-human", task_id, "decision needed", "--actor", _ACTOR)
+        events_path = initialized_root / ".lattice" / "events" / f"{task_id}.jsonl"
+        events = [json.loads(line) for line in events_path.read_text().splitlines() if line]
+        flag_events = [e for e in events if e["type"] == "needs_human_flagged"]
+        assert len(flag_events) == 1
+        assert flag_events[0]["actor"] == _ACTOR
+        assert flag_events[0]["data"]["reason"] == "decision needed"
+
+    def test_orthogonal_to_blocked(self, invoke, initialized_root, fill_plan) -> None:
+        """A task can be blocked AND flagged simultaneously."""
+        task_id = _create(invoke)
+        invoke("status", task_id, "in_planning", "--actor", _ACTOR)
+        fill_plan(task_id)
+        invoke("status", task_id, "planned", "--actor", _ACTOR)
+        invoke("status", task_id, "blocked", "--actor", _ACTOR)
+        r = invoke("needs-human", task_id, "also need a decision", "--actor", _ACTOR, "--json")
+        assert r.exit_code == 0
+        data = json.loads(r.output)["data"]
+        assert data["status"] == "blocked"
+        assert data["needs_human"]["reason"] == "also need a decision"
+
+
+class TestClearFlag:
+    def test_clear(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        invoke("needs-human", task_id, "question", "--actor", _ACTOR)
+        r = invoke(
+            "needs-human", task_id, "--clear", "--note", "answered", "--actor", "human:t", "--json"
+        )
+        assert r.exit_code == 0, r.output
+        data = json.loads(r.output)["data"]
+        assert data["needs_human"] is None
+
+    def test_clear_event_appended(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        invoke("needs-human", task_id, "question", "--actor", _ACTOR)
+        invoke("needs-human", task_id, "--clear", "--note", "resolved", "--actor", "human:t")
+        events_path = initialized_root / ".lattice" / "events" / f"{task_id}.jsonl"
+        events = [json.loads(line) for line in events_path.read_text().splitlines() if line]
+        clear_events = [e for e in events if e["type"] == "needs_human_cleared"]
+        assert len(clear_events) == 1
+        assert clear_events[0]["actor"] == "human:t"
+        assert clear_events[0]["data"]["note"] == "resolved"
+
+    def test_clear_when_not_set_rejected(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        r = invoke("needs-human", task_id, "--clear", "--actor", _ACTOR, "--json")
+        assert r.exit_code != 0
+        assert json.loads(r.output)["error"]["code"] == "FLAG_NOT_SET"
+
+    def test_clear_with_reason_rejected(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        invoke("needs-human", task_id, "question", "--actor", _ACTOR)
+        r = invoke("needs-human", task_id, "oops", "--clear", "--actor", _ACTOR)
+        assert r.exit_code != 0
+
+    def test_set_clear_set_again(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        invoke("needs-human", task_id, "q1", "--actor", _ACTOR)
+        invoke("needs-human", task_id, "--clear", "--actor", _ACTOR)
+        r = invoke("needs-human", task_id, "q2", "--actor", _ACTOR, "--json")
+        assert r.exit_code == 0
+        assert json.loads(r.output)["data"]["needs_human"]["reason"] == "q2"
+
+
+class TestQueueAndSurfaces:
+    def test_list_needs_human_filter(self, invoke, initialized_root) -> None:
+        flagged_id = _create(invoke, "Flagged task")
+        _create(invoke, "Unflagged task")
+        invoke("needs-human", flagged_id, "decision", "--actor", _ACTOR)
+
+        r = invoke("list", "--needs-human", "--json")
+        assert r.exit_code == 0
+        data = json.loads(r.output)["data"]
+        assert len(data) == 1
+        assert data[0]["id"] == flagged_id
+        assert data[0]["needs_human"]["reason"] == "decision"
+
+    def test_list_human_output_marks_flagged(self, invoke, initialized_root) -> None:
+        flagged_id = _create(invoke, "Flagged task")
+        invoke("needs-human", flagged_id, "decision", "--actor", _ACTOR)
+        r = invoke("list")
+        assert r.exit_code == 0
+        flagged_line = next(line for line in r.output.splitlines() if "Flagged task" in line)
+        assert flagged_line.startswith(">>> ")
+        assert "needs human: decision" in flagged_line
+
+    def test_show_renders_flag(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        invoke("needs-human", task_id, "which key?", "--actor", _ACTOR)
+        r = invoke("show", task_id)
+        assert r.exit_code == 0
+        assert "NEEDS HUMAN" in r.output
+        assert "which key?" in r.output
+
+    def test_next_skips_flagged(self, invoke, initialized_root) -> None:
+        flagged_id = _create(invoke, "Flagged")
+        other_id = _create(invoke, "Pickable")
+        invoke("needs-human", flagged_id, "decision", "--actor", _ACTOR)
+        r = invoke("next", "--json")
+        assert r.exit_code == 0
+        data = json.loads(r.output)["data"]
+        assert data["id"] == other_id
+
+    def test_weather_surfaces_flag_reason(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke, "Stormy")
+        invoke("needs-human", task_id, "pick a vendor", "--actor", _ACTOR)
+        r = invoke("weather", "--json")
+        assert r.exit_code == 0
+        data = json.loads(r.output)["data"]
+        nh_items = [i for i in data["attention"] if i["type"] == "needs_human"]
+        assert len(nh_items) == 1
+        assert nh_items[0]["detail"] == "pick a vendor"
+
+
+class TestRebuildDeterminism:
+    def test_rebuild_reproduces_flag(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        invoke("needs-human", task_id, "decision", "--actor", _ACTOR)
+        snap_path = initialized_root / ".lattice" / "tasks" / f"{task_id}.json"
+        before = snap_path.read_text()
+        r = invoke("rebuild", "--all")
+        assert r.exit_code == 0, r.output
+        assert snap_path.read_text() == before
+
+    def test_rebuild_reproduces_cleared_flag(self, invoke, initialized_root) -> None:
+        task_id = _create(invoke)
+        invoke("needs-human", task_id, "decision", "--actor", _ACTOR)
+        invoke("needs-human", task_id, "--clear", "--actor", _ACTOR)
+        snap_path = initialized_root / ".lattice" / "tasks" / f"{task_id}.json"
+        before = snap_path.read_text()
+        r = invoke("rebuild", "--all")
+        assert r.exit_code == 0, r.output
+        assert snap_path.read_text() == before
+
+
+class TestLegacyStatusInstances:
+    """Instances whose config still carries the needs_human STATUS keep working."""
+
+    @staticmethod
+    def _add_legacy_status(initialized_root) -> None:
+        config_path = initialized_root / ".lattice" / "config.json"
+        config = json.loads(config_path.read_text())
+        wf = config["workflow"]
+        wf["statuses"].append("needs_human")
+        wf["transitions"]["needs_human"] = ["in_planning", "in_progress", "cancelled"]
+        wf["transitions"]["in_planning"].insert(0, "needs_human")
+        wf["universal_targets"] = ["needs_human", "cancelled"]
+        config_path.write_text(json.dumps(config, sort_keys=True, indent=2) + "\n")
+
+    def test_status_transitions_still_work(self, invoke, initialized_root) -> None:
+        """Transition into and out of the legacy status — no crash, sane snapshot."""
+        self._add_legacy_status(initialized_root)
+        task_id = _create(invoke)
+        invoke("status", task_id, "in_planning", "--actor", _ACTOR)
+
+        r = invoke("status", task_id, "needs_human", "--actor", _ACTOR, "--json")
+        assert r.exit_code == 0, r.output
+        assert json.loads(r.output)["data"]["status"] == "needs_human"
+
+        r = invoke("status", task_id, "in_planning", "--actor", _ACTOR, "--json")
+        assert r.exit_code == 0, r.output
+        data = json.loads(r.output)["data"]
+        assert data["status"] == "in_planning"
+        # needs_human is unranked in the default order — backward detection
+        # must degrade gracefully (no spurious reopen counting, no crash).
+        assert isinstance(data.get("reopened_count", 0), int)

--- a/tests/test_cli/test_review_cmds.py
+++ b/tests/test_cli/test_review_cmds.py
@@ -362,7 +362,7 @@ class TestPlanReviewSingle:
         # Should not crash
         assert result.exit_code == 0 or "failed" in result.output
 
-    def test_plan_approval_human_moves_status(self, tmp_path):
+    def test_plan_approval_human_sets_flag(self, tmp_path):
         root = _make_board(tmp_path, {"plan_review_mode": "single", "plan_approval": "human"})
         runner = CliRunner()
         task_id = _create_task(runner, root)
@@ -379,7 +379,7 @@ class TestPlanReviewSingle:
                 "lattice.cli.review_cmds._attach_review_artifact",
                 return_value=fake_art_id,
             ),
-            patch("lattice.cli.review_cmds._move_to_needs_human") as mock_move,
+            patch("lattice.cli.review_cmds._flag_needs_human") as mock_move,
         ):
             runner.invoke(
                 cli,

--- a/tests/test_cli/test_task_status.py
+++ b/tests/test_cli/test_task_status.py
@@ -148,12 +148,12 @@ class TestCompletionPolicyGating:
         assert parsed["ok"] is True
 
     def test_universal_target_bypasses_policy(self, invoke, initialized_root, fill_plan) -> None:
-        """Universal targets bypass policies — even with a policy on needs_human."""
+        """Universal targets bypass policies — even with a policy on cancelled."""
         _add_policies_to_config(
             initialized_root,
             {
                 "done": {"require_roles": ["review"]},
-                "needs_human": {"require_roles": ["review"]},
+                "cancelled": {"require_roles": ["review"]},
             },
         )
 
@@ -164,7 +164,7 @@ class TestCompletionPolicyGating:
         invoke("status", task_id, "planned", "--actor", _ACTOR)
         invoke("status", task_id, "in_progress", "--actor", _ACTOR)
 
-        r = invoke("status", task_id, "needs_human", "--actor", _ACTOR, "--json")
+        r = invoke("status", task_id, "cancelled", "--actor", _ACTOR, "--json")
         assert r.exit_code == 0
 
     def test_no_policy_no_gating(self, invoke, initialized_root, fill_plan) -> None:
@@ -665,28 +665,28 @@ class TestNextStepsHints:
         assert "implement the plan" in r.output
         assert "move to review" in r.output
 
-    def test_needs_human_echoes_latest_comment(self, invoke, initialized_root) -> None:
+    def test_needs_human_status_rejected_with_flag_hint(self, invoke, initialized_root) -> None:
+        """needs_human is not a status in the default config — the error points at the flag."""
         r = invoke("create", "Needs human hint", "--actor", _ACTOR, "--json")
         task_id = json.loads(r.output)["data"]["id"]
         invoke("status", task_id, "in_planning", "--actor", _ACTOR)
-        invoke("comment", task_id, "Need API design decision", "--actor", _ACTOR)
 
         r = invoke("status", task_id, "needs_human", "--actor", _ACTOR)
-        assert r.exit_code == 0
-        assert "Need API design decision" in r.output
+        assert r.exit_code != 0
+        assert "needs_human is a flag, not a status" in r.output
+        assert "lattice needs-human" in r.output
 
-    def test_needs_human_json_includes_comment(self, invoke, initialized_root) -> None:
+    def test_needs_human_status_rejected_json(self, invoke, initialized_root) -> None:
         r = invoke("create", "NH json", "--actor", _ACTOR, "--json")
         task_id = json.loads(r.output)["data"]["id"]
         invoke("status", task_id, "in_planning", "--actor", _ACTOR)
-        invoke("comment", task_id, "Blocked on credentials", "--actor", _ACTOR)
 
         r = invoke("status", task_id, "needs_human", "--actor", _ACTOR, "--json")
-        assert r.exit_code == 0
-        data = json.loads(r.output)["data"]
-        ns = data["next_steps"]
-        assert ns["action"] == "awaiting_human"
-        assert ns["latest_comment"] == "Blocked on credentials"
+        assert r.exit_code != 0
+        parsed = json.loads(r.output)
+        assert parsed["ok"] is False
+        assert parsed["error"]["code"] == "VALIDATION_ERROR"
+        assert "lattice needs-human" in parsed["error"]["message"]
 
     def test_planned_no_hint_when_inline(self, invoke, initialized_root, fill_plan) -> None:
         """When plan_review_mode is inline, planned produces no hint."""

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -54,7 +54,6 @@ class TestDefaultConfig:
             "pr_open",
             "done",
             "blocked",
-            "needs_human",
             "cancelled",
         ]
         assert config["workflow"]["statuses"] == expected
@@ -71,7 +70,6 @@ class TestDefaultConfig:
             "pr_open",
             "done",
             "blocked",
-            "needs_human",
             "cancelled",
         }
         assert set(transitions.keys()) == expected_keys
@@ -85,8 +83,8 @@ class TestDefaultConfig:
     def test_has_universal_targets(self) -> None:
         config = default_config()
         assert "universal_targets" in config["workflow"]
-        assert "needs_human" in config["workflow"]["universal_targets"]
-        assert "cancelled" in config["workflow"]["universal_targets"]
+        assert config["workflow"]["universal_targets"] == ["cancelled"]
+        assert "needs_human" not in config["workflow"]["universal_targets"]
 
     def test_wip_limits(self) -> None:
         config = default_config()
@@ -283,13 +281,14 @@ class TestValidateTransition:
                     f"Universal target {target!r} should be reachable from {from_s!r}"
                 )
 
-    def test_universal_target_backlog_to_needs_human(self) -> None:
+    def test_universal_target_backlog_to_cancelled(self) -> None:
         config = default_config()
-        assert validate_transition(config, "backlog", "needs_human") is True
+        assert validate_transition(config, "backlog", "cancelled") is True
 
-    def test_universal_target_done_to_needs_human(self) -> None:
+    def test_needs_human_not_a_default_status(self) -> None:
         config = default_config()
-        assert validate_transition(config, "done", "needs_human") is True
+        assert validate_transition(config, "backlog", "needs_human") is False
+        assert validate_transition(config, "in_progress", "needs_human") is False
 
     def test_universal_target_done_to_cancelled(self) -> None:
         config = default_config()
@@ -554,12 +553,14 @@ class TestValidateCompletionPolicy:
         assert ok is True
 
     def test_universal_target_bypasses_policy(self) -> None:
+        """Any status listed in universal_targets bypasses its policy."""
         config = default_config()
+        config["workflow"]["universal_targets"] = ["cancelled", "parked"]
         config["workflow"]["completion_policies"] = {
-            "needs_human": {"require_roles": ["review"]},
+            "parked": {"require_roles": ["review"]},
         }
         snap = _snap_with_evidence([])
-        ok, failures = validate_completion_policy(config, snap, "needs_human")
+        ok, failures = validate_completion_policy(config, snap, "parked")
         assert ok is True
 
     def test_cancelled_bypasses_policy(self) -> None:

--- a/tests/test_core/test_events.py
+++ b/tests/test_core/test_events.py
@@ -51,6 +51,8 @@ class TestBuiltinEventTypes:
             "resource_expired",
             "resource_updated",
             "auto_review_spawned",
+            "needs_human_flagged",
+            "needs_human_cleared",
         }
     )
 
@@ -61,7 +63,7 @@ class TestBuiltinEventTypes:
         assert isinstance(BUILTIN_EVENT_TYPES, frozenset)
 
     def test_count(self) -> None:
-        assert len(BUILTIN_EVENT_TYPES) == 27
+        assert len(BUILTIN_EVENT_TYPES) == 29
 
     def test_auto_review_spawned_is_not_lifecycle(self) -> None:
         # ``auto_review_spawned`` is a per-task event, not a lifecycle one.

--- a/tests/test_core/test_next.py
+++ b/tests/test_core/test_next.py
@@ -134,9 +134,25 @@ class TestSelectNextExclusions:
         snaps = [_snap("task_block", status="blocked")]
         assert select_next(snaps) is None
 
-    def test_excludes_needs_human(self) -> None:
-        snaps = [_snap("task_human", status="needs_human")]
-        assert select_next(snaps) is None
+    def test_excludes_needs_human_flagged(self) -> None:
+        """A flagged task is never suggested, even in a ready status."""
+        snap = _snap("task_human", status="backlog")
+        snap["needs_human"] = {
+            "flagged_by": "agent:x",
+            "reason": "decision needed",
+            "since": "2026-06-03T00:00:00Z",
+        }
+        assert select_next([snap]) is None
+
+    def test_excludes_needs_human_flagged_resume(self) -> None:
+        """A flagged in_progress task is not offered for resume."""
+        snap = _snap("task_resume", status="in_progress", assigned_to="agent:me")
+        snap["needs_human"] = {
+            "flagged_by": "agent:me",
+            "reason": "awaiting approval",
+            "since": "2026-06-03T00:00:00Z",
+        }
+        assert select_next([snap], actor="agent:me") is None
 
     def test_excludes_in_progress_without_actor(self) -> None:
         """in_progress is not in ready_statuses by default."""
@@ -309,11 +325,14 @@ class TestSelectAllReady:
     def test_empty_returns_empty(self) -> None:
         assert select_all_ready([]) == []
 
-    def test_needs_human_excluded(self) -> None:
-        snaps = [
-            _snap("task_nh", status="needs_human"),
-            _snap("task_bl", status="backlog"),
-        ]
+    def test_needs_human_flag_excluded(self) -> None:
+        flagged = _snap("task_nh", status="backlog")
+        flagged["needs_human"] = {
+            "flagged_by": "agent:x",
+            "reason": "decision needed",
+            "since": "2026-06-03T00:00:00Z",
+        }
+        snaps = [flagged, _snap("task_bl", status="backlog")]
         result = select_all_ready(snaps)
         assert len(result) == 1
         assert result[0]["id"] == "task_bl"
@@ -387,13 +406,12 @@ class TestComputeClaimTransitions:
         """Verify against the actual default workflow transitions."""
         transitions = {
             "backlog": ["in_planning", "planned", "cancelled"],
-            "in_planning": ["planned", "needs_human", "cancelled"],
-            "planned": ["in_progress", "review", "blocked", "needs_human", "cancelled"],
-            "in_progress": ["review", "blocked", "needs_human", "cancelled"],
-            "review": ["done", "in_progress", "needs_human", "cancelled"],
+            "in_planning": ["planned", "cancelled"],
+            "planned": ["in_progress", "review", "blocked", "cancelled"],
+            "in_progress": ["review", "blocked", "cancelled"],
+            "review": ["done", "in_progress", "cancelled"],
             "done": [],
             "blocked": ["in_planning", "planned", "in_progress", "cancelled"],
-            "needs_human": ["in_planning", "planned", "in_progress", "review", "cancelled"],
             "cancelled": [],
         }
         # backlog -> planned -> in_progress (2 hops)

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -412,7 +412,7 @@ class TestTripleReviewSpawn:
         # Pane prompt contains the trident slash command + routing table.
         assert "/trident-code-review LAT-218" in captured["prompt"]
         assert "pr_open" in captured["prompt"]
-        assert "needs_human" in captured["prompt"]
+        assert "lattice needs-human LAT-218" in captured["prompt"]
         # review_state marker landed.
         state = review_mod.read_review_state(lattice_dir, "task_01ABC")
         assert state is not None
@@ -455,6 +455,8 @@ class TestTripleReviewSpawn:
         assert "/trident-plan-review LAT-42" in prompt
         assert "Review Verdict Routing" in prompt
         # Routing table outcomes
-        for outcome in ("pr_open", "in_progress", "in_planning", "needs_human"):
+        for outcome in ("pr_open", "in_progress", "in_planning"):
             assert outcome in prompt
+        # Complex findings route to the needs-human flag, not a status.
+        assert "lattice needs-human LAT-42" in prompt
         assert "agent:trident-pane-LAT-42" in prompt

--- a/tests/test_core/test_tasks.py
+++ b/tests/test_core/test_tasks.py
@@ -1030,6 +1030,7 @@ class TestCompactSnapshot:
             "last_status_changed_at",
             "comment_count",
             "reopened_count",
+            "needs_human",
             "relationships_out_count",
             "evidence_ref_count",
             "branch_link_count",

--- a/tests/test_mcp/test_completion_policy.py
+++ b/tests/test_mcp/test_completion_policy.py
@@ -78,14 +78,14 @@ class TestMCPCompletionPolicy:
             lattice_env,
             {
                 "done": {"require_roles": ["review"]},
-                "needs_human": {"require_roles": ["review"]},
+                "cancelled": {"require_roles": ["review"]},
             },
         )
         task_id = _create_task_at_review(lattice_env)
 
-        # needs_human is a universal target — should bypass policy
-        snapshot = lattice_status(task_id=task_id, new_status="needs_human", actor=_ACTOR)
-        assert snapshot["status"] == "needs_human"
+        # cancelled is a universal target — should bypass policy
+        snapshot = lattice_status(task_id=task_id, new_status="cancelled", actor=_ACTOR)
+        assert snapshot["status"] == "cancelled"
 
     def test_no_policy_no_gating(self, lattice_env: Path) -> None:
         """Without completion_policies, transitions work normally."""


### PR DESCRIPTION
## Summary

Converts `needs_human` from a workflow status into an orthogonal structured flag any task can carry in any status. A task can now be `in_progress` AND visibly waiting on a human — the board keeps its swimlane information, and agents no longer have to remember where to route a task back after the human answers.

**Lattice ticket:** LAT-232 (`task_01KT7B7AECYJVC7B4K76HSYRBM`)

## What changed

- **Flag** `needs_human: {flagged_by, reason, since}` on the task snapshot, mutable only via two new builtin events (`needs_human_flagged` / `needs_human_cleared`) — fully attributed, rebuild-deterministic, protected from `field_updated`.
- **CLI:** `lattice needs-human <task> "<reason>"` (reason **required** — structurally enforces the old mandatory-comment convention) and `--clear [--note]`. Queue survives as `lattice list --needs-human`; `show` renders a NEEDS HUMAN banner; `weather` keys off the flag; `next` never suggests a flagged task in any status (including resume).
- **Status removed from default presets** (statuses, transitions, `universal_targets` → `["cancelled"]`, descriptions, "ask flesh" display name). `lattice status X needs_human` on a new instance errors with a pointer to the flag command.
- **Migration:** `lattice migrate needs-human [--dry-run]` — idempotent, two-phase: flags every task sitting in the legacy status (reason = latest comment, fallback note), routes each back to its pre-needs_human status (fallback backlog) with provenance, then strips the status from config. **Unmigrated instances keep working untouched** (workflow is config-driven).
- **Behavior changes:** `plan_approval: human` now sets the flag and leaves the task in `planned`; review-cycle-limit error and failure-diagnostic tasks use the flag; trident handoff prompt routes complex findings to the flag.
- **Dashboard:** amber "Needs Human" pill on board cards (reason as tooltip) + detail-panel callout; flag-driven color override in both 3D renderers; `/api/graph` nodes carry the field.
- **Docs/templates/skills:** full sweep — CLAUDE.md template, /lattice skill (both copies), multi-agent guide (both copies), delegator-example, needs-human guide (rewritten + migration section), user-reference/user-guide/integrations/README, Decisions.md entry superseding the 2026-02-16 status decision.

## Decisions & notes

- `blocked` remains a status (generic external dependency); it can coexist with the flag — that's the feature.
- Migration reason uses the latest non-deleted comment — deliberate, documented-lossy heuristic per plan.
- Coordinated with LAT-233 (validation swimlane) at the config-surface level; rebase reconciliation happens at the PR layer.

## Test evidence

- `uv run pytest`: **1896 passed** (incl. new `test_needs_human_flag.py` and `test_migrate.py`: set/clear/queue/next/weather, rebuild determinism, migration idempotency + dry-run + provenance, legacy-status instances)
- `ruff check` + `ruff format --check`: clean; `node --check` on both 3D renderers: clean
- Live smoke on a fresh instance: init has no needs_human anywhere; flag/clear/queue/show/next/error-hint verified; dashboard badge confirmed in the live DOM (board + graph APIs carry the flag)
- Plan-review + code-review artifacts on the Lattice ticket, both PASS, all findings triaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)