### PR TITLE
LAT-240: harden auto-fired review-agent spawn against hangs

### DIFF
--- a/src/lattice/cli/auto_review.py
+++ b/src/lattice/cli/auto_review.py
@@ -194,6 +194,7 @@ def auto_fire_review(
         proc = subprocess.Popen(
             cmd,
             cwd=str(lattice_dir.parent),
+            stdin=subprocess.DEVNULL,
             stdout=log_fh,
             stderr=subprocess.STDOUT,
             start_new_session=True,

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -23,6 +23,8 @@ from lattice.cli.helpers import (
 )
 from lattice.cli.main import cli
 from lattice.core.review import (
+    DEFAULT_MAX_DIFF_LINES,
+    cap_diff,
     claim_review_state,
     cleanup_temp_files,
     clear_review_state,
@@ -214,6 +216,17 @@ def code_review(
             "Diff is empty — no changes detected. Use --base <ref> if the diff range is wrong.",
             "EMPTY_DIFF",
             is_json,
+        )
+
+    # Cap a pathologically large diff before it bloats the prompt. Defense in
+    # depth: a too-wide resolution range shouldn't blow up review cost.
+    max_diff_lines = config.get("review_max_diff_lines", DEFAULT_MAX_DIFF_LINES)
+    diff_content, diff_capped, diff_lines = cap_diff(diff_content, max_diff_lines)
+    if diff_capped and not quiet:
+        click.echo(
+            f"Note: diff has {diff_lines} lines — truncated to {max_diff_lines} "
+            f"for review (configurable via review_max_diff_lines).",
+            err=True,
         )
 
     # Load and fill review template

--- a/src/lattice/core/agent_spawn.py
+++ b/src/lattice/core/agent_spawn.py
@@ -59,7 +59,13 @@ class SpawnRequest:
 
 @dataclass(frozen=True)
 class SpawnResult:
-    """Result of a single agent spawn."""
+    """Result of a single agent spawn.
+
+    ``returncode``, ``stderr_tail`` and ``command`` are diagnostic extras
+    populated by the headless backend so a failure (notably a timeout) can be
+    recorded with enough detail to diagnose it later. They default to
+    empty/None so older callers and other backends remain unaffected.
+    """
 
     agent: str
     success: bool
@@ -67,6 +73,9 @@ class SpawnResult:
     error: str
     backend: str
     duration_seconds: float
+    returncode: int | None = None
+    stderr_tail: str = ""
+    command: str = ""
 
 
 class BackendUnavailableError(RuntimeError):

--- a/src/lattice/core/config.py
+++ b/src/lattice/core/config.py
@@ -160,6 +160,7 @@ class LatticeConfig(TypedDict, total=False):
     plan_review_mode: Literal["inline", "single", "triple"]
     plan_approval: Literal["auto", "human"]
     review_timeout_seconds: int
+    review_max_diff_lines: int
     auto_code_review_on_transition: bool
     auto_plan_review_on_transition: bool
     done_display: Literal["all", "recent", "grouped"]
@@ -417,6 +418,7 @@ def default_config(preset: str = "classic", status_preset: str = "stage11") -> L
         "plan_review_mode": "single",
         "plan_approval": "auto",
         "review_timeout_seconds": 600,
+        "review_max_diff_lines": 5000,
         "auto_code_review_on_transition": True,
         "auto_plan_review_on_transition": True,
         "done_display": "grouped",

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -40,6 +40,13 @@ from lattice.core.agent_spawn import (
 DEFAULT_AGENT_TIMEOUT = 600  # 10 minutes
 FAILURE_THRESHOLD = 2  # auto-create diagnostic task after this many failures
 
+#: Default ceiling on diff lines embedded in a review prompt. Generous on
+#: purpose — a real large change still gets a full review; this only guards
+#: against a pathologically large diff (e.g. a resolution fallback that sweeps
+#: in unrelated merged work) ballooning the prompt and cost. Configurable via
+#: ``review_max_diff_lines``.
+DEFAULT_MAX_DIFF_LINES = 5000
+
 REVIEW_STATE_DIR = "review_state"
 TMP_PROMPTS_DIR = "tmp-prompts"
 FAILURES_FILE = "failures.jsonl"
@@ -237,20 +244,33 @@ def _failures_path(lattice_dir: Path) -> Path:
     return lattice_dir / REVIEW_STATE_DIR / FAILURES_FILE
 
 
-def record_agent_failure(lattice_dir: Path, agent_type: str, task_id: str) -> int:
-    """Record that an agent failed a review. Returns the total failure count for this agent."""
+def record_agent_failure(
+    lattice_dir: Path,
+    agent_type: str,
+    task_id: str,
+    *,
+    detail: dict | None = None,
+) -> int:
+    """Record that an agent failed a review. Returns the total failure count.
+
+    ``detail`` carries diagnostic fields captured from the failed run — the
+    error message, returncode, duration, the resolved command, prompt size,
+    and a tail of the agent's stderr/stdout. Without this the record is just
+    ``{agent, task_id, timestamp}``, which is why six identical timeouts were
+    never diagnosable. Unknown/None detail values are dropped so the line
+    stays compact. ``agent``/``task_id``/``timestamp`` are always present and
+    win over any same-named detail key.
+    """
     state_dir = lattice_dir / REVIEW_STATE_DIR
     state_dir.mkdir(exist_ok=True)
     path = _failures_path(lattice_dir)
-    entry = json.dumps(
-        {
-            "agent": agent_type,
-            "task_id": task_id,
-            "timestamp": _now_iso(),
-        },
-        sort_keys=True,
-        separators=(",", ":"),
-    )
+    record: dict[str, Any] = {}
+    if detail:
+        record.update({k: v for k, v in detail.items() if v not in (None, "")})
+    record["agent"] = agent_type
+    record["task_id"] = task_id
+    record["timestamp"] = _now_iso()
+    entry = json.dumps(record, sort_keys=True, separators=(",", ":"))
     with open(path, "a", encoding="utf-8") as f:
         f.write(entry + "\n")
     return count_agent_failures(lattice_dir, agent_type)
@@ -277,6 +297,43 @@ def count_agent_failures(lattice_dir: Path, agent_type: str) -> int:
     return count
 
 
+#: Stable title prefix for auto-filed diagnostic tasks. Dedup keys on this so
+#: one root cause yields one open ticket instead of a new one per failure.
+DIAGNOSTIC_TITLE_PREFIX = "Investigate"
+_DIAGNOSTIC_TITLE_SUFFIX = "review failures"
+
+
+def _open_diagnostic_task_exists(lattice_dir: Path, agent_type: str) -> bool:
+    """Return True if an unresolved diagnostic task for ``agent_type`` already exists.
+
+    Scans the needs-human queue (every diagnostic task is filed flagged) for a
+    title matching ``Investigate <agent> review failures``. Best-effort: any
+    error means "assume none" so a transient failure never *suppresses* a real
+    escalation — at worst it files one extra ticket, which is the safe default.
+    """
+    try:
+        result = subprocess.run(
+            ["lattice", "list", "--needs-human", "--json"],
+            capture_output=True,
+            text=True,
+            cwd=str(lattice_dir.parent),
+        )
+        if result.returncode != 0:
+            return False
+        payload = json.loads(result.stdout or "{}")
+    except (OSError, json.JSONDecodeError):
+        return False
+    data = payload.get("data", payload)
+    tasks = data.get("tasks", data) if isinstance(data, dict) else data
+    if not isinstance(tasks, list):
+        return False
+    needle = f"{DIAGNOSTIC_TITLE_PREFIX} {agent_type} {_DIAGNOSTIC_TITLE_SUFFIX}"
+    for task in tasks:
+        if isinstance(task, dict) and str(task.get("title", "")).startswith(needle):
+            return True
+    return False
+
+
 def create_failure_diagnostic_task(
     lattice_dir: Path,
     agent_type: str,
@@ -285,9 +342,16 @@ def create_failure_diagnostic_task(
 ) -> str | None:
     """Create a needs_human-flagged task for investigating persistent agent failures.
 
-    Returns the created task ID, or None on failure.
+    Returns the created task ID, or None on failure (or when a diagnostic task
+    for this agent is already open — dedup, so one root cause doesn't escalate
+    into a ladder of near-identical tickets).
     """
-    title = f"Investigate {agent_type} review failures — failed {failure_count} times"
+    if _open_diagnostic_task_exists(lattice_dir, agent_type):
+        return None
+    title = (
+        f"{DIAGNOSTIC_TITLE_PREFIX} {agent_type} {_DIAGNOSTIC_TITLE_SUFFIX} "
+        f"— failed {failure_count} times"
+    )
     try:
         result = subprocess.run(
             [
@@ -331,12 +395,14 @@ def _handle_agent_failure(
     agent_type: str,
     task_id: str,
     actor: str,
+    *,
+    detail: dict | None = None,
 ) -> str | None:
     """Record failure and create diagnostic task if threshold exceeded.
 
     Returns the diagnostic task ID if one was created.
     """
-    count = record_agent_failure(lattice_dir, agent_type, task_id)
+    count = record_agent_failure(lattice_dir, agent_type, task_id, detail=detail)
     if count >= FAILURE_THRESHOLD:
         return create_failure_diagnostic_task(lattice_dir, agent_type, count, actor)
     return None
@@ -452,6 +518,34 @@ def resolve_diff(
         "Could not resolve diff automatically. "
         "Use --base <ref> to specify the base commit or branch."
     )
+
+
+def cap_diff(diff: str, max_lines: int = DEFAULT_MAX_DIFF_LINES) -> tuple[str, bool, int]:
+    """Cap a diff to ``max_lines``, truncating with a visible marker if over.
+
+    Returns ``(possibly_truncated_diff, was_capped, original_line_count)``.
+
+    A non-positive ``max_lines`` disables the cap (returns the diff unchanged).
+    When truncated, a clear marker is appended so the review agent — and any
+    human reading the artifact — knows the diff was cut and by how much, rather
+    than silently reviewing a partial change.
+    """
+    if max_lines <= 0:
+        lines = diff.count("\n") + (1 if diff and not diff.endswith("\n") else 0)
+        return diff, False, lines
+    lines = diff.splitlines()
+    original = len(lines)
+    if original <= max_lines:
+        return diff, False, original
+    kept = "\n".join(lines[:max_lines])
+    omitted = original - max_lines
+    marker = (
+        f"\n\n[diff truncated by Lattice: showing first {max_lines} of {original} "
+        f"lines; {omitted} lines omitted. Review the most significant changes above; "
+        f"if the change is genuinely this large, narrow the diff with --base or raise "
+        f"review_max_diff_lines.]\n"
+    )
+    return kept + marker, True, original
 
 
 def _find_git_root(lattice_dir: Path) -> Path | None:
@@ -679,9 +773,19 @@ def run_single_review(
 
         if not result.success:
             actor_str = _extract_actor_str(actor)
-            _handle_agent_failure(lattice_dir, "claude", task_id, actor_str)
+            message = _format_legacy_error("claude", result, timeout)
+            detail = {
+                "error": result.error or message,
+                "review_type": review_type,
+                "returncode": result.returncode,
+                "duration_seconds": round(result.duration_seconds, 1),
+                "command": result.command,
+                "prompt_chars": len(prompt_content),
+                "stderr_tail": result.stderr_tail,
+            }
+            _handle_agent_failure(lattice_dir, "claude", task_id, actor_str, detail=detail)
             clear_review_state(lattice_dir, task_id)
-            return False, _format_legacy_error("claude", result, timeout), None
+            return False, message, None
 
         clear_review_state(lattice_dir, task_id)
         return True, "Review complete.", result.output_text

--- a/src/lattice/storage/agent_spawn.py
+++ b/src/lattice/storage/agent_spawn.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import os
+import signal
 import subprocess
 import time
 from collections.abc import Sequence
@@ -27,6 +28,11 @@ from lattice.core.agent_spawn import (
 )
 
 logger = logging.getLogger(__name__)
+
+#: How many trailing characters of an agent's stderr/stdout we keep on the
+#: ``SpawnResult`` for diagnostics. Enough to capture the tail of a hang or a
+#: crash without bloating the failure record.
+_TAIL_CHARS = 4000
 
 
 class HeadlessBackend(Backend):
@@ -54,38 +60,67 @@ class HeadlessBackend(Backend):
             env[k] = v
 
         start = time.monotonic()
+        # stdin=DEVNULL: a headless, non-interactive agent must never inherit
+        # the parent's stdin. An inherited, never-EOF stdin (a pipe/pty held
+        # open by a detached parent chain) is the classic cause of an agent
+        # hanging for its entire timeout regardless of workload.
+        #
+        # start_new_session=True puts the shell in its own process group so a
+        # timeout can kill the WHOLE tree. With shell=True, subprocess.run's
+        # own kill-on-timeout reaches only the `sh`; the `claude` (and its
+        # children) underneath survive as orphans that keep consuming API
+        # quota and ~/.claude locks. We manage Popen + killpg ourselves to
+        # avoid that leak.
         try:
-            result = subprocess.run(
+            proc = subprocess.Popen(
                 cmd,
                 shell=True,
                 env=env,
-                capture_output=True,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                timeout=req.timeout_seconds,
-            )
-        except subprocess.TimeoutExpired:
-            duration = time.monotonic() - start
-            self._write_sentinel(req, success=False, error="timed out")
-            return _failure_result(
-                req,
-                f"timed out after {req.timeout_seconds}s",
-                duration=duration,
+                start_new_session=True,
             )
         except OSError as exc:
             duration = time.monotonic() - start
             self._write_sentinel(req, success=False, error=str(exc))
-            return _failure_result(req, f"failed to spawn: {exc}", duration=duration)
+            return _failure_result(req, f"failed to spawn: {exc}", duration=duration, command=cmd)
 
-        duration = time.monotonic() - start
-
-        if result.returncode != 0:
-            stderr = (result.stderr or "").strip()
-            self._write_sentinel(req, success=False, error=stderr or f"exit {result.returncode}")
+        try:
+            stdout, stderr = proc.communicate(timeout=req.timeout_seconds)
+        except subprocess.TimeoutExpired as exc:
+            duration = time.monotonic() - start
+            stdout, stderr = self._kill_group_and_drain(proc, exc)
+            tail = _tail(stderr) or _tail(stdout)
+            err = f"timed out after {req.timeout_seconds}s"
+            self._write_sentinel(req, success=False, error=tail or err)
             return _failure_result(
                 req,
-                f"exited with code {result.returncode}. {stderr}",
+                err,
                 duration=duration,
+                returncode=None,
+                stderr_tail=tail,
+                command=cmd,
             )
+
+        duration = time.monotonic() - start
+        returncode = proc.returncode
+
+        if returncode != 0:
+            stderr_clean = (stderr or "").strip()
+            tail = _tail(stderr_clean) or _tail((stdout or "").strip())
+            self._write_sentinel(req, success=False, error=tail or f"exit {returncode}")
+            return _failure_result(
+                req,
+                f"exited with code {returncode}. {stderr_clean}",
+                duration=duration,
+                returncode=returncode,
+                stderr_tail=tail,
+                command=cmd,
+            )
+
+        result = subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
 
         # Ensure output file is populated (may fall back to stdout).
         output_text = ""
@@ -114,7 +149,35 @@ class HeadlessBackend(Backend):
             error="",
             backend=self.name,
             duration_seconds=duration,
+            returncode=returncode,
+            command=cmd,
         )
+
+    def _kill_group_and_drain(
+        self, proc: subprocess.Popen, exc: subprocess.TimeoutExpired
+    ) -> tuple[str, str]:
+        """Kill the timed-out process group and return its partial output.
+
+        ``proc`` was launched with ``start_new_session=True`` so it leads its
+        own process group; ``os.killpg`` reaps the shell and every descendant
+        (the agent and any tools it spawned), preventing orphan leaks. After
+        the group dies the pipes close and a final ``communicate()`` drains
+        whatever the agent wrote before the wall — the diagnostic that the
+        previous ``subprocess.run`` path discarded.
+        """
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            proc.kill()  # group gone or unreachable — fall back to leader kill
+        try:
+            stdout, stderr = proc.communicate(timeout=10)
+        except (subprocess.TimeoutExpired, ValueError):
+            stdout, stderr = "", ""
+        # Prefer freshly drained output; fall back to whatever the timeout
+        # exception already captured.
+        stdout = stdout or _as_text(exc.stdout)
+        stderr = stderr or _as_text(exc.stderr)
+        return stdout, stderr
 
     def _write_sentinel(self, req: SpawnRequest, *, success: bool, error: str = "") -> None:
         """Write the ``.done`` sentinel (and optional ``.err`` sidecar)."""
@@ -128,7 +191,15 @@ class HeadlessBackend(Backend):
             logger.exception("Failed to write sentinel for %s", req.agent)
 
 
-def _failure_result(req: SpawnRequest, error: str, *, duration: float) -> SpawnResult:
+def _failure_result(
+    req: SpawnRequest,
+    error: str,
+    *,
+    duration: float,
+    returncode: int | None = None,
+    stderr_tail: str = "",
+    command: str = "",
+) -> SpawnResult:
     return SpawnResult(
         agent=req.agent,
         success=False,
@@ -136,4 +207,24 @@ def _failure_result(req: SpawnRequest, error: str, *, duration: float) -> SpawnR
         error=error,
         backend="headless",
         duration_seconds=duration,
+        returncode=returncode,
+        stderr_tail=stderr_tail,
+        command=command,
     )
+
+
+def _tail(text: str | None) -> str:
+    """Return the trailing ``_TAIL_CHARS`` of ``text`` (stripped), or ""."""
+    if not text:
+        return ""
+    text = text.strip()
+    return text[-_TAIL_CHARS:]
+
+
+def _as_text(value: object) -> str:
+    """Coerce a TimeoutExpired.stdout/.stderr (str | bytes | None) to str."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)

--- a/tests/test_core/test_agent_spawn_headless.py
+++ b/tests/test_core/test_agent_spawn_headless.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -105,3 +107,71 @@ class TestHeadlessBackendEndToEnd:
         assert all(r.success for r in results), [r.error for r in results]
         for req in reqs:
             assert sentinel_path(req.output_file).exists()
+
+    def test_timeout_records_command_for_diagnostics(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A timed-out spawn carries the resolved command on the result.
+
+        This is the diagnostic the failure record needs — the timeout path
+        previously discarded everything but a bare 'timed out' string.
+        """
+        _patch_command(monkeypatch, behavior="sleep:5")
+        req = _make_request(tmp_path, "claude", timeout=1)
+        result = spawn_one(req, workspace_label="test", backend=HeadlessBackend())
+        assert not result.success
+        assert result.command and "fake_agent" in result.command
+
+    def test_failure_records_returncode_and_stderr_tail(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_command(monkeypatch, behavior="fail")
+        req = _make_request(tmp_path, "claude")
+        result = spawn_one(req, workspace_label="test", backend=HeadlessBackend())
+        assert not result.success
+        assert result.returncode == 1
+        assert "simulated failure" in result.stderr_tail
+
+    def test_timeout_kills_whole_process_group(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On timeout, a child spawned by the agent is killed too (no orphan).
+
+        Reproduces the real shape: the shell wrapper backgrounds a child (like
+        ``claude`` under ``env``) that would otherwise survive a kill aimed
+        only at the shell. With start_new_session + killpg the whole group dies.
+        """
+        pidfile = tmp_path / "child.pid"
+
+        def _stub(agent_type: str, prompt_file: str, output_file: str) -> str:
+            child = (
+                f"python3 -c 'import os,time;"
+                f'open("{pidfile}","w").write(str(os.getpid()));'
+                f"time.sleep(30)' &"
+            )
+            return f"{child} python3 -c 'import time; time.sleep(30)'"
+
+        monkeypatch.setattr("lattice.core.agent_spawn._agent_cli_command", _stub)
+        monkeypatch.setattr("lattice.storage.agent_spawn._agent_cli_command", _stub)
+
+        req = _make_request(tmp_path, "claude", timeout=2)
+        result = spawn_one(req, workspace_label="test", backend=HeadlessBackend())
+        assert not result.success
+        assert "timed out" in result.error
+
+        assert pidfile.exists(), "child never started"
+        child_pid = int(pidfile.read_text().strip())
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline and _pid_alive(child_pid):
+            time.sleep(0.1)
+        assert not _pid_alive(child_pid), f"orphan child {child_pid} survived the timeout"
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -9,15 +9,19 @@ from pathlib import Path
 
 import pytest
 
+from lattice.core import review as review_mod
 from lattice.core.review import (
     DEFAULT_AGENT_TIMEOUT,
+    DEFAULT_MAX_DIFF_LINES,
     FAILURE_THRESHOLD,
     _extract_actor_str,
     pid_alive,
+    cap_diff,
     claim_review_state,
     cleanup_temp_files,
     clear_review_state,
     count_agent_failures,
+    create_failure_diagnostic_task,
     read_review_state,
     record_agent_failure,
     write_review_state,
@@ -249,6 +253,124 @@ class TestFailureTracking:
         assert entry["agent"] == "claude"
         assert entry["task_id"] == "t1"
         assert "timestamp" in entry
+
+    def test_record_failure_with_detail_persists_diagnostics(self, lattice_dir: Path) -> None:
+        record_agent_failure(
+            lattice_dir,
+            "claude",
+            "t1",
+            detail={
+                "error": "timed out after 600s",
+                "review_type": "code-review",
+                "returncode": None,
+                "duration_seconds": 600.1,
+                "command": "env -u CLAUDECODE claude ...",
+                "prompt_chars": 21591,
+                "stderr_tail": "",
+            },
+        )
+        entry = json.loads((lattice_dir / "review_state" / "failures.jsonl").read_text().strip())
+        # Core fields always present and authoritative.
+        assert entry["agent"] == "claude"
+        assert entry["task_id"] == "t1"
+        assert "timestamp" in entry
+        # Diagnostic detail carried through.
+        assert entry["error"] == "timed out after 600s"
+        assert entry["review_type"] == "code-review"
+        assert entry["duration_seconds"] == 600.1
+        assert entry["command"].startswith("env -u CLAUDECODE")
+        assert entry["prompt_chars"] == 21591
+        # None/empty detail values are dropped to keep the line compact.
+        assert "returncode" not in entry
+        assert "stderr_tail" not in entry
+
+    def test_core_fields_win_over_detail(self, lattice_dir: Path) -> None:
+        record_agent_failure(
+            lattice_dir, "claude", "real", detail={"agent": "spoof", "task_id": "spoof"}
+        )
+        entry = json.loads((lattice_dir / "review_state" / "failures.jsonl").read_text().strip())
+        assert entry["agent"] == "claude"
+        assert entry["task_id"] == "real"
+
+
+class TestDiffCap:
+    def test_under_cap_unchanged(self) -> None:
+        diff = "\n".join(f"line {i}" for i in range(10))
+        capped, was_capped, original = cap_diff(diff, max_lines=100)
+        assert capped == diff
+        assert was_capped is False
+        assert original == 10
+
+    def test_over_cap_truncated_with_marker(self) -> None:
+        diff = "\n".join(f"line {i}" for i in range(500))
+        capped, was_capped, original = cap_diff(diff, max_lines=100)
+        assert was_capped is True
+        assert original == 500
+        assert "diff truncated by Lattice" in capped
+        assert "showing first 100 of 500" in capped
+        # Only the first 100 source lines survive (plus the marker block).
+        assert "line 99" in capped
+        assert "line 100\n" not in capped
+
+    def test_zero_disables_cap(self) -> None:
+        diff = "\n".join(f"line {i}" for i in range(500))
+        capped, was_capped, original = cap_diff(diff, max_lines=0)
+        assert capped == diff
+        assert was_capped is False
+        assert original == 500
+
+    def test_default_constant_is_generous(self) -> None:
+        # A real large change still gets fully reviewed; the cap only guards
+        # against pathological diffs.
+        assert DEFAULT_MAX_DIFF_LINES >= 2000
+
+
+class TestEscalationDedup:
+    """create_failure_diagnostic_task must not file a duplicate when one is open."""
+
+    def test_skips_when_open_diagnostic_exists(
+        self, lattice_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        existing = {
+            "data": {
+                "tasks": [
+                    {"title": "Investigate claude review failures — failed 3 times"},
+                ]
+            }
+        }
+
+        def fake_run(cmd, *args, **kwargs):  # noqa: ANN001
+            import subprocess
+
+            # The dedup probe lists the needs-human queue.
+            assert cmd[:3] == ["lattice", "list", "--needs-human"]
+            return subprocess.CompletedProcess(cmd, 0, json.dumps(existing), "")
+
+        monkeypatch.setattr(review_mod.subprocess, "run", fake_run)
+        result = create_failure_diagnostic_task(lattice_dir, "claude", 4, "agent:x")
+        assert result is None  # deduped — no new ticket
+
+    def test_creates_when_no_open_diagnostic(
+        self, lattice_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *args, **kwargs):  # noqa: ANN001
+            import subprocess
+
+            calls.append(cmd)
+            if cmd[:2] == ["lattice", "list"]:
+                return subprocess.CompletedProcess(cmd, 0, json.dumps({"data": {"tasks": []}}), "")
+            if cmd[:2] == ["lattice", "create"]:
+                return subprocess.CompletedProcess(cmd, 0, "LAT-999\n", "")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(review_mod.subprocess, "run", fake_run)
+        result = create_failure_diagnostic_task(lattice_dir, "claude", 2, "agent:x")
+        assert result == "LAT-999"
+        # The created title carries the stable dedup-able prefix.
+        create_call = next(c for c in calls if c[:2] == ["lattice", "create"])
+        assert create_call[2].startswith("Investigate claude review failures")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Substrate's Lattice instance auto-fired headless `claude` code-reviews that **failed 6 times, escalating** into a ladder of needs-human tickets (SB-57→61→62→66→81). The failure log recorded only `{agent, task_id, timestamp}` — no error — so it was never diagnosable.

## Root cause

Every recorded failure is `Agent 'claude' timed out after 600s`. The review-time diffs spanned **390 → 11,013 lines and *all* died at exactly the 600s cap** — the signature of a structural hang, not slow work (slowness would let small diffs finish). A faithful repro of the exact headless command on a 390-line diff completes in **48s**, so the review itself is fine.

The hang lives in the **detached spawn context**: the agent is launched with **stdin left inherited** through a detached, nested-under-another-agent chain. A non-interactive agent with an inherited never-EOF stdin blocks for its whole timeout. (Current claude masks this with a 3s stdin self-heal; Lattice must not depend on it, and other agents/older builds lack it.)

## Changes

- **`stdin=subprocess.DEVNULL`** on both spawn sites — the detached `lattice {code,plan}-review` `Popen` (`cli/auto_review.py`) and the subprocess that launches the agent (`storage/agent_spawn.py`). **Primary fix.**
- **Process-group kill on timeout** — launch via `start_new_session` + `os.killpg` so a timed-out review leaves no orphan `claude` consuming API quota / `~/.claude` locks (`shell=True` previously killed only the `sh`).
- **Rich failure capture** — keep the agent's partial stdout/stderr on timeout (previously discarded), and record `error`, `returncode`, `duration_seconds`, `command`, `prompt_chars` into `failures.jsonl`. The next failure is self-diagnosing.
- **Diff-size cap (defense in depth)** — `cap_diff()` truncates a pathologically large diff with a visible marker. New config key `review_max_diff_lines` (default 5000 — generous; real large changes still get a full review). *Not the proven root cause; hygiene.*
- **Escalation dedup** — don't file a new diagnostic task when an open one for the same agent already exists. One root cause → one ticket.

Deferred to **LAT-241**: tighten `resolve_diff` so a no-branch-link task reviews only its own commits instead of `{oldest}^...HEAD` spanning unrelated merged work.

## Validation

- **End-to-end in a throwaway instance:** a forced 1s timeout writes the rich record (`command`, `duration`, `error`, `prompt_chars`, `review_type`) and leaves **no orphan**; happy-path review still completes and stores its artifact.
- Full suite green (**1982 passed**), `ruff check` + `ruff format` clean. New tests cover `cap_diff`, rich failure detail, escalation dedup, timeout command/stderr capture, and the process-group kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)