### PR TITLE
LAT-243: surface failed reviews instead of silently clearing state

### DIFF
--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -28,6 +28,7 @@ from lattice.core.review import (
     claim_review_state,
     cleanup_temp_files,
     clear_review_state,
+    last_failure_for_task,
     read_review_state,
     run_single_review,
     run_triple_review,
@@ -413,6 +414,33 @@ def plan_review(
 # ---------------------------------------------------------------------------
 
 
+def _echo_review_failure(
+    task_id: str,
+    *,
+    error: str | None,
+    returncode: Any = None,
+    duration: Any = None,
+    stderr_tail: str | None = None,
+    when: str | None = None,
+    source: str | None = None,
+) -> None:
+    """Print a clear, diagnosable FAILED report for a review."""
+    header = f"Review FAILED for {task_id}"
+    if when:
+        header += f" (at {when})"
+    click.echo(header)
+    if source:
+        click.echo(f"  source:       {source}")
+    click.echo(f"  error:        {error or '(none recorded)'}")
+    if returncode is not None:
+        click.echo(f"  returncode:   {returncode}")
+    if duration is not None:
+        click.echo(f"  duration:     {duration}s")
+    if stderr_tail:
+        click.echo(f"  stderr tail:  {stderr_tail}")
+    click.echo(f"  Re-run with:  lattice code-review {task_id}")
+
+
 @cli.command("review-status")
 @click.argument("task_id")
 @click.option("--json", "output_json", is_flag=True, help="Output structured JSON.")
@@ -425,22 +453,56 @@ def review_status(task_id: str, output_json: bool) -> None:
 
     state = read_review_state(lattice_dir, task_id)
     if state is None:
-        # Check if review artifacts exist (review already completed)
+        # No in-flight record. Distinguish: a completed review (artifact exists),
+        # a *failed* review whose state was cleared by an older path (surface it
+        # from failures.jsonl), or genuinely nothing ever ran.
         has_artifacts = _check_review_artifacts(lattice_dir, task_id)
+        failure = None if has_artifacts else last_failure_for_task(lattice_dir, task_id)
         if is_json:
             data: dict[str, Any] = {"task_id": task_id, "status": "none"}
             if has_artifacts:
                 data["note"] = "Review artifacts exist — review may have already completed."
+            elif failure:
+                data["status"] = "failed"
+                data["last_failure"] = failure
             click.echo(json.dumps({"ok": True, "data": data}, indent=2))
         else:
             if has_artifacts:
                 click.echo(
                     f"No in-flight review for {task_id}. Review artifacts exist — review may have already completed."
                 )
+            elif failure:
+                _echo_review_failure(
+                    task_id,
+                    error=failure.get("error"),
+                    returncode=failure.get("returncode"),
+                    duration=failure.get("duration_seconds"),
+                    stderr_tail=failure.get("stderr_tail"),
+                    when=failure.get("timestamp"),
+                    source="failures.jsonl",
+                )
             else:
                 click.echo(
                     f"No in-flight review found for {task_id}. No review artifacts found either."
                 )
+        return
+
+    # A durable 'failed' record (LAT-243): a review ran and failed. Surface it
+    # loudly instead of falling through to the generic in-flight render.
+    if state.get("status") == "failed":
+        if is_json:
+            click.echo(json.dumps({"ok": True, "data": state}, indent=2))
+        else:
+            detail = state.get("detail") or {}
+            _echo_review_failure(
+                task_id,
+                error=state.get("error"),
+                returncode=detail.get("returncode"),
+                duration=detail.get("duration_seconds"),
+                stderr_tail=detail.get("stderr_tail"),
+                when=state.get("finished_at"),
+                source="in-flight review record",
+            )
         return
 
     now = datetime.now(timezone.utc)

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -297,6 +297,33 @@ def count_agent_failures(lattice_dir: Path, agent_type: str) -> int:
     return count
 
 
+def last_failure_for_task(lattice_dir: Path, task_id: str) -> dict | None:
+    """Return the most recent ``failures.jsonl`` entry for ``task_id``, or None.
+
+    Lets ``review-status`` surface a failed review even when the ``review_state``
+    record is gone — e.g. a failure recorded by an older code path that cleared
+    state, or a record overwritten by a later attempt. The file is append-only
+    and chronological, so the last matching line is the most recent failure.
+    """
+    path = _failures_path(lattice_dir)
+    if not path.exists():
+        return None
+    latest: dict | None = None
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get("task_id") == task_id:
+                latest = entry
+    except OSError:
+        return None
+    return latest
+
+
 #: Stable title prefix for auto-filed diagnostic tasks. Dedup keys on this so
 #: one root cause yields one open ticket instead of a new one per failure.
 DIAGNOSTIC_TITLE_PREFIX = "Investigate"
@@ -784,7 +811,21 @@ def run_single_review(
                 "stderr_tail": result.stderr_tail,
             }
             _handle_agent_failure(lattice_dir, "claude", task_id, actor_str, detail=detail)
-            clear_review_state(lattice_dir, task_id)
+            # Leave a durable, observable record instead of clearing it: a failed
+            # review must surface in `review-status`, not vanish into "no review
+            # found". We intentionally store NO review artifact — a failed review
+            # must not satisfy the `done` completion gate. A lingering failed
+            # record never blocks the next review: its started_by_pid is the dead
+            # child, so claim_review_state reclaims the slot (dead-PID → stale).
+            state["status"] = "failed"
+            state["error"] = result.error or message
+            state["finished_at"] = finished_at
+            state["detail"] = {
+                "returncode": result.returncode,
+                "duration_seconds": round(result.duration_seconds, 1),
+                "stderr_tail": result.stderr_tail,
+            }
+            write_review_state(lattice_dir, state)
             return False, message, None
 
         clear_review_state(lattice_dir, task_id)

--- a/tests/test_cli/test_review_cmds.py
+++ b/tests/test_cli/test_review_cmds.py
@@ -154,6 +154,79 @@ class TestReviewStatus:
         assert data["data"]["mode"] == "single"
         assert data["data"]["agents"][0]["name"] == "claude"
 
+    def test_shows_failed_review_state(self, tmp_path):
+        """LAT-243: a durable 'failed' review_state surfaces loudly, not as 'no review'."""
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        from lattice.core.review import write_review_state
+
+        lattice_dir = root / LATTICE_DIR
+        write_review_state(
+            lattice_dir,
+            {
+                "task_id": task_id,
+                "mode": "single",
+                "review_type": "code-review",
+                "status": "failed",
+                "started_at": "2026-06-23T00:00:00Z",
+                "finished_at": "2026-06-23T00:05:00Z",
+                "error": "produced no output",
+                "detail": {"returncode": 1, "duration_seconds": 300.0, "stderr_tail": "boom"},
+                "agents": [{"name": "claude", "status": "failed", "artifact_id": None}],
+            },
+        )
+
+        result = runner.invoke(
+            cli,
+            ["review-status", task_id],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "FAILED" in result.output
+        assert "produced no output" in result.output
+        # Must NOT masquerade as "nothing ran".
+        assert "No in-flight review found" not in result.output
+
+    def test_falls_back_to_failures_jsonl(self, tmp_path):
+        """LAT-243: with no review_state, a recorded failure still surfaces (not 'no review')."""
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        from lattice.core.review import record_agent_failure
+
+        lattice_dir = root / LATTICE_DIR
+        record_agent_failure(
+            lattice_dir,
+            "claude",
+            task_id,
+            detail={"error": "exited with code 1", "returncode": 1, "duration_seconds": 312.0},
+        )
+
+        result = runner.invoke(
+            cli,
+            ["review-status", task_id],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "FAILED" in result.output
+        assert "exited with code 1" in result.output
+
+        # JSON surfaces the failure too.
+        result_json = runner.invoke(
+            cli,
+            ["review-status", task_id, "--json"],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+        data = json.loads(result_json.output)
+        assert data["data"]["status"] == "failed"
+        assert data["data"]["last_failure"]["task_id"] == task_id
+
 
 # ---------------------------------------------------------------------------
 # Tests: code-review inline mode

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -479,6 +479,132 @@ class TestSingleReviewBackend:
         assert isinstance(captured["kwargs"].get("backend"), HeadlessBackend)
 
 
+class TestSingleReviewFailureObservability:
+    """LAT-243: a failed single-mode review must leave a durable, observable record
+    instead of clearing state and vanishing into "no review found"."""
+
+    @staticmethod
+    def _fail_spawn(*, error="produced no output", returncode=1, duration=300.0, stderr="boom"):
+        from lattice.core.agent_spawn import SpawnResult
+
+        def _fake(request, **kwargs):
+            return SpawnResult(
+                agent=request.agent,
+                success=False,
+                output_text="",
+                error=error,
+                backend="headless",
+                duration_seconds=duration,
+                returncode=returncode,
+                stderr_tail=stderr,
+            )
+
+        return _fake
+
+    def test_failure_leaves_durable_failed_state(self, lattice_dir, monkeypatch):
+        from lattice.core import review as review_mod
+
+        monkeypatch.setattr(review_mod, "spawn_one", self._fail_spawn())
+        # Isolate state behavior from the failures.jsonl / diagnostic-task plumbing.
+        monkeypatch.setattr(review_mod, "_handle_agent_failure", lambda *a, **k: 1)
+
+        success, _msg, text = review_mod.run_single_review(
+            lattice_dir=lattice_dir,
+            task_id="t1",
+            review_type="code-review",
+            prompt_content="noop",
+            actor="agent:test",
+            timeout=5,
+        )
+
+        assert success is False
+        assert text is None
+        state = review_mod.read_review_state(lattice_dir, "t1")
+        assert state is not None, "a failed review must NOT clear review_state"
+        assert state["status"] == "failed"
+        assert state["agents"][0]["status"] == "failed"
+        assert "finished_at" in state
+        assert state["detail"]["returncode"] == 1
+
+    def test_success_still_clears_state(self, lattice_dir, monkeypatch):
+        from lattice.core import review as review_mod
+        from lattice.core.agent_spawn import SpawnResult
+
+        def _ok(request, **kwargs):
+            return SpawnResult(
+                agent=request.agent,
+                success=True,
+                output_text="LGTM",
+                error="",
+                backend="headless",
+                duration_seconds=1.0,
+            )
+
+        monkeypatch.setattr(review_mod, "spawn_one", _ok)
+
+        success, _msg, text = review_mod.run_single_review(
+            lattice_dir=lattice_dir,
+            task_id="t2",
+            review_type="code-review",
+            prompt_content="noop",
+            actor="agent:test",
+            timeout=5,
+        )
+
+        assert success is True
+        assert text == "LGTM"
+        assert review_mod.read_review_state(lattice_dir, "t2") is None
+
+    def test_failed_state_does_not_block_next_claim(self, lattice_dir, monkeypatch):
+        from lattice.core import review as review_mod
+
+        monkeypatch.setattr(review_mod, "spawn_one", self._fail_spawn())
+        monkeypatch.setattr(review_mod, "_handle_agent_failure", lambda *a, **k: 1)
+
+        review_mod.run_single_review(
+            lattice_dir=lattice_dir,
+            task_id="t3",
+            review_type="code-review",
+            prompt_content="noop",
+            actor="agent:test",
+            timeout=5,
+        )
+        assert review_mod.read_review_state(lattice_dir, "t3")["status"] == "failed"
+
+        # In production the `lattice code-review` subprocess that wrote this
+        # record has exited by now, so its started_by_pid is dead. Simulate that
+        # (the test runs in-process, so the writer pid is still us) and confirm
+        # the next review can reclaim the slot.
+        monkeypatch.setattr(review_mod, "pid_alive", lambda pid: False)
+        ok, _existing = review_mod.claim_review_state(
+            lattice_dir,
+            "t3",
+            mode="single",
+            review_type="code-review",
+            started_by_pid=12_345,
+            auto_fired=True,
+        )
+        assert ok is True
+
+    def test_last_failure_for_task(self, lattice_dir):
+        from lattice.core import review as review_mod
+
+        assert review_mod.last_failure_for_task(lattice_dir, "tX") is None
+        review_mod.record_agent_failure(
+            lattice_dir, "claude", "tX", detail={"error": "first", "returncode": 1}
+        )
+        review_mod.record_agent_failure(
+            lattice_dir, "claude", "tX", detail={"error": "second", "returncode": 2}
+        )
+        review_mod.record_agent_failure(
+            lattice_dir, "claude", "other", detail={"error": "unrelated"}
+        )
+        latest = review_mod.last_failure_for_task(lattice_dir, "tX")
+        assert latest is not None
+        assert latest["error"] == "second"  # most recent match wins
+        assert latest["task_id"] == "tX"
+
+
 # ---------------------------------------------------------------------------
 # Triple-mode reviews (LAT-218) — fire-and-forget c11 pane spawn
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
A failed single-mode auto-review called `clear_review_state` and stored no artifact. `lattice review-status` reads only `review_state` + artifacts — never `failures.jsonl` — so after a failure it printed *"No in-flight review found. No review artifacts found either,"* indistinguishable from a review that never ran. The task sat silently stuck in `review`, with the failure buried in a per-task log that's overwritten on every spawn.

This is the gap behind the **LAT-240 recurrence**: LAT-240 fixed the 600s stdin-inherited *hang*; this fixes the **observability** of any review failure (timeout, crash, empty output, resource-starved kill under concurrent load).

## Fix
- **`core/review.py::run_single_review`** — on agent failure, write a durable `failed` `review_state` (`status=failed`, `error`, `finished_at`, `detail{returncode,duration_seconds,stderr_tail}`) instead of clearing it. Still stores **no artifact** — a failed review must not satisfy the `done` completion gate. A lingering failed record never blocks the next review: its `started_by_pid` is the dead child, so `claim_review_state` reclaims the slot (dead-PID → stale).
- **`core/review.py::last_failure_for_task`** — new helper scanning `failures.jsonl` for the most recent entry for a task.
- **`cli/review_cmds.py::review_status`** — renders a clear **FAILED** report (error + returncode/duration/stderr-tail + re-run hint) for a failed `review_state`, and falls back to `last_failure_for_task` when no state exists. So a real failure never again reads as "nothing ran." `--json` carries `status:"failed"` + detail.

## Tests
Durable-failed-state, success-still-clears, failed-record-reclaimable, `last_failure_for_task`, plus two `review-status` CLI surfacing tests (failed state + `failures.jsonl` fallback, incl. `--json`).

Full suite green (**1990 passed**); ruff check + format clean. Independently reviewed (PASS) — verified gate integrity and reclaim-safety across the manual / auto-fire / inline claim paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)