### PR TITLE
feat(init): workflow status presets (stage11 / linear / custom) + interview (LAT-234)

### DIFF
--- a/src/lattice/cli/helpers.py
+++ b/src/lattice/cli/helpers.py
@@ -456,17 +456,22 @@ def check_plan_gate(
     task_id: str,
     target_status: str,
     is_json: bool,
+    config: dict,
     *,
     force: bool = False,
     reason: str | None = None,
 ) -> None:
     """Block transition to in_progress if the plan file is still scaffold.
 
-    Does nothing if *target_status* is not ``in_progress`` or if *force* is True
-    (with a reason).  Calls ``output_error`` (which raises SystemExit) when the
-    gate fires.
+    Does nothing if *target_status* is not ``in_progress``, if the workflow
+    has no planning swimlane (no ``in_planning`` status — e.g. the linear
+    status preset, which has no plan ritual), or if *force* is True (with a
+    reason).  Calls ``output_error`` (which raises SystemExit) when the gate
+    fires.
     """
     if target_status != "in_progress":
+        return
+    if "in_planning" not in config.get("workflow", {}).get("statuses", []):
         return
     if force:
         if not reason:

--- a/src/lattice/cli/main.py
+++ b/src/lattice/cli/main.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import click
 
 from lattice.core.config import (
+    WORKFLOW_PRESETS,
+    compose_workflow,
     default_config,
     serialize_config,
     validate_project_code,
@@ -298,6 +300,14 @@ def cli(ctx: click.Context) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _stdin_is_tty() -> bool:
+    """True when stdin is a real terminal (module-level so tests can patch)."""
+    try:
+        return sys.stdin.isatty()
+    except AttributeError:
+        return False
+
+
 @cli.command()
 @click.option(
     "--path",
@@ -347,6 +357,14 @@ def cli(ctx: click.Context) -> None:
     type=click.Choice(["classic", "opinionated"], case_sensitive=False),
     default=None,
     help="Workflow personality preset for status names.",
+)
+@click.option(
+    "--preset",
+    "status_preset",
+    type=click.Choice(["stage11", "linear"], case_sensitive=False),
+    default=None,
+    help="Workflow status preset: stage11 (the full agentic flow, default) or "
+    "linear (the familiar minimal board). Interactive init asks when omitted.",
 )
 @click.option(
     "--setup-claude/--no-setup-claude",
@@ -414,6 +432,7 @@ def init(
     instance_name: str | None,
     heartbeat: bool | None,
     workflow_preset: str | None,
+    status_preset: str | None,
     setup_claude: bool | None,
     setup_agents: bool | None,
     seed: bool | None,
@@ -446,6 +465,10 @@ def init(
     actor_from_flag = actor is not None
     project_code_from_flag = project_code is not None
     non_interactive = actor_from_flag and project_code_from_flag
+
+    # Custom status sets are composed in the interactive interview; when set,
+    # this overrides the named-preset workflow at config-creation time.
+    custom_workflow: dict | None = None
 
     # ── Interactive flow ──────────────────────────────────────────────
     if not non_interactive:
@@ -542,6 +565,57 @@ def init(
                     "starting with a letter (e.g. LAT, C11, AUT2)."
                 )
 
+        # ── Workflow statuses ──
+        # Asked only on a real TTY so piped/agent-driven init never hangs on
+        # the new question; any abort falls back to the stage11 default.
+        if status_preset is None:
+            if _stdin_is_tty():
+                click.echo("")
+                click.echo("how should work flow here?")
+                click.echo("")
+                click.echo("  1) stage 11 — the full agentic flow: planning gates, code review,")
+                click.echo(
+                    "     e2e validation, PR tracking. built for fleets of agents. (default)"
+                )
+                click.echo(
+                    "  2) linear — the familiar minimal board: backlog / todo / in progress /"
+                )
+                click.echo("     in review / done.")
+                click.echo("  3) custom — the stage 11 spine, choosing which gates you want.")
+                try:
+                    choice = click.prompt("Choice", default="1", show_default=False).strip()
+                except (click.Abort, EOFError):
+                    choice = "1"
+                if choice == "2":
+                    status_preset = "linear"
+                    click.echo("  → backlog / todo / in progress / in review / done")
+                elif choice == "3":
+                    status_preset = "custom"
+                    click.echo("")
+                    try:
+                        inc_review = click.confirm(
+                            "code review stage? (review — auto-fired review agents examine the diff)",
+                            default=True,
+                        )
+                        inc_validation = click.confirm(
+                            "e2e validation stage? (in_validation — prove it works against a running system)",
+                            default=True,
+                        )
+                        inc_pr_open = click.confirm(
+                            "PR stage? (pr_open — open PRs as their own swimlane)",
+                            default=True,
+                        )
+                    except (click.Abort, EOFError):
+                        inc_review = inc_validation = inc_pr_open = True
+                    custom_workflow = compose_workflow(
+                        include_review=inc_review,
+                        include_validation=inc_validation,
+                        include_pr_open=inc_pr_open,
+                    )
+                    click.echo("  → " + " / ".join(custom_workflow["statuses"]))
+                else:
+                    status_preset = "stage11"
+
     # ── Validate inputs (flag-provided values only) ───────────────────
     # Interactive prompts validate inline with retry loops above.
 
@@ -578,6 +652,11 @@ def init(
         heartbeat = False
     if workflow_preset is None:
         workflow_preset = "classic"
+    # Status preset: flag > interview answer > stage11 (non-interactive and
+    # no-TTY paths both land here).
+    if status_preset is None:
+        status_preset = "stage11"
+    status_preset = status_preset.lower()
 
     # ── Seed prompt (interactive only, when project_code is set) ──
     if not non_interactive and seed is None and project_code:
@@ -612,7 +691,17 @@ def init(
         ensure_lattice_dirs(root)
 
         # Write default config atomically
-        config: dict = dict(default_config(preset=workflow_preset))
+        config: dict = dict(default_config(preset=workflow_preset, status_preset=status_preset))
+        if custom_workflow is not None:
+            # Personality display names apply only to statuses that exist.
+            display_names = {
+                slug: name
+                for slug, name in WORKFLOW_PRESETS[workflow_preset]["display_names"].items()
+                if slug in custom_workflow["statuses"]
+            }
+            if display_names:
+                custom_workflow["display_names"] = display_names
+            config["workflow"] = custom_workflow
         # Always generate instance_id
         config["instance_id"] = generate_instance_id()
         if actor:
@@ -719,8 +808,8 @@ def init(
                 proceed = False
 
             if proceed:
-                _create_or_update_agents_md(root)
-                _offer_claude_md(root, auto_accept=True)
+                _create_or_update_agents_md(root, config)
+                _offer_claude_md(root, auto_accept=True, config=config)
                 agents_created = True
                 click.echo("")
 
@@ -737,22 +826,22 @@ def init(
                     _install_openclaw_skill(root)
 
         elif setup_agents:
-            _create_or_update_agents_md(root)
+            _create_or_update_agents_md(root, config)
             agents_created = True
         # else: --no-setup-agents
     else:
         # Non-interactive: auto-create unless explicitly declined
         if setup_agents is not False:
-            _create_or_update_agents_md(root)
+            _create_or_update_agents_md(root, config)
             agents_created = True
 
     # CLAUDE.md: create or update for non-interactive or explicit flag.
     # (Interactive path handles CLAUDE.md inline above.)
     if not agents_created or non_interactive:
         if setup_claude is True:
-            _offer_claude_md(root, auto_accept=True)
+            _offer_claude_md(root, auto_accept=True, config=config)
         elif setup_claude is not False and agents_created:
-            _offer_claude_md(root, auto_accept=True)
+            _offer_claude_md(root, auto_accept=True, config=config)
 
     # ── Dashboard auto-start (interactive + real TTY only) ───────────
 
@@ -796,6 +885,8 @@ def init(
         )
         click.echo("")
         click.echo(f"  {LATTICE_DIR}/          task state, events, plans, notes")
+        n_statuses = len(config["workflow"]["statuses"])
+        click.echo(f"  workflow         {status_preset} ({n_statuses} statuses)")
         if (root / "agents.md").exists():
             click.echo("  agents.md        agent integration instructions")
         if (root / "CLAUDE.md").exists():
@@ -859,6 +950,8 @@ def init(
             click.echo("Heartbeat: enabled (agents auto-advance, max 10 per session)")
         if workflow_preset and workflow_preset != "classic":
             click.echo(f"Workflow: {workflow_preset}")
+        n_statuses = len(config["workflow"]["statuses"])
+        click.echo(f"Workflow statuses: {status_preset} ({n_statuses} statuses)")
 
 
 # ---------------------------------------------------------------------------
@@ -866,9 +959,11 @@ def init(
 # ---------------------------------------------------------------------------
 
 
-def _create_or_update_agents_md(root: Path) -> None:
+def _create_or_update_agents_md(root: Path, config: dict | None = None) -> None:
     """Create or update agents.md with Lattice integration block."""
-    marker, composed_block = _compose_claude_md_blocks()
+    if config is None:
+        config = _load_instance_config(root)
+    marker, composed_block = _compose_claude_md_blocks(config)
     agents_md = root / "agents.md"
 
     try:
@@ -925,7 +1020,7 @@ def _silent_update_claude_md(root: Path) -> None:
     Does not create CLAUDE.md — only updates an existing one.
     Does not prompt — silently appends if the marker is not present.
     """
-    marker, composed_block = _compose_claude_md_blocks()
+    marker, composed_block = _compose_claude_md_blocks(_load_instance_config(root))
     claude_md = root / "CLAUDE.md"
 
     if not claude_md.exists():
@@ -1003,20 +1098,38 @@ def _start_dashboard_background(
 # ---------------------------------------------------------------------------
 
 
-def _compose_claude_md_blocks() -> tuple[str, str]:
+def _load_instance_config(root: Path) -> dict | None:
+    """Best-effort load of the instance config from *root*'s ``.lattice/``.
+
+    Returns ``None`` when the config is missing or unreadable — callers fall
+    back to the stage11 default template.
+    """
+    import json
+
+    try:
+        return json.loads((root / LATTICE_DIR / "config.json").read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _compose_claude_md_blocks(config: dict | None = None) -> tuple[str, str]:
     """Return (marker, composed_block) from base template + any plugin template blocks.
 
-    Plugin blocks with ``position: "after_base"`` are appended in discovery order.
+    The base block is rendered from *config* so it only describes statuses
+    that exist in the instance (stage11 default when ``None``).  Plugin
+    blocks with ``position: "after_base"`` are appended in discovery order.
     """
     from lattice.plugins import discover_template_blocks
-    from lattice.templates.claude_md_block import CLAUDE_MD_BLOCK, CLAUDE_MD_MARKER
+    from lattice.templates.claude_md_block import CLAUDE_MD_MARKER, render_claude_md_block
+
+    base_block = render_claude_md_block(config)
 
     plugin_blocks = discover_template_blocks()
     if not plugin_blocks:
-        return CLAUDE_MD_MARKER, CLAUDE_MD_BLOCK
+        return CLAUDE_MD_MARKER, base_block
 
     # Build composed block: base + plugin blocks appended
-    parts = [CLAUDE_MD_BLOCK.rstrip("\n")]
+    parts = [base_block.rstrip("\n")]
     for block in plugin_blocks:
         parts.append("")  # blank line separator
         parts.append(block["content"].rstrip("\n"))
@@ -1037,13 +1150,15 @@ def _collect_all_markers() -> list[str]:
     return markers
 
 
-def _offer_claude_md(root: Path, *, auto_accept: bool = False) -> None:
+def _offer_claude_md(root: Path, *, auto_accept: bool = False, config: dict | None = None) -> None:
     """Detect CLAUDE.md and offer to add Lattice integration block.
 
     When *auto_accept* is True (non-interactive init), automatically create or
     update CLAUDE.md without prompting.
     """
-    marker, composed_block = _compose_claude_md_blocks()
+    if config is None:
+        config = _load_instance_config(root)
+    marker, composed_block = _compose_claude_md_blocks(config)
 
     claude_md = root / "CLAUDE.md"
 
@@ -1186,7 +1301,7 @@ def set_subproject_code(code: str, force: bool) -> None:
 def setup_claude(target_path: str, force: bool) -> None:
     """Add or update Lattice agent integration in CLAUDE.md."""
     root = Path(target_path)
-    marker, composed_block = _compose_claude_md_blocks()
+    marker, composed_block = _compose_claude_md_blocks(_load_instance_config(root))
     claude_md = root / "CLAUDE.md"
 
     if claude_md.exists():
@@ -1415,9 +1530,10 @@ def setup_prompt(use_claude_md: bool) -> None:
     Use --claude-md to get the CLAUDE.md integration block instead.
     """
     if use_claude_md:
-        from lattice.templates.claude_md_block import CLAUDE_MD_BLOCK
+        from lattice.templates.claude_md_block import render_claude_md_block
 
-        click.echo(CLAUDE_MD_BLOCK.strip())
+        block = render_claude_md_block(_load_instance_config(Path(".").resolve()))
+        click.echo(block.strip())
     else:
         skill_src = Path(__file__).resolve().parent.parent / "skills" / "lattice"
         skill_file = skill_src / "SKILL.md"

--- a/src/lattice/cli/query_cmds.py
+++ b/src/lattice/cli/query_cmds.py
@@ -523,7 +523,7 @@ def next_cmd(
     # --claim: atomically assign + move to in_progress with valid transitions
     if claim:
         # Planning gate: block if plan is still scaffold
-        check_plan_gate(lattice_dir, task_id, "in_progress", is_json)
+        check_plan_gate(lattice_dir, task_id, "in_progress", is_json, config)
 
         locks_dir = lattice_dir / "locks"
         lock_keys = sorted([f"events_{task_id}", f"tasks_{task_id}"])

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -883,6 +883,7 @@ def status_cmd(
         task_id,
         new_status,
         is_json,
+        config,
         force=force,
         reason=provenance_reason,
     )

--- a/src/lattice/core/config.py
+++ b/src/lattice/core/config.py
@@ -115,7 +115,9 @@ STATUS_DESCRIPTIONS: dict[str, str] = {
     "backlog": "Task is captured but no work has started. No planning, no implementation.",
     "in_planning": "Design, dialogue, and scoping underway. No implementation code should be written yet.",
     "planned": "Plan is written and approved. Ready for implementation but work has not started.",
+    "todo": "Selected for work; not started.",
     "in_progress": "Implementation is actively underway. Code is being written, tested, or integrated.",
+    "in_review": "A human or agent is reviewing the change.",
     "review": "Local review is underway. A review sub-agent is examining the diff before validation begins.",
     "in_validation": (
         "End-to-end validation is underway. The change is being exercised against a "
@@ -139,6 +141,7 @@ class LatticeConfig(TypedDict, total=False):
     default_complexity: str
     task_types: list[str]
     workflow: Workflow
+    status_preset: str
     default_actor: str
     project_code: str
     subproject_code: str
@@ -163,35 +166,53 @@ class LatticeConfig(TypedDict, total=False):
     project_type: Literal["standard", "structure"]
 
 
-def default_config(preset: str = "classic") -> LatticeConfig:
-    """Return the default Lattice configuration.
+# ---------------------------------------------------------------------------
+# Status presets — which workflow statuses an instance uses
+# ---------------------------------------------------------------------------
+# Orthogonal to WORKFLOW_PRESETS (display-name personality): a status preset
+# decides WHICH statuses exist; the personality decides what they're called.
+# ``stage11`` is the full agentic flow (the default), ``linear`` the familiar
+# minimal board, ``custom`` an interview-composed subset of the stage11 spine.
 
-    The returned dict, when serialized with
-    ``json.dumps(data, sort_keys=True, indent=2) + "\\n"``,
-    produces the canonical default config.json.
+STATUS_PRESET_VALUES: tuple[str, ...] = ("stage11", "linear", "custom")
 
-    *preset* selects the workflow personality ("classic" or "opinionated").
-    The opinionated preset adds human-friendly display names for statuses
-    while keeping the same underlying slugs and transition graph.
+#: Role vocabulary shared by every status preset.  Roles without completion
+#: policies are inert, so even minimal presets keep the full list — attach
+#: ``--role`` works everywhere.
+_FULL_ROLES: list[str] = ["review", "plan-review", "review-individual", "validation"]
+
+#: Shipped WIP limit per in-flight status; presets include only the entries
+#: whose status exists.
+_WIP_DEFAULTS: dict[str, int] = {
+    "in_progress": 10,
+    "review": 5,
+    "in_validation": 5,
+    "pr_open": 10,
+}
+
+
+def stage11_workflow() -> dict:
+    """The full Stage 11 agentic workflow (the shipped default).
+
+    This is a hand-tuned literal — the transition graph carries deliberate
+    skip-forward edges (``backlog → planned``, ``planned → review``,
+    ``review → pr_open/done``, ``pr_open → review``) that no clean derivation
+    rule reproduces.  Do not re-express it through :func:`compose_workflow`.
     """
-    if preset not in WORKFLOW_PRESETS:
-        preset = "classic"
-
-    display_names = WORKFLOW_PRESETS[preset]["display_names"]
-
-    workflow: dict = {
-        "statuses": [
-            "backlog",
-            "in_planning",
-            "planned",
-            "in_progress",
-            "review",
-            "in_validation",
-            "pr_open",
-            "done",
-            "blocked",
-            "cancelled",
-        ],
+    statuses = [
+        "backlog",
+        "in_planning",
+        "planned",
+        "in_progress",
+        "review",
+        "in_validation",
+        "pr_open",
+        "done",
+        "blocked",
+        "cancelled",
+    ]
+    return {
+        "statuses": statuses,
         "transitions": {
             "backlog": ["in_planning", "planned", "cancelled"],
             "in_planning": ["planned", "cancelled"],
@@ -231,23 +252,153 @@ def default_config(preset: str = "classic") -> LatticeConfig:
             "cancelled": [],
         },
         "universal_targets": ["cancelled"],
-        "roles": ["review", "plan-review", "review-individual", "validation"],
-        "wip_limits": {
-            "in_progress": 10,
-            "review": 5,
-            "in_validation": 5,
-            "pr_open": 10,
-        },
+        "roles": list(_FULL_ROLES),
+        "wip_limits": dict(_WIP_DEFAULTS),
         "completion_policies": {
             "done": {"require_roles": ["review"]},
             "pr_open": {"require_roles": ["validation"]},
         },
+        "descriptions": {s: STATUS_DESCRIPTIONS[s] for s in statuses},
     }
 
-    if display_names:
-        workflow["display_names"] = display_names
 
-    workflow["descriptions"] = dict(STATUS_DESCRIPTIONS)
+def linear_workflow() -> dict:
+    """The familiar minimal board: backlog / todo / in progress / in review / done.
+
+    Machinery-light by design: the literal ``todo`` / ``in_review`` slugs mean
+    the slug-keyed agentic machinery (auto-fired reviews on ``review`` /
+    ``planned``, plan gating, rework-cycle counting) is naturally inert.  No
+    WIP limits, no completion policies.
+    """
+    statuses = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled"]
+    return {
+        "statuses": statuses,
+        "transitions": {
+            "backlog": ["todo", "in_progress", "cancelled"],
+            "todo": ["in_progress", "cancelled"],
+            "in_progress": ["in_review", "todo", "cancelled"],
+            "in_review": ["done", "in_progress", "cancelled"],
+            "done": [],
+            "cancelled": [],
+        },
+        "universal_targets": ["cancelled"],
+        "roles": list(_FULL_ROLES),
+        "wip_limits": {},
+        "completion_policies": {},
+        "descriptions": {s: STATUS_DESCRIPTIONS[s] for s in statuses},
+    }
+
+
+def compose_workflow(
+    *,
+    include_review: bool,
+    include_validation: bool,
+    include_pr_open: bool,
+) -> dict:
+    """Compose a custom workflow from the Stage 11 spine with opt-in gates.
+
+    Used by the ``lattice init`` custom interview path only — the named
+    presets are literals (:func:`stage11_workflow`, :func:`linear_workflow`).
+    Forward edges target the immediate next present stage; rework and blocked
+    edges mirror the stage11 graph for the statuses that exist.
+
+    Policy rules: ``done`` requires ``review``-role evidence iff the review
+    stage exists; ``pr_open`` requires ``validation``-role evidence iff BOTH
+    ``pr_open`` and ``in_validation`` exist (declining the validation stage at
+    init time is human intent that this project has no validation ritual).
+    """
+    gates = []
+    if include_review:
+        gates.append("review")
+    if include_validation:
+        gates.append("in_validation")
+    if include_pr_open:
+        gates.append("pr_open")
+
+    chain = ["backlog", "in_planning", "planned", "in_progress", *gates, "done"]
+    statuses = [*chain, "blocked", "cancelled"]
+
+    # Forward chain: each non-terminal status targets the immediate next stage.
+    transitions: dict[str, list[str]] = {
+        status: [chain[i + 1]] for i, status in enumerate(chain[:-1])
+    }
+    transitions["done"] = []
+
+    # Rework edges mirroring stage11: gates route back to in_progress, and
+    # review/in_validation additionally to in_planning.
+    for gate in gates:
+        transitions[gate].append("in_progress")
+        if gate in ("review", "in_validation"):
+            transitions[gate].append("in_planning")
+
+    # Blocked edges mirroring stage11, restricted to present statuses.
+    for status in ("planned", "in_progress", "in_validation", "pr_open"):
+        if status in chain:
+            transitions[status].append("blocked")
+    transitions["blocked"] = [
+        s
+        for s in ("in_planning", "planned", "in_progress", "in_validation", "pr_open")
+        if s in chain
+    ]
+
+    # Cancelled closes out every non-terminal status (it is also a universal
+    # target; the explicit edges match the stage11 literal's style).
+    for status in [*chain[:-1], "blocked"]:
+        transitions[status].append("cancelled")
+    transitions["cancelled"] = []
+
+    completion_policies: dict[str, dict] = {}
+    if include_review:
+        completion_policies["done"] = {"require_roles": ["review"]}
+    if include_pr_open and include_validation:
+        completion_policies["pr_open"] = {"require_roles": ["validation"]}
+
+    return {
+        "statuses": statuses,
+        "transitions": transitions,
+        "universal_targets": ["cancelled"],
+        "roles": list(_FULL_ROLES),
+        "wip_limits": {s: v for s, v in _WIP_DEFAULTS.items() if s in statuses},
+        "completion_policies": completion_policies,
+        "descriptions": {s: STATUS_DESCRIPTIONS[s] for s in statuses},
+    }
+
+
+def default_config(preset: str = "classic", status_preset: str = "stage11") -> LatticeConfig:
+    """Return the default Lattice configuration.
+
+    The returned dict, when serialized with
+    ``json.dumps(data, sort_keys=True, indent=2) + "\\n"``,
+    produces the canonical default config.json.
+
+    *preset* selects the workflow personality ("classic" or "opinionated").
+    The opinionated preset adds human-friendly display names for statuses
+    while keeping the same underlying slugs and transition graph.
+
+    *status_preset* selects WHICH statuses the workflow uses ("stage11",
+    "linear", or "custom").  For "custom" the caller composes the workflow
+    itself via :func:`compose_workflow` and overrides ``config["workflow"]``
+    — this function only stamps the ``status_preset`` key and installs the
+    stage11 workflow as the base.
+    """
+    if preset not in WORKFLOW_PRESETS:
+        preset = "classic"
+    if status_preset not in STATUS_PRESET_VALUES:
+        status_preset = "stage11"
+
+    workflow = linear_workflow() if status_preset == "linear" else stage11_workflow()
+
+    # Personality display names apply only to statuses that exist in the set.
+    display_names = {
+        slug: name
+        for slug, name in WORKFLOW_PRESETS[preset]["display_names"].items()
+        if slug in workflow["statuses"]
+    }
+    if display_names:
+        # Keep key order consistent with prior serialization: display_names
+        # sits between completion_policies and descriptions semantically, but
+        # sort_keys=True serialization makes insertion order irrelevant.
+        workflow["display_names"] = display_names
 
     config: LatticeConfig = {
         "schema_version": 1,
@@ -261,6 +412,7 @@ def default_config(preset: str = "classic") -> LatticeConfig:
         ],
         "workflow": workflow,
         "workflow_preset": preset,
+        "status_preset": status_preset,
         "review_mode": "single",
         "plan_review_mode": "single",
         "plan_approval": "auto",

--- a/tests/fixtures/claude_md_block_stage11_snapshot.md
+++ b/tests/fixtures/claude_md_block_stage11_snapshot.md
@@ -1,102 +1,4 @@
-"""CLAUDE.md integration template for Lattice.
 
-This is the single source of truth for the Lattice agent integration block.
-Edit this file to update what `lattice init` and `lattice setup-claude` write.
-
-The block is rendered from the instance config so the agent guidance only
-describes statuses that actually exist (LAT-234): a linear-preset instance
-gets a minimal block with no planning/review/validation gate sections, a
-custom instance gets exactly the gate sections its statuses call for, and the
-stage11 default renders byte-identically to the historical static block
-(locked by a snapshot test).
-"""
-
-from __future__ import annotations
-
-#: Canonical forward ordering used to draw the lifecycle diagram.  Terminal /
-#: side statuses (blocked, cancelled) are not part of the forward chain.
-_CHAIN_ORDER = [
-    "backlog",
-    "in_planning",
-    "planned",
-    "todo",
-    "in_progress",
-    "review",
-    "in_review",
-    "in_validation",
-    "pr_open",
-    "done",
-]
-
-#: Transition-discipline bullet per status.  ``done`` and ``pr_open`` have
-#: context-dependent variants handled in the renderer.
-_DISCIPLINE_LINES = {
-    "in_planning": "- `in_planning` — before you open the first file to read. Then write the plan.",
-    "planned": "- `planned` — only after the plan file has real content.",
-    "todo": "- `todo` — when the task is selected for work.",
-    "in_progress": "- `in_progress` — before you write the first line of code.",
-    "review": "- `review` — when implementation is complete, before review starts. Then actually review.",
-    "in_review": "- `in_review` — when implementation is complete and the change is being reviewed.",
-    "in_validation": (
-        "- `in_validation` — after local review passes, before e2e validation starts. "
-        "Then actually validate against a running system."
-    ),
-}
-
-
-def _lifecycle_diagram(statuses: list[str]) -> str:
-    """Render the lifecycle diagram for the configured statuses.
-
-    The forward chain follows ``_CHAIN_ORDER``; when ``blocked`` exists it is
-    drawn beneath ``in_progress`` with a ``↕`` connector.
-    """
-    chain = [s for s in _CHAIN_ORDER if s in statuses]
-    line = " → ".join(chain)
-    if "blocked" not in statuses:
-        return line
-    anchor = "in_progress" if "in_progress" in chain else chain[len(chain) // 2]
-    center = line.index(anchor) + len(anchor) // 2
-    arrow = " " * center + "↕"
-    blocked = " " * (center - len("blocked") // 2) + "blocked"
-    return f"{line}\n{arrow}\n{blocked}"
-
-
-def render_claude_md_block(config: dict | None = None) -> str:
-    """Render the Lattice agent-integration block for *config*.
-
-    With no config (or no workflow section) the full stage11 default is
-    rendered.  Sections are included only when the statuses they describe
-    exist in the instance.
-    """
-    if config is None:
-        from lattice.core.config import default_config
-
-        config = dict(default_config())
-
-    workflow = config.get("workflow", {})
-    statuses = workflow.get("statuses", [])
-    if not statuses:
-        from lattice.core.config import stage11_workflow
-
-        workflow = stage11_workflow()
-        statuses = workflow["statuses"]
-    policies = workflow.get("completion_policies", {})
-
-    has_planning = "in_planning" in statuses
-    has_review = "review" in statuses
-    has_validation = "in_validation" in statuses
-    has_pr_open = "pr_open" in statuses
-    pr_open_gated = "validation" in policies.get("pr_open", {}).get("require_roles", [])
-
-    #: First present stage after ``review`` on the forward path.
-    next_after_review = next(
-        (s for s in ("in_validation", "pr_open", "done") if s in statuses), "done"
-    )
-
-    parts: list[str] = []
-
-    # ── Header + mandate (always) ────────────────────────────────────────
-    parts.append("""
 ## Lattice
 
 > **MANDATORY: This project has Lattice initialized (`.lattice/` exists). You MUST use Lattice to track all work. Creating tasks, updating statuses, and following the workflow below is not optional — it is a hard requirement. Failure to track work in Lattice is a coordination failure: other agents and humans cannot see, build on, or trust untracked work. If you are about to write code and no Lattice task exists for it, stop and create one first.**
@@ -118,11 +20,7 @@ lattice create "<title>" --actor agent:<your-id>
 When in doubt, create the task. A small task costs nothing. Lost visibility costs everything.
 
 **Recurring observations become tasks.** If you observe the same issue in 2+ consecutive sessions or advances (e.g., a failing test, a lint warning, a flaky behavior), create a task for it. Agents are disciplined about tracking assigned work but not discovered work — this convention closes that gap. Create discovered issues at `backlog`; if they need human scoping, also flag them (`lattice needs-human <task> "Need: scoping"`).
-""")
 
-    # ── Descriptions Carry Context ───────────────────────────────────────
-    if has_planning:
-        parts.append("""
 ### Descriptions Carry Context
 
 Descriptions tell *what* and *why*. Plan files tell *how*.
@@ -130,44 +28,7 @@ Descriptions tell *what* and *why*. Plan files tell *how*.
 - **Fully specified** (bug located, fix named, files identified): still go through `in_planning`, but the plan can be a single line (e.g., "Fix the typo on line 77"). Mark `complexity: low`.
 - **Clear goal, open implementation**: go through `in_planning`. The agent figures out the approach and writes a substantive plan.
 - **Decision context from conversations**: bake decisions and rationale into the description — without it, the next agent re-derives what was already decided.
-""")
-    else:
-        parts.append("""
-### Descriptions Carry Context
 
-Descriptions tell *what* and *why*.
-
-- **Fully specified** (bug located, fix named, files identified): mark `complexity: low` and get to it.
-- **Clear goal, open implementation**: the agent figures out the approach.
-- **Decision context from conversations**: bake decisions and rationale into the description — without it, the next agent re-derives what was already decided.
-""")
-
-    # ── Status Transitions (always; diagram + bullets generated) ────────
-    discipline: list[str] = []
-    for status in [s for s in _CHAIN_ORDER if s in statuses]:
-        if status == "backlog":
-            continue
-        if status == "pr_open":
-            line = "- `pr_open` — when the PR is open."
-            if pr_open_gated:
-                line += " Requires recorded validation evidence (`--role validation`)."
-            discipline.append(line)
-        elif status == "done":
-            if has_review:
-                discipline.append(
-                    "- `done` — only after a review has been performed and recorded "
-                    "(and the PR merged, for PR work)."
-                )
-            elif "in_review" in statuses:
-                discipline.append("- `done` — when review is complete and the work has shipped.")
-            else:
-                discipline.append("- `done` — when the work has shipped.")
-        else:
-            discipline.append(_DISCIPLINE_LINES[status])
-    discipline.append("- Spawning a sub-agent? Update status in the parent context first.")
-    discipline_block = "\n".join(discipline)
-
-    parts.append(f"""
 ### Status Transitions
 
 Every transition is an immutable, attributed event. **The cardinal rule: update status BEFORE you start the work, not after.** If the board says `backlog` but you're actively working, the board is lying and every mind reading it makes decisions on false information.
@@ -177,71 +38,43 @@ lattice status <task> <status> --actor agent:<your-id>
 ```
 
 ```
-{_lifecycle_diagram(statuses)}
+backlog → in_planning → planned → in_progress → review → in_validation → pr_open → done
+                                       ↕
+                                    blocked
 ```
 
 Human attention is NOT a status: any task in any status can carry the orthogonal `needs_human` flag (`lattice needs-human <task> "<what you need>"`). The task keeps its swimlane while it waits — see "When You're Stuck" below.
 
 **Transition discipline:**
-{discipline_block}
-""")
+- `in_planning` — before you open the first file to read. Then write the plan.
+- `planned` — only after the plan file has real content.
+- `in_progress` — before you write the first line of code.
+- `review` — when implementation is complete, before review starts. Then actually review.
+- `in_validation` — after local review passes, before e2e validation starts. Then actually validate against a running system.
+- `pr_open` — when the PR is open. Requires recorded validation evidence (`--role validation`).
+- `done` — only after a review has been performed and recorded (and the PR merged, for PR work).
+- Spawning a sub-agent? Update status in the parent context first.
 
-    # ── Sub-Agent Execution Model (planning workflows only) ─────────────
-    if has_planning:
-        impl_target = "review" if has_review else next_after_review
-        rows = [
-            "| Stage | Sub-agent does | Reads | Produces |",
-            "|-------|---------------|-------|----------|",
-            "| **Plan** | Explore codebase, write plan, move to `planned` | Task description | Plan file |",
-            f"| **Implement** | Read plan, build it, test, commit, move to `{impl_target}` | Plan file | Committed code |",
-        ]
-        if has_review:
-            rows.append(
-                "| **Review** | Read diff cold, review against acceptance criteria, record findings "
-                f"| Git diff + plan | Review artifact (`--role review`), move to `{next_after_review}` on pass |"
-            )
-        if has_validation:
-            rows.append(
-                "| **Validate** | Exercise the change end-to-end against a running system "
-                "| Running app + plan | Validation evidence (`--role validation`), "
-                f"move to `{'pr_open' if has_pr_open else 'done'}` on pass |"
-            )
-        table = "\n".join(rows)
-
-        subagents_label = (
-            "**The three sub-agents:**" if has_review and has_validation else "**The sub-agents:**"
-        )
-
-        steps = [
-            "1. Move the task to `in_planning` before spawning the planning sub-agent.",
-            "2. After the planner finishes, move to `in_progress` and spawn the implementation sub-agent.",
-        ]
-        if has_review:
-            steps.append(
-                "3. After the implementer finishes, the review sub-agent runs independently."
-            )
-        if has_validation:
-            lead = "After review passes," if has_review else "After the implementer finishes,"
-            tail = "before the PR opens" if has_pr_open else "before completion"
-            steps.append(
-                f"{len(steps) + 1}. {lead} move to `in_validation` and spawn the validation "
-                f"sub-agent to prove the change end-to-end {tail}."
-            )
-        steps_block = "\n".join(steps)
-
-        parts.append(f"""
 ### Sub-Agent Execution Model
 
 Each lifecycle stage gets its own sub-agent with fresh context. This is the default execution pattern — not a suggestion, not complexity-gated. Every task, every time.
 
 **Why this matters:** When a planning agent writes a plan and a separate implementation agent reads it, the plan *must* be clear and complete — there's no shared context to fall back on. This forces better plans. When a review agent reads the diff cold, it catches things the implementer's context-polluted mind would miss. The plan file and git diff are the handoff artifacts.
 
-{subagents_label}
+**The three sub-agents:**
 
-{table}
+| Stage | Sub-agent does | Reads | Produces |
+|-------|---------------|-------|----------|
+| **Plan** | Explore codebase, write plan, move to `planned` | Task description | Plan file |
+| **Implement** | Read plan, build it, test, commit, move to `review` | Plan file | Committed code |
+| **Review** | Read diff cold, review against acceptance criteria, record findings | Git diff + plan | Review artifact (`--role review`), move to `in_validation` on pass |
+| **Validate** | Exercise the change end-to-end against a running system | Running app + plan | Validation evidence (`--role validation`), move to `pr_open` on pass |
 
 **The parent orchestrator** (the main agent session) manages the lifecycle:
-{steps_block}
+1. Move the task to `in_planning` before spawning the planning sub-agent.
+2. After the planner finishes, move to `in_progress` and spawn the implementation sub-agent.
+3. After the implementer finishes, the review sub-agent runs independently.
+4. After review passes, move to `in_validation` and spawn the validation sub-agent to prove the change end-to-end before the PR opens.
 
 Each sub-agent should use a distinct actor ID (e.g., `agent:claude-opus-4-planner`, `agent:claude-opus-4-impl`, `agent:claude-opus-4-reviewer`) so the event log shows who did what.
 
@@ -257,11 +90,7 @@ Each sub-agent should use a distinct actor ID (e.g., `agent:claude-opus-4-planne
 **Don't pick 300s.** It's just past the 5-min cache TTL — pays the cache-miss without amortizing it into a long wait. Either stay ≤270s (cache-warm) or step up to ≥1200s (one cache-miss amortized over a longer wait).
 
 **Pair short cadence with brief ticks.** Heartbeat ticks (no state change) get one sentence at most. State-change ticks (sub-agent finished, task transitioned, blocker hit) get as much detail as the situation demands. Short interval + silent-on-no-change keeps the transcript scannable while staying responsive to real events.
-""")
 
-    # ── Planning Gate + Plan Review Triage (planning workflows only) ────
-    if has_planning:
-        parts.append("""
 ### The Planning Gate
 
 The plan file lives at `.lattice/plans/<task_id>.md` — scaffolded on creation, empty until you fill it.
@@ -299,11 +128,7 @@ When the plan review returns (trident or otherwise), the orchestrator sorts ever
 Every finding must be explicitly triaged — no silent drops. If triage produces no complex questions, advance to `in_progress`. Otherwise, wait for the human answer, fold it into the plan, then advance.
 
 **Why these three buckets:** Obvious findings improve the plan at zero cost — apply them. Evolutionary findings are often well-intentioned but scope-creep the ticket; the cost of folding them in compounds. Complex findings are where human judgment actually adds value — surface them, don't guess.
-""")
 
-    # ── Review Gate + Verdict Routing + Rework Loop (review status only) ─
-    if has_review:
-        parts.append("""
 ### The Review Gate
 
 Moving to `review` is a commitment to actually review the work.
@@ -348,52 +173,12 @@ When the orchestrator reads a completed review (from the review artifact or inli
 3. **Create new task** — Legitimate findings that are out of scope for the current ticket. Create a new Lattice task to track the work: `lattice create "<finding title>" --actor agent:<id>`. The insight is captured without blocking the current task.
 
 Every finding must be explicitly routed. No finding may be silently dropped.
-""")
 
-        # Rework loop — paths and cross-references depend on which gates exist.
-        if has_validation:
-            advance_phrase = "advance — `in_validation` on the PR path, `done` for non-PR work"
-        elif has_pr_open:
-            advance_phrase = "advance — `pr_open` on the PR path, `done` for non-PR work"
-        else:
-            advance_phrase = "move to `done`"
-
-        rework_origins = "/".join(
-            f"`{s}`" for s in ("review", "in_validation", "pr_open") if s in statuses
-        )
-
-        post_review = [s for s in ("in_validation", "pr_open") if s in statuses]
-        full_chain = " -> ".join(["in_progress", "review", *post_review, "done"])
-        minor_chain = " -> ".join(["in_progress", "review", "(fix inline)", *post_review, "done"])
-        impl_tail = f" -> {post_review[0]} -> ..." if post_review else " -> done"
-        path_lines = []
-        if has_pr_open:
-            path_lines.append(f"Normal (PR):   {full_chain}")
-            path_lines.append("Non-PR work:   in_progress -> review -> done")
-        else:
-            path_lines.append(f"Normal:        {full_chain}")
-        path_lines.append(f"Minor fix:     {minor_chain}")
-        path_lines.append(
-            f"1 impl rework: in_progress -> review -> in_progress -> review{impl_tail}"
-        )
-        if has_validation:
-            path_lines.append(
-                "1 e2e rework:  ... review -> in_validation -> in_progress -> review -> in_validation -> ..."
-            )
-        path_lines.append(
-            "1 plan rework: in_progress -> review -> in_planning -> planned -> in_progress -> review -> ..."
-        )
-        path_lines.append(
-            "Max cycles:    3 rework transitions, then CLI blocks -> flag needs-human"
-        )
-        paths_block = "\n".join(path_lines)
-
-        parts.append(f"""
 ### Review Rework Loop
 
 When a review agent evaluates work, it produces one of three outcomes:
 
-1. **Pass (with optional minor fix):** The review agent uses vibes-based judgment. If the only issues are trivial (obvious typos, missing semicolons, etc.), fix them inline, record what was changed in the review comment, and {advance_phrase}. No strict line-count threshold — the review agent decides.
+1. **Pass (with optional minor fix):** The review agent uses vibes-based judgment. If the only issues are trivial (obvious typos, missing semicolons, etc.), fix them inline, record what was changed in the review comment, and advance — `in_validation` on the PR path, `done` for non-PR work. No strict line-count threshold — the review agent decides.
 
 2. **Fail — implementation-level:** The plan was sound but the implementation has issues. The review agent explicitly states "implementation-level rework needed" in its comment. The orchestrator transitions the task `review -> in_progress`. Critical findings from the review are appended to the plan file under a new `## Review Cycle N Findings` section. A fresh sub-agent is encouraged (but not mandated) for the rework.
 
@@ -408,30 +193,20 @@ When a review agent evaluates work, it produces one of three outcomes:
 | Route to in_progress vs in_planning | Orchestrator | Follows review agent's recommendation |
 | Whether to spawn fresh sub-agent | Orchestrator | Encouraged by convention, not enforced |
 
-**3-cycle safety valve:** After 3 rework transitions (any combination of {rework_origins} -> `in_progress` or `in_planning`), the CLI blocks the 4th attempt. The error message instructs the agent to set the `needs_human` flag with a reason explaining the situation. The limit is configurable via `review_cycle_limit` in the workflow config (default: 3). Override with `--force --reason` for genuinely exceptional cases.
+**3-cycle safety valve:** After 3 rework transitions (any combination of `review`/`in_validation`/`pr_open` -> `in_progress` or `in_planning`), the CLI blocks the 4th attempt. The error message instructs the agent to set the `needs_human` flag with a reason explaining the situation. The limit is configurable via `review_cycle_limit` in the workflow config (default: 3). Override with `--force --reason` for genuinely exceptional cases.
 
 **Allowed lifecycle paths:**
 
 ```
-{paths_block}
+Normal (PR):   in_progress -> review -> in_validation -> pr_open -> done
+Non-PR work:   in_progress -> review -> done
+Minor fix:     in_progress -> review -> (fix inline) -> in_validation -> pr_open -> done
+1 impl rework: in_progress -> review -> in_progress -> review -> in_validation -> ...
+1 e2e rework:  ... review -> in_validation -> in_progress -> review -> in_validation -> ...
+1 plan rework: in_progress -> review -> in_planning -> planned -> in_progress -> review -> ...
+Max cycles:    3 rework transitions, then CLI blocks -> flag needs-human
 ```
-""")
 
-    # ── Validation Gate (in_validation status only) ─────────────────────
-    if has_validation:
-        pass_route = "pass → `pr_open` (open the PR now)" if has_pr_open else "pass → `done`"
-        rework_ref = ", same routing as review rework" if has_review else ""
-        if pr_open_gated:
-            enforcement = (
-                "The CLI enforces the evidence: transitioning to `pr_open` is blocked until "
-                "validation-role evidence is recorded."
-            )
-        else:
-            enforcement = (
-                "Record the evidence even though no CLI gate enforces it here — the ritual "
-                "is the point."
-            )
-        parts.append(f"""
 ### The Validation Gate
 
 Moving to `in_validation` is a commitment to **prove the change works end-to-end** — not to re-run unit tests. The bar: **"I saw it work," not "I think it should work."** A server returning 200 is not a user successfully logging in.
@@ -440,78 +215,37 @@ The validating agent:
 1. **Runs the change against a real running system** — browser automation for web, iOS Simulator MCP / Mobile MCP for mobile, curl flows for APIs, the CLI itself for CLI tools.
 2. **Exercises the actual flow the ticket touched** — clicks the buttons, fills the forms, follows the redirects.
 3. **Records evidence:** `lattice attach <task> --role validation` (or `lattice comment <task> --role validation`) — what was run, what was observed, pass/fail.
-4. **Routes the outcome:** {pass_route}. Fail → `in_progress` (implementation-level) or `in_planning` (plan-level){rework_ref}; the 3-cycle safety valve applies.
+4. **Routes the outcome:** pass → `pr_open` (open the PR now). Fail → `in_progress` (implementation-level) or `in_planning` (plan-level), same routing as review rework; the 3-cycle safety valve applies.
 
-{enforcement} If e2e validation genuinely doesn't apply (docs-only change, pure refactor with no observable behavior), record a one-line N/A justification as the validation evidence — the decision must be explicit, never silent. Do not `--force` past the policy.
-""")
+The CLI enforces the evidence: transitioning to `pr_open` is blocked until validation-role evidence is recorded. If e2e validation genuinely doesn't apply (docs-only change, pure refactor with no observable behavior), record a one-line N/A justification as the validation evidence — the decision must be explicit, never silent. Do not `--force` past the policy.
 
-    # ── Review Config Reference + Auto-fire (any review machinery) ──────
-    if has_review or has_planning:
-        setting_rows = []
-        if has_review:
-            setting_rows.append(
-                "| `review_mode` | `inline`, `single`, `triple` | `single` "
-                "| How code review is performed at the review gate |"
-            )
-        if has_planning:
-            setting_rows.append(
-                "| `plan_review_mode` | `inline`, `single`, `triple` | `single` "
-                "| How plan review is performed after the plan is written |"
-            )
-            setting_rows.append(
-                "| `plan_approval` | `auto`, `human` | `auto` "
-                "| After plan-review: `auto` proceeds, `human` sets the `needs_human` flag "
-                "(task stays `planned`) for approval |"
-            )
-        if has_review:
-            setting_rows.append(
-                "| `auto_code_review_on_transition` | `true`, `false` | `true` "
-                "| Auto-spawn `lattice code-review` when a task transitions to `review` |"
-            )
-        if has_planning:
-            setting_rows.append(
-                "| `auto_plan_review_on_transition` | `true`, `false` | `true` "
-                "| Auto-spawn `lattice plan-review` when a task transitions to `planned` |"
-            )
-        count_word = {1: "One", 2: "Two", 3: "Three", 4: "Four", 5: "Five"}[len(setting_rows)]
-        plural = "settings" if len(setting_rows) > 1 else "setting"
-        settings_table = "\n".join(setting_rows)
-
-        gate_statuses = " or ".join(f"`{s}`" for s in ("review", "planned") if s in statuses)
-        if has_review and has_planning:
-            gate_commands = "`lattice code-review` / `plan-review`"
-        elif has_review:
-            gate_commands = "`lattice code-review`"
-        else:
-            gate_commands = "`lattice plan-review`"
-
-        parts.append(f"""
 ### Review Config Reference
 
-{count_word} {plural} in `.lattice/config.json` control review behavior:
+Five settings in `.lattice/config.json` control review behavior:
 
 | Setting | Values | Default | Meaning |
 |---------|--------|---------|---------|
-{settings_table}
+| `review_mode` | `inline`, `single`, `triple` | `single` | How code review is performed at the review gate |
+| `plan_review_mode` | `inline`, `single`, `triple` | `single` | How plan review is performed after the plan is written |
+| `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` sets the `needs_human` flag (task stays `planned`) for approval |
+| `auto_code_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice code-review` when a task transitions to `review` |
+| `auto_plan_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice plan-review` when a task transitions to `planned` |
 
 **`inline`** — review happens in the same agent session (no subprocess spawned).
 **`single`** — one headless review agent is spawned; result stored as a `review` or `plan-review` artifact. No c11 surface.
-**`triple`** — one new c11 pane sibling to the caller is spawned; the pane runs `/trident-{{code|plan}}-review`, which fans out to multiple agents, merges findings, stores the artifact, and advances the task. Requires c11 (the command errors cleanly otherwise).
+**`triple`** — one new c11 pane sibling to the caller is spawned; the pane runs `/trident-{code|plan}-review`, which fans out to multiple agents, merges findings, stores the artifact, and advances the task. Requires c11 (the command errors cleanly otherwise).
 
 ### Auto-fire Conventions
 
-When a task transitions to {gate_statuses}, `lattice status` automatically spawns a detached {gate_commands} subprocess. The transition itself never blocks on the spawn.
+When a task transitions to `review` or `planned`, `lattice status` automatically spawns a detached `lattice code-review` / `plan-review` subprocess. The transition itself never blocks on the spawn.
 
 - **Coordination** lives in `.lattice/review_state/<task_id>.json` (extended with `started_by_pid` and `auto_fired` fields). First-writer-wins.
-- **Logs** at `.lattice/.daemon/auto-{{code,plan}}-review-<task_id>.log`, overwritten per spawn. Header records the spawn timestamp.
+- **Logs** at `.lattice/.daemon/auto-{code,plan}-review-<task_id>.log`, overwritten per spawn. Header records the spawn timestamp.
 - **Monitor** with `lattice review-status <task_id>` (covers both manual and auto-fired reviews).
 - **Audit** via the `auto_review_spawned` event in the per-task event log.
 - **Per-call opt-out**: `--no-auto-review` on `lattice status`.
 - **Project-wide opt-out**: `auto_code_review_on_transition: false` and/or `auto_plan_review_on_transition: false`.
-""")
 
-    # ── Always-on closing sections ───────────────────────────────────────
-    parts.append("""
 ### When You're Stuck
 
 Set the `needs_human` flag when you need human decision, approval, or input **right now**. The flag is orthogonal to status: the task keeps its swimlane (it can be `in_progress` AND waiting on a human), and it is distinct from `blocked` (generic external dependency — a task can be both). **The flag means actionable NOW** — future checkpoints (quality gates, review gates, approval milestones) stay unflagged until the preceding work is complete. The orchestrator flags them at the moment they become actionable.
@@ -592,14 +326,3 @@ lattice list
 - `lattice link <task> subtask_of|depends_on|blocks <target>` — task relationships
 
 For the full CLI reference, see the `/lattice` skill.
-""")
-
-    return "".join(parts)
-
-
-#: The stage11-default block.  Kept as a module constant for callers that
-#: have no instance config (and as the historical import surface).
-CLAUDE_MD_BLOCK = render_claude_md_block()
-
-# Marker comment used to detect if the block was already added
-CLAUDE_MD_MARKER = "## Lattice"

--- a/tests/test_cli/test_init_presets.py
+++ b/tests/test_cli/test_init_presets.py
@@ -1,0 +1,295 @@
+"""Tests for `lattice init` status presets and the workflow interview (LAT-234)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from lattice.cli.main import cli
+from lattice.core.config import default_config, linear_workflow
+
+# Interactive input that skips the pre-interview prompts with defaults:
+# name, project-name, project-code (the interview question comes next when
+# the TTY guard passes).
+_PRE_INTERVIEW = "\n\n\n"
+# Post-interview prompts: done-display choice, agents.md confirm.
+_POST_INTERVIEW = "1\nn\n"
+
+
+def _read_config(root: Path) -> dict:
+    return json.loads((root / ".lattice" / "config.json").read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def force_tty(monkeypatch: pytest.MonkeyPatch):
+    """Make init believe stdin is a real TTY so the interview fires."""
+    monkeypatch.setattr("lattice.cli.main._stdin_is_tty", lambda: True)
+
+
+class TestPresetFlag:
+    def test_preset_linear_non_interactive(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "init",
+                "--path",
+                str(tmp_path),
+                "--actor",
+                "human:tester",
+                "--project-code",
+                "T",
+                "--preset",
+                "linear",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        config = _read_config(tmp_path)
+        assert config["status_preset"] == "linear"
+        assert config["workflow"]["statuses"] == linear_workflow()["statuses"]
+        assert config["workflow"]["completion_policies"] == {}
+        assert config["workflow"]["wip_limits"] == {}
+        assert "Workflow statuses: linear (6 statuses)" in result.output
+
+    def test_preset_stage11_explicit(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "init",
+                "--path",
+                str(tmp_path),
+                "--actor",
+                "human:tester",
+                "--project-code",
+                "T",
+                "--preset",
+                "stage11",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        config = _read_config(tmp_path)
+        assert config["status_preset"] == "stage11"
+        assert config["workflow"]["statuses"] == default_config()["workflow"]["statuses"]
+
+    def test_no_preset_non_interactive_defaults_to_stage11(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["init", "--path", str(tmp_path), "--actor", "human:tester", "--project-code", "T"],
+        )
+        assert result.exit_code == 0, result.output
+        config = _read_config(tmp_path)
+        assert config["status_preset"] == "stage11"
+        # Workflow section identical to the canonical default (AC2).
+        assert config["workflow"] == json.loads(
+            json.dumps(default_config()["workflow"], sort_keys=True)
+        )
+
+    def test_preset_is_case_insensitive(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "init",
+                "--path",
+                str(tmp_path),
+                "--actor",
+                "human:tester",
+                "--project-code",
+                "T",
+                "--preset",
+                "LINEAR",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert _read_config(tmp_path)["status_preset"] == "linear"
+
+
+class TestNoTtySafety:
+    def test_interactive_init_without_tty_skips_question_and_defaults(
+        self, tmp_path: Path
+    ) -> None:
+        # CliRunner stdin is not a TTY: the interview question must not fire
+        # and init must complete without hanging.
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["init", "--path", str(tmp_path)],
+            input=_PRE_INTERVIEW + _POST_INTERVIEW,
+        )
+        assert result.exit_code == 0, result.output
+        assert "how should work flow here?" not in result.output
+        assert _read_config(tmp_path)["status_preset"] == "stage11"
+
+
+class TestInterview:
+    def test_choice_default_is_stage11(self, tmp_path: Path, force_tty) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["init", "--path", str(tmp_path)],
+            input=_PRE_INTERVIEW + "\n" + _POST_INTERVIEW,
+        )
+        assert result.exit_code == 0, result.output
+        assert "how should work flow here?" in result.output
+        assert _read_config(tmp_path)["status_preset"] == "stage11"
+
+    def test_choice_2_is_linear(self, tmp_path: Path, force_tty) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["init", "--path", str(tmp_path)],
+            input=_PRE_INTERVIEW + "2\n" + _POST_INTERVIEW,
+        )
+        assert result.exit_code == 0, result.output
+        config = _read_config(tmp_path)
+        assert config["status_preset"] == "linear"
+        assert config["workflow"]["statuses"] == linear_workflow()["statuses"]
+
+    def test_choice_3_custom_asks_three_stage_questions(self, tmp_path: Path, force_tty) -> None:
+        runner = CliRunner()
+        # review=yes, validation=no, pr_open=yes
+        result = runner.invoke(
+            cli,
+            ["init", "--path", str(tmp_path)],
+            input=_PRE_INTERVIEW + "3\ny\nn\ny\n" + _POST_INTERVIEW,
+        )
+        assert result.exit_code == 0, result.output
+        assert "code review stage?" in result.output
+        assert "e2e validation stage?" in result.output
+        assert "PR stage?" in result.output
+        config = _read_config(tmp_path)
+        assert config["status_preset"] == "custom"
+        statuses = config["workflow"]["statuses"]
+        assert "review" in statuses
+        assert "in_validation" not in statuses
+        assert "pr_open" in statuses
+        # R3: declining validation drops the pr_open evidence policy.
+        assert "pr_open" not in config["workflow"]["completion_policies"]
+        assert "pr_open" in config["workflow"]["transitions"]["review"]
+
+    def test_needs_human_never_offered(self, tmp_path: Path, force_tty) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["init", "--path", str(tmp_path)],
+            input=_PRE_INTERVIEW + "3\ny\ny\ny\n" + _POST_INTERVIEW,
+        )
+        assert result.exit_code == 0, result.output
+        assert "needs_human" not in result.output
+        assert "needs_human" not in _read_config(tmp_path)["workflow"]["statuses"]
+
+
+class TestGeneratedGuidance:
+    def test_linear_agents_md_mentions_only_linear_statuses(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "init",
+                "--path",
+                str(tmp_path),
+                "--actor",
+                "human:tester",
+                "--project-code",
+                "T",
+                "--preset",
+                "linear",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        agents_md = (tmp_path / "agents.md").read_text(encoding="utf-8")
+        for absent in ("in_planning", "in_validation", "pr_open", "`planned`", "`review`"):
+            assert absent not in agents_md, f"agents.md leaks {absent!r}"
+        assert "backlog → todo → in_progress → in_review → done" in agents_md
+
+    def test_stage11_agents_md_matches_static_block(self, tmp_path: Path) -> None:
+        from lattice.templates.claude_md_block import CLAUDE_MD_BLOCK
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["init", "--path", str(tmp_path), "--actor", "human:tester", "--project-code", "T"],
+        )
+        assert result.exit_code == 0, result.output
+        agents_md = (tmp_path / "agents.md").read_text(encoding="utf-8")
+        assert CLAUDE_MD_BLOCK.lstrip("\n") in agents_md + "\n"
+
+
+class TestLinearPlanGate:
+    def test_todo_to_in_progress_not_blocked_by_plan_scaffold(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "init",
+                "--path",
+                str(tmp_path),
+                "--actor",
+                "human:tester",
+                "--project-code",
+                "T",
+                "--preset",
+                "linear",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        import os
+
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            result = runner.invoke(cli, ["create", "Linear task", "--actor", "agent:t", "--quiet"])
+            assert result.exit_code == 0, result.output
+            task_id = result.output.strip()
+
+            result = runner.invoke(cli, ["status", task_id, "todo", "--actor", "agent:t"])
+            assert result.exit_code == 0, result.output
+
+            # Plan file is still scaffold — the gate must NOT fire (no
+            # planning swimlane in this workflow).
+            result = runner.invoke(cli, ["status", task_id, "in_progress", "--actor", "agent:t"])
+            assert result.exit_code == 0, result.output
+
+            # And the in_review path works through to done.
+            result = runner.invoke(cli, ["status", task_id, "in_review", "--actor", "agent:t"])
+            assert result.exit_code == 0, result.output
+        finally:
+            os.chdir(cwd)
+
+    def test_next_claim_not_blocked_in_linear(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "init",
+                "--path",
+                str(tmp_path),
+                "--actor",
+                "human:tester",
+                "--project-code",
+                "T",
+                "--preset",
+                "linear",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        import os
+
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            result = runner.invoke(cli, ["create", "Claimable", "--actor", "agent:t", "--quiet"])
+            assert result.exit_code == 0, result.output
+
+            result = runner.invoke(cli, ["next", "--actor", "agent:t", "--claim"])
+            assert result.exit_code == 0, result.output
+            assert "PLAN_REQUIRED" not in result.output
+        finally:
+            os.chdir(cwd)

--- a/tests/test_core/test_claude_md_render.py
+++ b/tests/test_core/test_claude_md_render.py
@@ -1,0 +1,130 @@
+"""Tests for the config-driven CLAUDE.md block renderer (LAT-234).
+
+The stage11 default render is locked byte-for-byte against the pre-change
+static block (tests/fixtures/claude_md_block_stage11_snapshot.md).  Other
+presets must only describe statuses that exist in the instance.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lattice.core.config import compose_workflow, default_config
+from lattice.templates.claude_md_block import CLAUDE_MD_BLOCK, render_claude_md_block
+
+_SNAPSHOT = Path(__file__).parent.parent / "fixtures" / "claude_md_block_stage11_snapshot.md"
+
+
+def _custom_config(*, review: bool, validation: bool, pr_open: bool) -> dict:
+    config = dict(default_config(status_preset="custom"))
+    config["workflow"] = compose_workflow(
+        include_review=review, include_validation=validation, include_pr_open=pr_open
+    )
+    return config
+
+
+class TestStage11Snapshot:
+    def test_render_default_is_byte_identical_to_pre_change_block(self) -> None:
+        snapshot = _SNAPSHOT.read_text(encoding="utf-8")
+        assert render_claude_md_block(None) == snapshot
+        assert render_claude_md_block(dict(default_config())) == snapshot
+
+    def test_module_constant_equals_default_render(self) -> None:
+        assert CLAUDE_MD_BLOCK == render_claude_md_block(None)
+
+    def test_empty_config_renders_stage11(self) -> None:
+        assert render_claude_md_block({}) == CLAUDE_MD_BLOCK
+
+
+class TestLinearBlock:
+    def test_mentions_only_existing_statuses(self) -> None:
+        block = render_claude_md_block(dict(default_config(status_preset="linear")))
+        for absent in ("in_planning", "in_validation", "pr_open", "`planned`", "`review`"):
+            assert absent not in block, f"linear block leaks {absent!r}"
+        for present in ("`todo`", "`in_review`", "backlog", "in_progress"):
+            assert present in block
+
+    def test_gate_sections_absent(self) -> None:
+        block = render_claude_md_block(dict(default_config(status_preset="linear")))
+        for section in (
+            "### Sub-Agent Execution Model",
+            "### The Planning Gate",
+            "### Plan Review Triage",
+            "### The Review Gate",
+            "### Review Verdict Routing",
+            "### Review Rework Loop",
+            "### The Validation Gate",
+            "### Review Config Reference",
+            "### Auto-fire Conventions",
+        ):
+            assert section not in block
+
+    def test_always_on_sections_present(self) -> None:
+        block = render_claude_md_block(dict(default_config(status_preset="linear")))
+        for section in (
+            "## Lattice",
+            "### Creating Tasks (Non-Negotiable)",
+            "### Status Transitions",
+            "### When You're Stuck",
+            "### Actor Attribution",
+            "### Quick Reference",
+        ):
+            assert section in block
+
+    def test_lifecycle_diagram(self) -> None:
+        block = render_claude_md_block(dict(default_config(status_preset="linear")))
+        assert "backlog → todo → in_progress → in_review → done" in block
+        assert "↕" not in block  # no blocked status, no connector
+
+
+class TestCustomBlocks:
+    def test_review_only(self) -> None:
+        block = render_claude_md_block(
+            _custom_config(review=True, validation=False, pr_open=False)
+        )
+        assert "### The Review Gate" in block
+        assert "### The Validation Gate" not in block
+        assert "in_validation" not in block
+        assert "pr_open" not in block
+        # Review pass routes straight to done.
+        assert "move to `done` on pass" in block
+
+    def test_validation_only(self) -> None:
+        block = render_claude_md_block(
+            _custom_config(review=False, validation=True, pr_open=False)
+        )
+        assert "### The Validation Gate" in block
+        assert "### The Review Gate" not in block
+        assert "pass → `done`" in block
+        assert "pr_open" not in block
+
+    def test_review_and_pr_open_without_validation(self) -> None:
+        all_on = render_claude_md_block(_custom_config(review=True, validation=True, pr_open=True))
+        no_validation = render_claude_md_block(
+            _custom_config(review=True, validation=False, pr_open=True)
+        )
+        # With validation declined, pr_open carries no evidence requirement.
+        assert "Requires recorded validation evidence" in all_on
+        assert "Requires recorded validation evidence" not in no_validation
+        assert "in_validation" not in no_validation
+
+    def test_all_gates_on_includes_everything(self) -> None:
+        block = render_claude_md_block(_custom_config(review=True, validation=True, pr_open=True))
+        for section in (
+            "### The Planning Gate",
+            "### The Review Gate",
+            "### The Validation Gate",
+            "### Auto-fire Conventions",
+        ):
+            assert section in block
+
+    def test_needs_human_never_a_status(self) -> None:
+        # The flag is referenced (it exists in every preset); the *status* is
+        # never drawn in the lifecycle diagram.
+        for combo in (
+            dict(review=True, validation=True, pr_open=True),
+            dict(review=False, validation=False, pr_open=False),
+        ):
+            block = render_claude_md_block(_custom_config(**combo))
+            assert "→ needs_human" not in block
+            assert "needs_human →" not in block

--- a/tests/test_core/test_status_presets.py
+++ b/tests/test_core/test_status_presets.py
@@ -1,0 +1,248 @@
+"""Tests for workflow status presets (LAT-234).
+
+stage11 is locked as a literal; linear is its own literal; compose_workflow
+serves the custom interview path and must always produce a connected,
+policy-consistent graph.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from lattice.core.config import (
+    STATUS_PRESET_VALUES,
+    compose_workflow,
+    default_config,
+    linear_workflow,
+    stage11_workflow,
+)
+
+# The previously-shipped default workflow, locked byte-for-byte (AC8a).
+# Do NOT regenerate this from code under test — it is the regression anchor.
+_SHIPPED_STAGE11 = {
+    "statuses": [
+        "backlog",
+        "in_planning",
+        "planned",
+        "in_progress",
+        "review",
+        "in_validation",
+        "pr_open",
+        "done",
+        "blocked",
+        "cancelled",
+    ],
+    "transitions": {
+        "backlog": ["in_planning", "planned", "cancelled"],
+        "in_planning": ["planned", "cancelled"],
+        "planned": ["in_progress", "review", "blocked", "cancelled"],
+        "in_progress": ["review", "blocked", "cancelled"],
+        "review": [
+            "in_validation",
+            "pr_open",
+            "done",
+            "in_progress",
+            "in_planning",
+            "cancelled",
+        ],
+        "in_validation": [
+            "pr_open",
+            "in_progress",
+            "in_planning",
+            "blocked",
+            "cancelled",
+        ],
+        "pr_open": [
+            "done",
+            "in_progress",
+            "review",
+            "blocked",
+            "cancelled",
+        ],
+        "done": [],
+        "blocked": [
+            "in_planning",
+            "planned",
+            "in_progress",
+            "in_validation",
+            "pr_open",
+            "cancelled",
+        ],
+        "cancelled": [],
+    },
+    "universal_targets": ["cancelled"],
+    "roles": ["review", "plan-review", "review-individual", "validation"],
+    "wip_limits": {
+        "in_progress": 10,
+        "review": 5,
+        "in_validation": 5,
+        "pr_open": 10,
+    },
+    "completion_policies": {
+        "done": {"require_roles": ["review"]},
+        "pr_open": {"require_roles": ["validation"]},
+    },
+}
+
+
+def _reachable(transitions: dict[str, list[str]], universal: list[str], start: str) -> set[str]:
+    seen = {start}
+    frontier = [start]
+    while frontier:
+        current = frontier.pop()
+        for target in [*transitions.get(current, []), *universal]:
+            if target not in seen:
+                seen.add(target)
+                frontier.append(target)
+    return seen
+
+
+class TestStage11Literal:
+    def test_matches_shipped_literal(self) -> None:
+        wf = stage11_workflow()
+        descriptions = wf.pop("descriptions")
+        assert wf == _SHIPPED_STAGE11
+        assert set(descriptions) == set(_SHIPPED_STAGE11["statuses"])
+
+    def test_default_config_workflow_is_stage11(self) -> None:
+        config = default_config()
+        assert config["status_preset"] == "stage11"
+        wf = dict(config["workflow"])
+        wf.pop("descriptions")
+        assert wf == _SHIPPED_STAGE11
+
+    def test_needs_human_is_not_a_status(self) -> None:
+        for preset in STATUS_PRESET_VALUES:
+            assert (
+                "needs_human" not in default_config(status_preset=preset)["workflow"]["statuses"]
+            )
+
+
+class TestLinearPreset:
+    def test_statuses(self) -> None:
+        wf = linear_workflow()
+        assert wf["statuses"] == [
+            "backlog",
+            "todo",
+            "in_progress",
+            "in_review",
+            "done",
+            "cancelled",
+        ]
+
+    def test_machinery_light(self) -> None:
+        wf = linear_workflow()
+        assert wf["wip_limits"] == {}
+        assert wf["completion_policies"] == {}
+        # Slug-keyed machinery statuses are absent by design.
+        for slug in ("in_planning", "planned", "review", "in_validation", "pr_open", "blocked"):
+            assert slug not in wf["statuses"]
+
+    def test_descriptions_cover_exactly_the_statuses(self) -> None:
+        wf = linear_workflow()
+        assert set(wf["descriptions"]) == set(wf["statuses"])
+
+    def test_connected(self) -> None:
+        wf = linear_workflow()
+        reachable = _reachable(wf["transitions"], wf["universal_targets"], "backlog")
+        assert reachable == set(wf["statuses"])
+
+    def test_default_config_linear(self) -> None:
+        config = default_config(status_preset="linear")
+        assert config["status_preset"] == "linear"
+        assert config["workflow"]["statuses"] == linear_workflow()["statuses"]
+
+    def test_opinionated_display_names_filtered(self) -> None:
+        config = default_config(preset="opinionated", status_preset="linear")
+        display_names = config["workflow"]["display_names"]
+        assert set(display_names) <= set(config["workflow"]["statuses"])
+        assert "in_validation" not in display_names
+        assert display_names["done"] == "shipped"
+
+
+class TestComposeWorkflow:
+    @pytest.mark.parametrize(
+        "include_review,include_validation,include_pr_open",
+        list(itertools.product([True, False], repeat=3)),
+    )
+    def test_connected_and_policy_consistent(
+        self, include_review: bool, include_validation: bool, include_pr_open: bool
+    ) -> None:
+        wf = compose_workflow(
+            include_review=include_review,
+            include_validation=include_validation,
+            include_pr_open=include_pr_open,
+        )
+        statuses = wf["statuses"]
+        transitions = wf["transitions"]
+        universal = wf["universal_targets"]
+
+        # Spine is always present; gates appear iff opted in.
+        for spine in (
+            "backlog",
+            "in_planning",
+            "planned",
+            "in_progress",
+            "done",
+            "blocked",
+            "cancelled",
+        ):
+            assert spine in statuses
+        assert ("review" in statuses) == include_review
+        assert ("in_validation" in statuses) == include_validation
+        assert ("pr_open" in statuses) == include_pr_open
+        assert "needs_human" not in statuses
+
+        # Every status reachable from backlog (AC8b).
+        assert _reachable(transitions, universal, "backlog") == set(statuses)
+
+        # done reachable from every non-terminal status.
+        for status in statuses:
+            if status in ("done", "cancelled"):
+                continue
+            assert "done" in _reachable(transitions, universal, status), status
+
+        # Transition targets are all defined statuses.
+        for source, targets in transitions.items():
+            assert source in statuses
+            for target in targets:
+                assert target in statuses, f"{source} -> {target} undefined"
+
+        # WIP limits only for present statuses.
+        assert set(wf["wip_limits"]) <= set(statuses)
+
+        # Policy rules (R3): done gated iff review exists; pr_open gated iff
+        # pr_open AND in_validation exist.
+        policies = wf["completion_policies"]
+        assert ("done" in policies) == include_review
+        assert ("pr_open" in policies) == (include_pr_open and include_validation)
+        if include_review:
+            assert policies["done"] == {"require_roles": ["review"]}
+        if include_pr_open and include_validation:
+            assert policies["pr_open"] == {"require_roles": ["validation"]}
+
+        # Descriptions cover exactly the present statuses.
+        assert set(wf["descriptions"]) == set(statuses)
+
+    def test_all_gates_on_uses_immediate_forward_edges(self) -> None:
+        # compose_workflow is for custom subsets — it does NOT reproduce the
+        # stage11 literal's skip-forward edges, and that is deliberate.
+        wf = compose_workflow(include_review=True, include_validation=True, include_pr_open=True)
+        assert wf["transitions"]["backlog"] == ["in_planning", "cancelled"]
+        assert wf["transitions"]["review"][0] == "in_validation"
+
+    def test_validation_off_routes_review_to_pr_open(self) -> None:
+        wf = compose_workflow(include_review=True, include_validation=False, include_pr_open=True)
+        assert wf["transitions"]["review"][0] == "pr_open"
+        assert "pr_open" not in wf["completion_policies"]
+
+
+class TestStatusPresetFallback:
+    def test_invalid_status_preset_falls_back_to_stage11(self) -> None:
+        config = default_config(status_preset="nonsense")
+        assert config["status_preset"] == "stage11"
+        wf = dict(config["workflow"])
+        wf.pop("descriptions")
+        assert wf == _SHIPPED_STAGE11


### PR DESCRIPTION
## Summary

`lattice init` now interviews the user about which workflow statuses to install instead of silently writing one default (LAT-234). Builds on LAT-232 (needs_human flag) and LAT-233 (in_validation swimlane).

### Status presets — a new axis, orthogonal to personality

The existing `workflow_preset` (`classic`/`opinionated`) keeps meaning display-name *personality*. The new `status_preset` key decides *which statuses exist*:

| Preset | Statuses | Character |
|---|---|---|
| `stage11` (default) | backlog → in_planning → planned → in_progress → review → in_validation → pr_open → done (+ blocked, cancelled) | The full agentic flow, kept as a **hand-tuned literal** — its skip-forward transition edges are deliberate and locked by test against the previously-shipped workflow |
| `linear` | backlog → todo → in_progress → in_review → done (+ cancelled) | Machinery-light: literal `todo`/`in_review` slugs leave the slug-keyed agentic machinery (auto-fired reviews, plan gating, rework counting) naturally inert; no WIP limits, no completion policies |
| `custom` (interactive only) | Stage 11 spine + opt-in gates | Three y/n questions (code review? e2e validation? PR stage?) composed by `compose_workflow()` — immediate-next forward edges, stage11-mirrored rework/blocked edges, policies derived from present gates |

Key decisions (full rationale in the plan file):
- **No migration**: existing instances untouched; config is instance data (LAT-213 precedent).
- **pr_open requires validation evidence only when BOTH pr_open and in_validation were opted in** — declining the validation stage at init time is human intent that the project has no validation ritual.
- **needs_human is never offered as a status** anywhere (LAT-232).

### Scriptability / no-TTY safety

`--preset stage11|linear` for scripted init. The interview question is TTY-guarded (`_stdin_is_tty()`, monkeypatch-able) with EOF/Abort fallbacks — agent-driven init can never hang. Non-interactive and no-TTY paths produce a workflow section **byte-identical** to the pre-change default.

### Config-driven agent guidance

`templates/claude_md_block.py` becomes `render_claude_md_block(config)`: the CLAUDE.md / agents.md block describes **only statuses that exist in the instance**. The stage11 render is locked **byte-for-byte** against the pre-change static block via a snapshot fixture captured from the old code — re-running `setup-claude` on an existing stage11 project is a no-op. All setup-* paths now render from the instance config.

`check_plan_gate` is config-aware: no planning swimlane → no scaffold block (both callers updated: `status` command and `next --claim`).

### Interview transcript excerpt (real PTY, custom path)

```
how should work flow here?

  1) stage 11 — the full agentic flow: planning gates, code review,
     e2e validation, PR tracking. built for fleets of agents. (default)
  2) linear — the familiar minimal board: backlog / todo / in progress /
     in review / done.
  3) custom — the stage 11 spine, choosing which gates you want.
Choice: 3

code review stage? (review — auto-fired review agents examine the diff) [Y/n]: y
e2e validation stage? (in_validation — prove it works against a running system) [Y/n]: n
PR stage? (pr_open — open PRs as their own swimlane) [Y/n]: y
  → backlog / in_planning / planned / in_progress / review / pr_open / done / blocked / cancelled
```

## Test & validation evidence

- **1970 tests pass** (45 new across `test_status_presets.py`, `test_claude_md_render.py`, `test_init_presets.py`); ruff clean. `compose_workflow` is property-tested over all 8 gate combinations (connectivity, policy consistency).
- **Plan review** (single, auto-fired): PASS — 2 MAJOR findings folded in (stage11 stays a literal; byte-for-byte renderer lock).
- **Code review** (single, auto-fired): PASS, no blocking issues — reviewer independently re-verified both byte-identity locks against `fe016b3`.
- **E2E validation** (real CLI in temp dirs, evidence on the ticket): all three presets initialized and exercised, including the real interview on a PTY via expect, plan-gate quiet in linear (`todo → in_progress` with scaffold plan), pr_open evidence-gating live in stage11, and `in_validation` correctly rejected in a custom-no-validation instance.
- Follow-up filed: **LAT-236** (status-transition hints hardcode stage11 slugs — cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)