### PR TITLE
Reject epic/spike by default + freshness-audit the lattice skill (LAT-248, LAT-249)

### DIFF
--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -76,7 +76,7 @@ _CREATE_COMPARE_FIELDS = (
 
 @cli.command()
 @click.argument("title")
-@click.option("--type", "task_type", default=None, help="Task type (task, bug, spike, chore).")
+@click.option("--type", "task_type", default=None, help="Task type (task, bug, chore).")
 @click.option("--priority", default=None, help="Priority (critical, high, medium, low).")
 @click.option("--urgency", default=None, help="Urgency (immediate, high, normal, low).")
 @click.option("--complexity", default=None, help="Agentic complexity (low, medium, high).")

--- a/src/lattice/core/config.py
+++ b/src/lattice/core/config.py
@@ -408,7 +408,6 @@ def default_config(preset: str = "classic", status_preset: str = "stage11") -> L
         "task_types": [
             "task",
             "bug",
-            "spike",
             "chore",
         ],
         "workflow": workflow,

--- a/src/lattice/skills/lattice/SKILL.md
+++ b/src/lattice/skills/lattice/SKILL.md
@@ -46,6 +46,8 @@ The `--review` text is your breadcrumb for every future agent and human who read
 
 **Do not use raw `lattice status ... done` to finish work.** The `complete` command exists because completion requires evidence — a review comment and artifact. Skipping this ceremony leaves the task without an audit trail.
 
+`complete` moves `review → done` directly. The `in_validation` and `pr_open` gates in the status workflow below apply only when you drive `status` transitions manually (e.g. when a change needs e2e validation or an open PR before it lands).
+
 | Outcome | Action |
 |---------|--------|
 | **Done** | `lattice complete <task_id> --review "..." --actor agent:claude-cli` |
@@ -72,10 +74,11 @@ lattice create "Title" --actor agent:claude-cli --priority high --type bug
 lattice list                           # All active tasks
 lattice list --status in_progress      # Filter by status
 lattice list --assigned agent:claude-cli
+lattice list --type bug --priority high  # Filter by type / priority
 
 # Show
 lattice show PROJ-1                    # Summary
-lattice show PROJ-1 --events           # Full event history
+lattice show PROJ-1 --full             # Full event history
 
 # Status transitions
 lattice status PROJ-1 in_progress --actor agent:claude-cli
@@ -116,13 +119,15 @@ lattice doctor     # Data integrity check
 lattice archive PROJ-1 --actor agent:claude-cli
 ```
 
-Options for `create`: `--priority` (critical/high/medium/low/none), `--type` (task/bug/chore), `--description "..."`, `--assign agent:claude-cli`
+Options for `create`: `--priority` (critical/high/medium/low), `--type` (task/bug/chore), `--description "..."`, `--assigned-to agent:claude-cli`
 
-**No `epic` or `spike` types — just items of work with a dependency graph.** Lattice intentionally rejects umbrella/exploratory ticket types. Express multi-phase or umbrella work as a plain `task` with `subtask_of` links from its children. Express exploratory/investigation work as a plain `task` whose deliverable is a concrete artifact (plan doc, prototype, decision). The subtask + dependency graph (`subtask_of`, `blocks`, `depends_on`) gives you epic-shape and spike-shape without dedicated types. Every ticket is a chunk of work with a real output, not a bucket or a question.
+**No `epic` or `spike` types — just items of work with a dependency graph.** Lattice intentionally rejects umbrella/exploratory ticket types. Express multi-phase work as a single ticket with sections in the description, or as sibling tickets connected by `blocks`/`depends_on` edges. Express exploratory/investigation work as a plain `task` whose deliverable is a concrete artifact (plan doc, prototype, decision). The dependency graph (`blocks`, `depends_on`, `subtask_of`) gives you epic-shape and spike-shape without dedicated types. Every ticket is a chunk of work with a real output, not a bucket or a question.
+
+**Anti-pattern: container tickets.** If a ticket has no concrete deliverable of its own — if its "done" criterion is "all subtasks done" — it is a container, not work, and it breaks Lattice's metaphor. Restructure: collapse the umbrella into one ticket with the work areas as sections in the description (still parallelizable: spell out which sections are independent), or keep sibling tickets with `blocks`/`depends_on` edges and drop the empty parent. `subtask_of` is reserved for genuine decomposition of a larger work item that itself has a deliverable — not for grouping related tickets under a header. When in doubt, ask: "What ships when this ticket is done, separate from its children?" If the answer is "nothing," delete the ticket and consolidate.
 
 **Task description depth:** Match description detail to task ambiguity. Bug fixes and chores can be one-liners ("Add regex validation to frequency names"). Features and integration tasks should include: (1) what it does, (2) acceptance criteria, (3) architectural context, (4) what the user/operator experiences when done.
 
-Relationship types for `link`: `blocks`, `blocked_by`, `subtask_of`, `parent_of`, `depends_on`, `depended_on_by`, `related_to`
+Relationship types for `link`: `blocks`, `depends_on`, `subtask_of`, `related_to`, `spawned_by`, `duplicate_of`, `supersedes`
 
 ## Status Workflow
 
@@ -145,6 +150,8 @@ Every command requires `--actor`. Format: `prefix:identifier`
 - `agent:claude-cli` — default for your own actions
 - `agent:worker-1`, `agent:worker-2` — multi-agent setups
 - `human:username` — when acting on behalf of a human
+
+`--actor` is accepted on every command and is shown throughout this guide. A `--name` flag (session identity) is also accepted and is becoming the preferred form; either works.
 
 ## Task IDs
 

--- a/src/lattice/skills/lattice/references/multi-agent-guide.md
+++ b/src/lattice/skills/lattice/references/multi-agent-guide.md
@@ -11,20 +11,24 @@ Lattice is file-based and local. All state lives in `.lattice/` inside the proje
 ### 1. Initialize Lattice (once per project)
 
 ```bash
-lattice init --project-code PROJ
+lattice init --project-code PROJ --actor agent:orchestrator
 ```
+
+(`init` runs the interactive setup interview unless **both** `--project-code` and `--actor` are supplied.)
 
 ### 2. Orchestrator Creates Tasks
 
-The orchestrator agent creates and assigns work:
+The orchestrator agent creates and assigns work. Each ticket must have a real deliverable of its own — see the "container ticket" anti-pattern in the main skill. Express umbrella work as sibling tickets connected by `depends_on`, not an empty parent with `subtask_of` children.
 
 ```bash
-lattice create "Implement user auth" --actor agent:orchestrator --priority high
-lattice create "Build login endpoint" --actor agent:orchestrator --assign agent:worker-1
-lattice create "Build signup endpoint" --actor agent:orchestrator --assign agent:worker-2
-lattice link PROJ-2 subtask_of PROJ-1 --actor agent:orchestrator
-lattice link PROJ-3 subtask_of PROJ-1 --actor agent:orchestrator
+lattice create "Add session-token validation middleware" --actor agent:orchestrator --priority high --assigned-to agent:worker-1
+lattice create "Add login endpoint (uses session middleware)" --actor agent:orchestrator --assigned-to agent:worker-2
+lattice create "Add signup endpoint (uses session middleware)" --actor agent:orchestrator --assigned-to agent:worker-3
+lattice link PROJ-2 depends_on PROJ-1 --actor agent:orchestrator
+lattice link PROJ-3 depends_on PROJ-1 --actor agent:orchestrator
 ```
+
+Each of PROJ-1, PROJ-2, PROJ-3 ships a concrete change on its own; the dependency edges just sequence them. If the auth work fit in a single ticket, prefer that — three "areas" can live as sections in one description with a "parallel-execution map" up top.
 
 ### 3. Workers Claim and Execute
 
@@ -40,7 +44,7 @@ lattice status PROJ-2 in_progress --actor agent:worker-1
 # Leave progress notes
 lattice comment PROJ-2 "Auth middleware implemented, writing tests" --actor agent:worker-1
 
-# Complete
+# Hand off to review (the reviewer/orchestrator closes with `lattice complete`)
 lattice status PROJ-2 review --actor agent:worker-1
 ```
 
@@ -73,7 +77,7 @@ When a worker needs a human decision, it flags the task. `needs-human` is orthog
 lattice needs-human PROJ-2 "Which OAuth provider to use?" --actor agent:worker-1
 ```
 
-The reason is required and replaces the old "leave a comment" convention. The orchestrator sees the flagged task via `lattice list --needs-human` (a queue spanning every status), resolves it, and clears the flag:
+The reason is required. The orchestrator sees the flagged task via `lattice list --needs-human` (a queue spanning every status), resolves it, and clears the flag:
 
 ```bash
 lattice needs-human PROJ-2 --clear --note "Decided: Google" --actor agent:worker-1
@@ -86,7 +90,7 @@ Use `blocked` (a status) for generic external dependencies; use the `needs-human
 Every action is recorded as an immutable event:
 
 ```bash
-lattice show PROJ-2 --events
+lattice show PROJ-2 --full
 ```
 
 This provides a full audit trail: who changed what, when, and why.

--- a/src/lattice/skills/lattice/references/worktree-guide.md
+++ b/src/lattice/skills/lattice/references/worktree-guide.md
@@ -69,30 +69,27 @@ All worktrees MUST share a single `.lattice/` directory via the `LATTICE_ROOT` e
 When spawning sub-agents that will work in a worktree, ensure `LATTICE_ROOT` is set in their environment:
 
 ```bash
-LATTICE_ROOT=/absolute/path/to/.lattice <agent-command>
+LATTICE_ROOT=/absolute/path/to/primary-checkout <agent-command>
 ```
 
-Each sub-agent inherits the env var and operates against the shared Lattice state.
+`LATTICE_ROOT` is the primary checkout's **root** (the directory containing `.lattice/`), never `.lattice/` itself. Each sub-agent inherits the env var and operates against the shared Lattice state.
 
-## CLI worktree↔root bridge footguns (`code-review` and `plan-review`)
+## Reviewing from a worktree (`code-review` / `plan-review`)
 
-LAT-219 added directory-walking auto-detection so most `lattice` calls route correctly from a worktree (read/write tasks, comments, events, plan files all land in the root repo's `.lattice/`). **Two commands still have known worktree↔root bridge bugs even with `LATTICE_ROOT` set.**
+Most `lattice` calls auto-detect the root repo and route correctly from a worktree (tasks, comments, events, and plan-file writes all land in the root repo's `.lattice/`). Two review paths need extra care when run from a worktree.
 
-### `lattice code-review` — empty-diff failure
+### `lattice code-review` — make sure the diff is real
 
-- **Symptom:** `lattice code-review <TICKET> --base <remote>/main` returns an empty diff or a vacuous artifact when run from a worktree, even with `LATTICE_ROOT=$PWD` set. The reviewer sees no changes and writes a useless review. The auto-fired review (`review_mode: single`) can also just **die without attaching any artifact** — `review-status` keeps ticking, the spawned pid is dead, no `--role review` artifact exists.
-- **Also:** new files are invisible to the diff until committed. **Commit before transitioning to `review`** so the reviewer (and the diff) see the whole change.
-- **Why:** The diff-resolution path doesn't fully honor the worktree's HEAD; it falls back to the primary checkout's refs in some configurations.
-- **Cheap mitigation:** Always pass `--base <remote>/main` (NEVER bare `main` — they look identical but the local ref may be behind the remote). Set `export LATTICE_ROOT=$PWD` at session start.
-- **Fallback (small tickets):** review the committed diff yourself and complete with `lattice complete <TICKET> --review "<verdict + findings>"` — the review text satisfies the `done` policy without a CLI-spawned artifact.
-- **Fallback when cheap mitigation fails:** Spawn an own-reviewer sub-agent on the delegator's own pane that computes the diff itself (`git log <remote>/main..HEAD --stat` + per-file `git diff`), writes a custom artifact at `notes/.tmp/<TICKET>-codereview-custom.md`, and attaches it via `lattice attach <TICKET> --type note --role review --inline "<markdown>" --actor agent:<id>-reviewer`. The `--role review` attachment satisfies the `done` completion policy — the orchestrator can't tell the difference from a CLI-generated review. See the `lattice-orchestrator` skill's `references/orchestrator.md` `## Own-reviewer-tab fallback` section for the full pattern.
-- **Observed:** Every Wave 2 delegator on the EC v1.2.1 run hit this independently and converged on the fallback.
+The diff a worktree review sees can be empty or partial if it resolves against the wrong refs, which yields a vacuous review. Defend against it:
 
-### `lattice plan-review` — wrong-file silent read
+- **Commit before transitioning to `review`.** New/uncommitted files are invisible to the diff — commit so the reviewer sees the whole change.
+- **Always pass `--base <remote>/main`** (e.g. `origin/main`), never bare `main` — they look identical but the local ref may lag the remote, producing a stale or empty diff. Set `export LATTICE_ROOT=<primary-checkout>` at session start.
+- If the auto-review fails outright, `lattice review-status <TICKET>` reports it as `FAILED` (with no `review`-role artifact, so the `done` gate stays blocked). Re-run, or use a fallback below.
+- **Fallback (small tickets):** review the committed diff yourself and close with `lattice complete <TICKET> --review "<verdict + findings>"` — the review text satisfies the `done` policy without a CLI-spawned artifact.
+- **Fallback (richer):** spawn an own-reviewer sub-agent that computes the diff itself (`git log <remote>/main..HEAD --stat` + per-file `git diff`), writes an artifact, and attaches it with `lattice attach <TICKET> --type note --role review --inline "<markdown>" --actor agent:<id>-reviewer`. The `--role review` attachment satisfies the `done` policy. See the `lattice-orchestrator` skill's `references/orchestrator.md` (`## Own-reviewer-tab fallback`).
 
-- **Symptom:** `lattice plan-review <TICKET> --headless` silently reads the empty 30-line plan scaffold (from `.lattice/plans/<task_id>.md` in the wrong location) instead of the authored plan, and reports a vacuous FAIL with no findings against the actual plan content.
-- **Why:** LAT-219 routes plan-file *writes* to the root repo but the plan-review *read path* doesn't always resolve to the same location, depending on how the plan was authored (lattice CLI vs direct file write).
-- **Cheap mitigation:** Before `lattice plan-review`, verify `$REPO_ROOT/.lattice/plans/<task_id>.md` has the authored content via `wc -l`. If it's the 30-line scaffold but the worktree has the real plan, copy worktree→root: `cp <worktree>/.lattice/plans/<task_id>.md $REPO_ROOT/.lattice/plans/`.
-- **Observed:** EC v1.2.1 run, PSY-47 delegator. First plan-review pass returned vacuous FAIL; worked around by the copy. File a Lattice ticket if you hit this — it's an upstream defect that should follow LAT-219's fix to the same conclusion.
+### `lattice plan-review` — confirm it reads the authored plan
 
-Both bugs are upstream defects in Lattice, not workflow issues. Document a hit in your run's closeout audit and consider filing a Lattice ticket so the maintainer can apply the LAT-219 fix to the review path.
+A worktree plan-review can read the empty plan scaffold instead of the authored plan (depending on where the plan was written) and return a vacuous FAIL. Before running it, verify the root holds the real plan:
+
+- `wc -l $REPO_ROOT/.lattice/plans/<task_id>.md` — if it's still the short scaffold but the worktree has the authored plan, copy it across: `cp <worktree>/.lattice/plans/<task_id>.md $REPO_ROOT/.lattice/plans/`.

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -41,7 +41,7 @@ class TestDefaultConfig:
 
     def test_has_task_types(self) -> None:
         config = default_config()
-        assert config["task_types"] == ["task", "bug", "spike", "chore"]
+        assert config["task_types"] == ["task", "bug", "chore"]
 
     def test_workflow_statuses(self) -> None:
         config = default_config()


### PR DESCRIPTION
Makes the lattice skill accurate and brings the code in line with its stated philosophy. The skill (which now claims "no epic/spike") and the code change that makes that true land **together** so the docs never ship ahead of the behavior.

## LAT-248 — drop `spike` from default task_types
The skill stated Lattice has no epic/spike types, but the default shipped `spike` (and `--type` advertised it). Default is now `["task", "bug", "chore"]` (`epic` was already absent). Types stay **per-board configurable**, so this only changes the shipped default — existing boards that configured epic/spike are untouched (no hard blocklist, no migration). `--type` help updated; default-config test updated. Full suite green (1990).

## LAT-249 — skill freshness audit
A fresh-context audit cross-checked `SKILL.md` + references against the code (verified vs source **and** live CLI). Fixed copy-paste-fatal errors and trimmed non-timeless backstory. The container-ticket anti-pattern guidance (already staged) is preserved.

**SKILL.md**
- `link` relationship types corrected to the real set — the old list had `blocked_by`/`parent_of`/`depended_on_by`, which the CLI **rejects**.
- `show --events` → `--full`; `create --assign` → `--assigned-to`; `--priority` drops the non-existent `none`.
- Clarified `lattice complete` moves `review → done` directly (the `in_validation`/`pr_open` gates apply only to manual `status` transitions).
- Noted `--name` is accepted alongside `--actor`; documented `list --type/--priority`.

**multi-agent-guide.md**
- `--assign` → `--assigned-to`; `show --events` → `--full`; `lattice init` example gains `--actor` (interactive unless both flags given); dropped a non-timeless clause; relabeled a worker's `→ review` as a hand-off.

**worktree-guide.md**
- Fixed the sub-agent `LATTICE_ROOT=.../.lattice` example — it contradicted the guide's own invariant (must point at the repo root containing `.lattice/`).
- Rewrote the review-from-worktree section timelessly: kept the operational guidance (commit before review, `--base <remote>/main`, verify the plan file), dropped the run/ticket archaeology, and corrected the stale "review-status keeps ticking silently" claim (failures now surface as `FAILED`, per LAT-243).

## Validation
- All corrected commands run successfully against a live scratch board; grep confirms no stale patterns remain. Full suite green (1990); ruff check + format clean.

## Open flag
The two worktree review bugs' **current** reproduction status was not re-verified (would need a full worktree+review reproduction). Their backstory was reframed as defensive operational advice that's correct regardless of bug status; a deeper re-test can be a follow-up task if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)