### PR TITLE
feat(dashboard): per-lane organization dropdown on the board

### DIFF
--- a/src/lattice/dashboard/server.py
+++ b/src/lattice/dashboard/server.py
@@ -964,6 +964,7 @@ def _make_handler_class(lattice_dir: Path, *, readonly: bool = False) -> type:
                 "font_size",
                 "heat_map_enabled",
                 "lane_colors",
+                "lane_sort",
                 "max_items_per_column",
                 "theme",
                 "voice",
@@ -991,6 +992,20 @@ def _make_handler_class(lattice_dir: Path, *, readonly: bool = False) -> type:
                             _err(
                                 "VALIDATION_ERROR", "lane_colors keys and values must be strings"
                             ),
+                        )
+                        return
+
+            # Validate lane_sort if present
+            if "lane_sort" in body:
+                ls = body["lane_sort"]
+                if not isinstance(ls, dict):
+                    self._send_json(400, _err("VALIDATION_ERROR", "'lane_sort' must be an object"))
+                    return
+                for k, v in ls.items():
+                    if not isinstance(k, str) or not isinstance(v, str):
+                        self._send_json(
+                            400,
+                            _err("VALIDATION_ERROR", "lane_sort keys and values must be strings"),
                         )
                         return
 
@@ -1116,6 +1131,9 @@ def _make_handler_class(lattice_dir: Path, *, readonly: bool = False) -> type:
 
                     if "lane_colors" in body:
                         dashboard["lane_colors"] = body["lane_colors"]
+
+                    if "lane_sort" in body:
+                        dashboard["lane_sort"] = body["lane_sort"]
 
                     if "theme" in body:
                         theme = body["theme"]

--- a/src/lattice/dashboard/static/index.html
+++ b/src/lattice/dashboard/static/index.html
@@ -186,6 +186,11 @@ a:hover{text-decoration:underline}
 .board-col-header .count{font-weight:400;color:var(--text-on-lane-muted);font-size:.75rem;flex-shrink:0;margin-left:0.25rem}
 .board-col-header .lane-color-btn{position:absolute;right:0.25rem;top:0.25rem;width:1.25rem;height:1.25rem;border:2px solid var(--lane-btn-border);border-radius:50%;cursor:pointer;padding:0;background:transparent;opacity:0;transition:opacity .2s}
 .board-col-header:hover .lane-color-btn{opacity:1}
+.board-col-toolbar{padding:0.25rem 0.375rem;border-bottom:1px solid var(--border);display:flex}
+.lane-sort{width:100%;background:transparent;color:var(--text-muted);border:1px solid transparent;border-radius:var(--radius-sm);font-family:inherit;font-size:.7rem;padding:0.125rem 0.25rem;cursor:pointer;transition:background .15s,color .15s,border-color .15s}
+.lane-sort:hover{background:var(--surface-hover);color:var(--text-secondary);border-color:var(--border)}
+.lane-sort:focus{outline:none;background:var(--surface-raised);color:var(--text-primary);border-color:var(--accent)}
+.lane-sort option,.lane-sort optgroup{background:var(--surface);color:var(--text-primary)}
 .board-col-body{padding:0.5rem}
 .board-col.empty-col .board-col-header{padding:0.5rem 0.5rem;font-size:.75rem;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;justify-content:flex-start}
 .board-col.empty-col .board-col-header .count{display:none}
@@ -4062,6 +4067,170 @@ function getLaneColor(status) {
   return themeDefaults[status] || "#6c757d";
 }
 
+// --- Per-lane organization (sort + group) ---
+// Each lane carries its own mode, stored as dashboard.lane_sort[status]. An absent
+// entry means DEFAULT_LANE_SORT, which reproduces the board's original ULID ordering.
+var DEFAULT_LANE_SORT = "created_asc";
+
+var LANE_SORT_MODES = [
+  {value: "created_asc",     label: "Oldest first",      group: "Sort"},
+  {value: "created_desc",    label: "Newest first",      group: "Sort"},
+  {value: "priority",        label: "Priority",          group: "Sort"},
+  {value: "urgency",         label: "Urgency",           group: "Sort"},
+  {value: "updated_desc",    label: "Recently updated",  group: "Sort"},
+  {value: "status_age_desc", label: "Time in status",    group: "Sort"},
+  {value: "complexity_asc",  label: "Quick wins",        group: "Sort"},
+  {value: "group:assignee",  label: "Assignee",          group: "Group"},
+  {value: "group:tag",       label: "Tag",               group: "Group"}
+];
+
+// Done-lane-only modes, kept in sync with the legacy done_display setting.
+var DONE_LANE_MODES = [
+  {value: "group:day", label: "Day completed", group: "Group"},
+  {value: "recent",    label: "Recent 24h",    group: "Group"}
+];
+
+var PRIORITY_RANK   = {critical: 0, high: 1, medium: 2, low: 3};
+var URGENCY_RANK    = {immediate: 0, high: 1, normal: 2, low: 3};
+var COMPLEXITY_RANK = {low: 0, medium: 1, high: 2};
+
+// done_display is the pre-existing setting for the done lane. Map it onto lane modes
+// so an existing config keeps rendering exactly as it did before this feature.
+var DONE_DISPLAY_TO_MODE = {grouped: "group:day", recent: "recent", all: "created_asc"};
+var MODE_TO_DONE_DISPLAY = {"group:day": "grouped", recent: "recent"};
+
+function laneModesFor(status) {
+  return status === "done" ? LANE_SORT_MODES.concat(DONE_LANE_MODES) : LANE_SORT_MODES;
+}
+
+function getLaneSort(status) {
+  var dc = getDashboardConfig();
+  var mode = dc.lane_sort && dc.lane_sort[status];
+  if (mode) return mode;
+  if (status === "done") {
+    var legacy = dc.done_display || (config && config.done_display) || "grouped";
+    return DONE_DISPLAY_TO_MODE[legacy] || DEFAULT_LANE_SORT;
+  }
+  return DEFAULT_LANE_SORT;
+}
+
+async function setLaneSort(status, mode) {
+  var dc = getDashboardConfig();
+  var laneSort = {};
+  if (dc.lane_sort) {
+    Object.keys(dc.lane_sort).forEach(function(k) { laneSort[k] = dc.lane_sort[k]; });
+  }
+  laneSort[status] = mode;
+
+  var payload = {lane_sort: laneSort};
+  // Mirror the done lane onto done_display so the Settings panel select stays truthful.
+  if (status === "done") payload.done_display = MODE_TO_DONE_DISPLAY[mode] || "all";
+
+  try {
+    // The server returns the merged dashboard config — adopt it wholesale.
+    var updated = await apiPost("/api/config/dashboard", payload);
+    if (config) config.dashboard = updated;
+  } catch (e) {
+    showToast(e.message || "Failed to save lane order", "error");
+    // Fall through to re-render anyway: the <select> is rebuilt from config, so this
+    // snaps it back to the value that actually persisted.
+  }
+  if (currentView === "board") renderBoard();
+}
+
+// Rank-based comparator over an enum field; unset values sort last.
+function _byRank(field, ranks) {
+  return function(a, b) {
+    var ra = ranks[a[field]], rb = ranks[b[field]];
+    if (ra == null) ra = 99;
+    if (rb == null) rb = 99;
+    return ra - rb;
+  };
+}
+
+// Timestamp comparator. Falls back to id (ULIDs are monotonic in creation time) so a
+// null timestamp never scrambles the order.
+function _byTime(field, dir) {
+  return function(a, b) {
+    var va = a[field] || a.id || "", vb = b[field] || b.id || "";
+    if (va === vb) return 0;
+    return (va < vb ? -1 : 1) * dir;
+  };
+}
+
+var LANE_COMPARATORS = {
+  created_asc:  _byTime("created_at", 1),
+  created_desc: _byTime("created_at", -1),
+  updated_desc: _byTime("updated_at", -1),
+  // Oldest transition = longest sitting in this lane, so age-descending is timestamp-ascending.
+  status_age_desc: _byTime("last_status_changed_at", 1),
+  priority:     _byRank("priority", PRIORITY_RANK),
+  urgency:      _byRank("urgency", URGENCY_RANK),
+  complexity_asc: _byRank("complexity", COMPLEXITY_RANK)
+};
+
+// Pure: returns a new sorted array. Ties always break on id, so renders are stable.
+function sortLaneItems(items, mode) {
+  var cmp = LANE_COMPARATORS[mode] || LANE_COMPARATORS[DEFAULT_LANE_SORT];
+  return items.slice().sort(function(a, b) {
+    return cmp(a, b) || ((a.id || "") < (b.id || "") ? -1 : (a.id || "") > (b.id || "") ? 1 : 0);
+  });
+}
+
+// Pure: returns [{label, items}] sections. A card belongs to exactly one section — cards
+// are never duplicated, so the lane's header count stays honest. Multi-tag cards group
+// under their alphabetically-first tag.
+function groupLaneItems(items, mode) {
+  var key, emptyLabel;
+  if (mode === "group:assignee") {
+    key = function(t) { return t.assigned_to || ""; };
+    emptyLabel = "Unassigned";
+  } else {
+    key = function(t) {
+      var tags = (t.tags || []).slice().sort();
+      return tags.length ? tags[0] : "";
+    };
+    emptyLabel = "Untagged";
+  }
+
+  var buckets = {};
+  items.forEach(function(t) {
+    var k = key(t);
+    if (!buckets[k]) buckets[k] = [];
+    buckets[k].push(t);
+  });
+
+  // Named sections alphabetically; the empty bucket always sinks to the bottom.
+  var names = Object.keys(buckets).filter(function(k) { return k !== ""; }).sort();
+  if (buckets[""]) names.push("");
+
+  return names.map(function(k) {
+    return {
+      label: k === "" ? emptyLabel : k,
+      items: sortLaneItems(buckets[k], DEFAULT_LANE_SORT)
+    };
+  });
+}
+
+function renderLaneSortSelect(status) {
+  var current = getLaneSort(status);
+  var modes = laneModesFor(status);
+  var html = '<select class="lane-sort" data-status="' + esc(status) + '"'
+    + ' title="How cards in this lane are organized"'
+    + ' onclick="event.stopPropagation()" onmousedown="event.stopPropagation()">';
+  ["Sort", "Group"].forEach(function(groupName) {
+    var inGroup = modes.filter(function(m) { return m.group === groupName; });
+    if (!inGroup.length) return;
+    html += '<optgroup label="' + groupName + '">';
+    inGroup.forEach(function(m) {
+      var sel = m.value === current ? ' selected' : '';
+      html += '<option value="' + esc(m.value) + '"' + sel + '>' + esc(m.label) + '</option>';
+    });
+    html += '</optgroup>';
+  });
+  return html + '</select>';
+}
+
 function getBackgroundImage() {
   var dc = getDashboardConfig();
   return dc.background_image || "";
@@ -4517,12 +4686,18 @@ function renderBoard() {
     html += '<span>' + esc(getStatusDisplayName(status)) + '</span>';
     html += '<span class="count">' + items.length + '</span>';
     html += '</div>';
+    // Empty lanes collapse to a 120px stub — nothing to organize, so no control.
+    var laneMode = getLaneSort(status);
+    if (items.length > 0) {
+      html += '<div class="board-col-toolbar">' + renderLaneSortSelect(status) + '</div>';
+    }
     var maxItems = getMaxItemsPerColumn();
     html += '<div class="board-col-body"' + (maxItems > 0 ? ' style="max-height:' + (maxItems * 5) + 'rem;overflow-y:auto"' : '') + '>';
-    if (status === "done" && items.length > 0) {
-      // Done column display mode
+    var isDoneGrouping = laneMode === "group:day" || laneMode === "recent";
+    if (status === "done" && items.length > 0 && isDoneGrouping) {
+      // Done column display mode (day-bucketed or last-24h) — the pre-existing rendering.
       var dc = getDashboardConfig();
-      var doneMode = dc.done_display || (config && config.done_display) || "grouped";
+      var doneMode = laneMode === "recent" ? "recent" : "grouped";
       var dayStartHour = (dc.day_start_hour != null) ? dc.day_start_hour : 6;
 
       // Helper: get the "logical day" string for a timestamp, shifted by dayStartHour
@@ -4539,10 +4714,7 @@ function renderBoard() {
       logicalYesterday.setDate(logicalYesterday.getDate() - 1);
       var yesterdayStr = logicalYesterday.toISOString().slice(0, 10);
 
-      if (doneMode === "all") {
-        // Flat list, no grouping
-        items.forEach(function(t) { html += renderBoardCard(t); });
-      } else if (doneMode === "recent") {
+      if (doneMode === "recent") {
         // Only items done in last 24 hours
         var cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
         var recentItems = [];
@@ -4601,8 +4773,15 @@ function renderBoard() {
           html += '<div style="color:var(--text-muted);font-size:.8rem;padding:8px;text-align:center">' + esc(t("empty.lane")) + '</div>';
         }
       }
+    } else if (laneMode.indexOf("group:") === 0 && items.length > 0) {
+      // Grouped by assignee or tag — section headers, cards never duplicated.
+      groupLaneItems(items, laneMode).forEach(function(section) {
+        html += '<div class="board-sub-header">' + esc(section.label)
+          + ' <span class="count">' + section.items.length + '</span></div>';
+        section.items.forEach(function(t) { html += renderBoardCard(t); });
+      });
     } else {
-      items.forEach(function(t) { html += renderBoardCard(t); });
+      sortLaneItems(items, laneMode).forEach(function(t) { html += renderBoardCard(t); });
       if (items.length === 0) html += '<div style="color:var(--text-muted);font-size:.8rem;padding:8px;text-align:center">' + esc(t("empty.lane")) + '</div>';
     }
     html += "</div></div>";
@@ -4612,6 +4791,13 @@ function renderBoard() {
   html += "</div>"; // close .board-wrapper
 
   app.innerHTML = html;
+
+  // Per-lane organization dropdown → persist and re-render just this lane's ordering
+  app.querySelectorAll("select.lane-sort").forEach(function(sel) {
+    sel.addEventListener("change", function() {
+      setLaneSort(sel.getAttribute("data-status"), sel.value);
+    });
+  });
 
   // Tag badge → set tag filter (stop propagation so the card click doesn't open detail)
   app.querySelectorAll(".tag-badge").forEach(function(el) {
@@ -6736,16 +6922,10 @@ document.getElementById("heat-map-info-btn").addEventListener("click", function(
   overlay.addEventListener("click", closePopup);
 });
 
-// Done display mode selector
+// Done display mode selector — writes through setLaneSort so this control and the done
+// lane's own dropdown can never disagree about how the lane is organized.
 document.getElementById("done-display-select").addEventListener("change", async function() {
-  var mode = this.value;
-  try {
-    var result = await apiPost("/api/config/dashboard", {done_display: mode});
-    if (config) config.dashboard = result;
-    if (currentView === "board") renderBoard();
-  } catch(e) {
-    showToast(e.message, "error");
-  }
+  await setLaneSort("done", DONE_DISPLAY_TO_MODE[this.value] || DEFAULT_LANE_SORT);
 });
 
 // Max items per column slider

--- a/src/lattice/dashboard/static/index.html
+++ b/src/lattice/dashboard/static/index.html
@@ -4103,13 +4103,24 @@ function laneModesFor(status) {
   return status === "done" ? LANE_SORT_MODES.concat(DONE_LANE_MODES) : LANE_SORT_MODES;
 }
 
+// The server validates lane_sort as a str→str map but does not police the values (a
+// hand-edited config.json can hold anything). Everything downstream indexes lookup
+// tables with this string, so it gets checked against the lane's own mode list here —
+// the single point where a mode enters the app.
+function isValidLaneMode(status, mode) {
+  return laneModesFor(status).some(function(m) { return m.value === mode; });
+}
+
 function getLaneSort(status) {
   var dc = getDashboardConfig();
   var mode = dc.lane_sort && dc.lane_sort[status];
-  if (mode) return mode;
+  if (mode && isValidLaneMode(status, mode)) return mode;
   if (status === "done") {
     var legacy = dc.done_display || (config && config.done_display) || "grouped";
-    return DONE_DISPLAY_TO_MODE[legacy] || DEFAULT_LANE_SORT;
+    var derived = Object.prototype.hasOwnProperty.call(DONE_DISPLAY_TO_MODE, legacy)
+      ? DONE_DISPLAY_TO_MODE[legacy]
+      : null;
+    return derived && isValidLaneMode(status, derived) ? derived : DEFAULT_LANE_SORT;
   }
   return DEFAULT_LANE_SORT;
 }
@@ -4135,6 +4146,10 @@ async function setLaneSort(status, mode) {
     // Fall through to re-render anyway: the <select> is rebuilt from config, so this
     // snaps it back to the value that actually persisted.
   }
+  // The Settings panel's done-display select is only ever written here. Without this the
+  // panel would keep showing a stale mode until a full page reload — the config poll
+  // won't repair it, because we just adopted the server's config as our own.
+  loadDoneDisplaySettings();
   if (currentView === "board") renderBoard();
 }
 
@@ -4148,11 +4163,16 @@ function _byRank(field, ranks) {
   };
 }
 
-// Timestamp comparator. Falls back to id (ULIDs are monotonic in creation time) so a
-// null timestamp never scrambles the order.
+// Timestamp comparator. If either side is missing the field, compare both by id instead
+// — ULIDs are monotonic in creation time, but they are not lexicographically comparable
+// with ISO timestamps, so the fallback has to apply to both operands or neither.
 function _byTime(field, dir) {
   return function(a, b) {
-    var va = a[field] || a.id || "", vb = b[field] || b.id || "";
+    var va = a[field], vb = b[field];
+    if (!va || !vb) {
+      va = a.id || "";
+      vb = b.id || "";
+    }
     if (va === vb) return 0;
     return (va < vb ? -1 : 1) * dir;
   };
@@ -4171,7 +4191,11 @@ var LANE_COMPARATORS = {
 
 // Pure: returns a new sorted array. Ties always break on id, so renders are stable.
 function sortLaneItems(items, mode) {
-  var cmp = LANE_COMPARATORS[mode] || LANE_COMPARATORS[DEFAULT_LANE_SORT];
+  // hasOwnProperty, not a truthiness check: LANE_COMPARATORS["constructor"] would
+  // otherwise hand back an inherited function and silently sort nothing.
+  var cmp = Object.prototype.hasOwnProperty.call(LANE_COMPARATORS, mode)
+    ? LANE_COMPARATORS[mode]
+    : LANE_COMPARATORS[DEFAULT_LANE_SORT];
   return items.slice().sort(function(a, b) {
     return cmp(a, b) || ((a.id || "") < (b.id || "") ? -1 : (a.id || "") > (b.id || "") ? 1 : 0);
   });
@@ -4193,7 +4217,11 @@ function groupLaneItems(items, mode) {
     emptyLabel = "Untagged";
   }
 
-  var buckets = {};
+  // Object.create(null): tags and actor ids are free-form strings, so a task tagged
+  // "constructor" or "__proto__" would otherwise hit an inherited property, skip the
+  // array init, and throw inside renderBoard() — blanking the entire board, not just
+  // this lane.
+  var buckets = Object.create(null);
   items.forEach(function(t) {
     var k = key(t);
     if (!buckets[k]) buckets[k] = [];

--- a/tests/test_dashboard/test_server.py
+++ b/tests/test_dashboard/test_server.py
@@ -976,6 +976,65 @@ class TestPostDashboardConfig:
         assert cfg["dashboard"]["lane_colors"]["backlog"] == "#ff0000"
         assert cfg["dashboard"]["lane_colors"]["done"] == "#00ff00"
 
+    def test_set_lane_sort(self, dashboard_server):
+        """POST /api/config/dashboard should set per-lane sort modes."""
+        base_url, ld, _ids = dashboard_server
+
+        lane_sort = {
+            "backlog": "priority",
+            "review": "status_age_desc",
+        }
+        status, body = _post(
+            base_url,
+            "/api/config/dashboard",
+            {
+                "lane_sort": lane_sort,
+            },
+        )
+        assert status == 200
+        assert body["ok"] is True
+        assert body["data"]["lane_sort"] == lane_sort
+
+        # Verify config on disk
+        cfg = json.loads((ld / "config.json").read_text())
+        assert cfg["dashboard"]["lane_sort"]["backlog"] == "priority"
+        assert cfg["dashboard"]["lane_sort"]["review"] == "status_age_desc"
+
+    def test_set_lane_sort_rejects_non_object(self, dashboard_server):
+        """lane_sort must be an object."""
+        base_url, _ld, _ids = dashboard_server
+
+        status, body = _post(base_url, "/api/config/dashboard", {"lane_sort": "priority"})
+        assert status == 400
+        assert body["ok"] is False
+        assert body["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_set_lane_sort_rejects_non_string_values(self, dashboard_server):
+        """lane_sort values must be strings."""
+        base_url, _ld, _ids = dashboard_server
+
+        status, body = _post(base_url, "/api/config/dashboard", {"lane_sort": {"backlog": 3}})
+        assert status == 400
+        assert body["ok"] is False
+        assert body["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_lane_sort_and_done_display_persist_together(self, dashboard_server):
+        """The done lane writes both keys — they must not clobber each other."""
+        base_url, ld, _ids = dashboard_server
+
+        status, body = _post(
+            base_url,
+            "/api/config/dashboard",
+            {
+                "lane_sort": {"done": "group:day"},
+                "done_display": "grouped",
+            },
+        )
+        assert status == 200
+        cfg = json.loads((ld / "config.json").read_text())
+        assert cfg["dashboard"]["lane_sort"]["done"] == "group:day"
+        assert cfg["dashboard"]["done_display"] == "grouped"
+
     def test_set_both_settings(self, dashboard_server):
         """Setting background_image and lane_colors in one request."""
         base_url, _ld, _ids = dashboard_server


### PR DESCRIPTION
## What

Each board swimlane gets its own dropdown controlling how the cards inside it are organized. Lanes are configured **independently** — the backlog can sort by priority while `review` sorts by how long cards have been rotting there.

Today every lane renders in ULID order (oldest-created first) with no control. That's the least useful order for almost every lane: a long backlog buries the critical item under six months of stale ideas, and there's no way to see which review has been sitting untouched for two weeks. The board shows *what exists*, but not *what matters*.

### Before

Cards in creation order, no control anywhere.

![before](https://raw.githubusercontent.com/jackkrone/lattice/pr-assets/pr-assets/before.png)

### After

Every non-empty lane has its own control, each set differently: backlog on **Priority** (the CRITICAL OAuth card jumps from 8th to 1st), In Progress grouped by **Assignee**, Review on **Urgency**, Done still **Day completed**. Empty lanes show no dropdown.

![after](https://raw.githubusercontent.com/jackkrone/lattice/pr-assets/pr-assets/after.png)

## Modes

One `<select>` per lane, split into two `<optgroup>`s:

**Sort** — Oldest first (default), Newest first, Priority, Urgency, Recently updated, **Time in status** (stalest first), Quick wins (complexity ascending).

**Group** — Assignee, Tag, plus the `done` lane's existing Day completed / Recent 24h.

`Time in status` is the one worth calling out: it keys off `last_status_changed_at` and answers the question a board actually exists to answer — *what has been rotting in this lane*. Stalest-first in `review` surfaces reviews nobody picked up; in `in_progress` it surfaces the card an agent died holding.

## How it's stored

A per-status map in the dashboard config, mirroring the `lane_colors` pattern exactly:

```json
"dashboard": { "lane_sort": { "backlog": "priority", "review": "status_age_desc" } }
```

An absent key means `created_asc`, which reproduces the previous ULID ordering — so **the change is purely additive**. A user who never touches a dropdown sees a byte-for-byte identical board, and an existing `config.json` needs no migration.

`POST /api/config/dashboard` gains `lane_sort`, validated as a `str → str` object by the same rules as `lane_colors`.

### `done` lane back-compat

`done_display` (`grouped` | `recent` | `all`) already existed, is written by the Settings panel, and is read in `renderBoard()`. Rather than fork it into a second source of truth:

- **Read:** `getLaneSort("done")` returns `lane_sort.done` if set, else derives it from `done_display` (`grouped`→`group:day`, `recent`→`recent`, `all`→`created_asc`).
- **Write:** both the lane dropdown and the Settings panel select go through one write path (`setLaneSort`), which mirrors the legacy value back into `done_display`. The two controls cannot disagree.

## Scope

Board view only — not list/cube/dag/web. Deliberately **not** included: manual drag-to-reorder (would need new per-task order persistence, and the dashboard layer is deliberately thin over `.lattice/` files) and alphabetical-by-title (nobody sorts a kanban that way).

## Testing

- `pytest` — **1994 passed**. Adds 4 server tests covering `lane_sort` persistence, validation of non-object / non-string values, and `lane_sort` + `done_display` round-tripping together.
- `ruff check src/ tests/` — clean.
- Verified end-to-end in a real browser against a 21-task board (16 assertions): default order unchanged, lanes independent, grouping never duplicates a card, choices survive reload, Settings panel stays in sync.
- The pure functions (`getLaneSort` / `sortLaneItems` / `groupLaneItems`) were exercised directly under node (12 assertions), including the edge cases below.

The second commit fixes findings from an independent cold review of the first, worth flagging for reviewers since two are non-obvious:

1. The Settings panel's `done-display-select` never re-synced after the lane dropdown was used — `setLaneSort` adopts the server's merged config, so the config poll saw no diff and never repaired it. Stale until a full page reload.
2. `groupLaneItems` bucketed into a bare `{}`, so a task tagged `constructor` (or an actor id `__proto__`) hit an inherited property, skipped the array init, and threw **inside `renderBoard()`** — blanking the entire board, not just the lane. Tags and actor ids are free-form strings, so this was reachable. Now `Object.create(null)`.
3. The timestamp comparator fell back to `id` for only the operand missing its field, lexicographically comparing a ULID against an ISO date — any task missing the field sorted as the oldest thing on the board.
4. A junk mode string from a hand-edited config resolved to an inherited property (`LANE_COMPARATORS["constructor"]` is truthy), silently disabling sorting. Modes are now validated against the lane's own list on read.

Explicitly checked and **not** broken: drag-and-drop still works (the handlers live on `.board-col` and use `closest()`); the removed `done_display: "all"` branch routes correctly to a flat list; `esc()` neutralizes a tag or assignee named `"><img onerror=…>`.

## Notes for the maintainer

- **Branch/commit naming:** I don't have a LAT number, so the branch is `feat/board-lane-organize` and the commits are prefixed `LOCAL-1:` rather than `LAT-<n>:`. Happy to rebase onto a real ticket number, or rename as you see fit.
- The JS has no automated test home in this repo (stdlib-Python server + static monolith, no JS runner), so the node/browser checks above live outside `tests/`. A JS harness feels like a worthwhile separate ticket.
- Screenshots are hosted on a branch of my fork so this PR's diff stays free of binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
