### PR TITLE
LAT-253: code-review resolves the branch diff, never an empty one (ACE-317)

### DIFF
--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -134,11 +134,26 @@ def _claim_or_refuse(
     help="Review mode (overrides config). One of: inline, single, triple.",
 )
 @click.option("--base", default=None, help="Base git ref for diff (branch or commit).")
+@click.option(
+    "--head",
+    default=None,
+    help="Head git ref for diff (branch or commit). Defaults to the task's linked branch, "
+    "then HEAD. Use this when the code under review is on a branch this checkout isn't on.",
+)
+@click.option(
+    "--worktree",
+    default=None,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Directory to run git from (a checkout/worktree that can resolve the head ref). "
+    "Defaults to the repo containing .lattice/.",
+)
 @common_options
 def code_review(
     task_id: str,
     mode: str | None,
     base: str | None,
+    head: str | None,
+    worktree: Path | None,
     model: str | None,
     session: str | None,
     output_json: bool,
@@ -206,7 +221,9 @@ def code_review(
     )
 
     # Resolve diff
-    success, diff_or_err = resolve_diff(lattice_dir, task_id, snapshot, base=base)
+    success, diff_or_err = resolve_diff(
+        lattice_dir, task_id, snapshot, base=base, head=head, worktree=worktree
+    )
     if not success:
         output_error(diff_or_err, "DIFF_RESOLUTION_FAILED", is_json)
 

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -490,60 +490,94 @@ def resolve_diff(
     task_id: str,
     snapshot: dict,
     base: str | None = None,
+    head: str | None = None,
+    worktree: Path | None = None,
 ) -> tuple[bool, str]:
     """Resolve the git diff for a task.
 
     Returns (success, diff_or_error_message).
 
-    Resolution chain:
-    1. --base provided → git diff <base>...HEAD
-    2. Branch-link exists → git diff <base_branch>...HEAD
-    3. Scan git log for task short ID in commit messages → diff that range
-    4. Commits by assigned actor since task moved to in_progress → diff
-    5. Error suggesting --base
+    The review must see the *branch's* changes even when it runs from a
+    checkout whose ``HEAD`` is not the branch under review — the common case
+    in a worktree-per-ticket model, where ``.lattice/`` lives in the main
+    checkout (``HEAD`` == ``main``) while the ticket's code lives on a feature
+    branch in a separate worktree. Because worktrees share the object store,
+    a ref-based three-dot diff ``<base>...<branch>`` resolves the real changes
+    from any checkout. HEAD-anchored resolution does not — it would diff
+    ``main`` against itself and see nothing.
+
+    Resolution is therefore driven by an explicit *head ref* rather than the
+    ambient ``HEAD``:
+
+    1. Head ref = ``--head`` > last linked branch (if it resolves) > ``HEAD``.
+       For each candidate, diff ``<base>...<head>`` (three-dot, merge-base
+       semantics). ``base`` = ``--base`` when given, else the repo's base
+       branch (``main``/``master``).
+    2. Fallback: scan ``git log --all`` for the task short ID in commit
+       messages → diff that range (finds commits on any branch/worktree, not
+       just those reachable from ``HEAD``).
+    3. Fallback: commits by the assigned actor since the task entered
+       ``in_progress`` (also ``--all``).
+
+    An **empty** diff is never accepted as success — a git command that
+    succeeds but produces no output means that candidate resolved to nothing,
+    so resolution continues to the next candidate. Only a non-empty diff
+    short-circuits. If every candidate is empty or unresolvable, this returns
+    a clear error so the caller refuses to emit a PASS on zero lines.
     """
-    repo_root = _find_git_root(lattice_dir)
+    repo_root = worktree if worktree is not None else _find_git_root(lattice_dir)
     if repo_root is None:
         return False, "Not inside a git repository."
 
-    # Step 0: explicit --base
-    if base is not None:
-        diff = _git_diff(repo_root, f"{base}...HEAD")
-        if diff is not None:
-            return True, diff
-        return False, f"git diff {base}...HEAD failed. Check that '{base}' is a valid ref."
+    # An explicit --base that doesn't resolve is a caller error worth naming
+    # precisely, rather than burying it in the generic exhausted-all-paths error.
+    if base is not None and not _ref_exists(repo_root, base):
+        return False, f"Base ref '{base}' does not resolve in {repo_root}. Check the ref name."
 
-    # Step 1: branch-link
-    branch_links = snapshot.get("branch_links", [])
-    if branch_links:
-        branch = branch_links[-1]["branch"]
-        # Try to find merge-base with main/master
-        base_branch = _find_base_branch(repo_root)
-        diff = _git_diff(repo_root, f"{base_branch}...{branch}")
-        if diff is not None:
+    base_ref = base if base is not None else _find_base_branch(repo_root)
+
+    # Step 1: ref-based three-dot diff against a resolved head ref.
+    tried: list[str] = []
+    linked = _linked_branch(snapshot)
+    head_candidates: list[str] = []
+    if head:
+        head_candidates.append(head)
+    if linked and _ref_exists(repo_root, linked):
+        head_candidates.append(linked)
+    head_candidates.append("HEAD")
+
+    for candidate in head_candidates:
+        ref = f"{base_ref}...{candidate}"
+        tried.append(ref)
+        diff = _git_diff(repo_root, ref)
+        if diff:  # non-empty only; "" and None both fall through
             return True, diff
 
-    # Step 2: task short ID in git log
+    # Step 2: task short ID in git log (across all refs).
     short_id = _get_short_id(snapshot)
     if short_id:
         commit_range = _find_commits_by_message(repo_root, short_id)
         if commit_range:
             diff = _git_diff(repo_root, commit_range)
-            if diff is not None:
+            if diff:
                 return True, diff
 
-    # Step 3: commits by assigned actor since in_progress
+    # Step 3: commits by assigned actor since in_progress (across all refs).
     assigned_to = snapshot.get("assigned_to")
     in_progress_time = _find_status_change_time(snapshot, "in_progress")
     if assigned_to and in_progress_time:
         actor_name = _extract_actor_name(assigned_to)
         diff = _git_diff_by_author(repo_root, actor_name, since=in_progress_time)
-        if diff is not None:
+        if diff:
             return True, diff
 
+    tried_desc = ", ".join(tried) if tried else "(none)"
     return False, (
-        "Could not resolve diff automatically. "
-        "Use --base <ref> to specify the base commit or branch."
+        "Could not resolve a non-empty diff for this task "
+        f"(tried: {tried_desc}). If the code under review lives on a branch or "
+        "worktree that this checkout's HEAD isn't on, pass --base/--head to name "
+        "the range explicitly, or --worktree <path> to diff from that checkout. "
+        "Refusing to review an empty diff."
     )
 
 
@@ -591,15 +625,38 @@ def _find_git_root(lattice_dir: Path) -> Path | None:
 def _find_base_branch(repo_root: Path) -> str:
     """Return the likely base branch (main or master)."""
     for branch in ("main", "master"):
-        result = subprocess.run(
-            ["git", "rev-parse", "--verify", branch],
-            cwd=str(repo_root),
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
+        if _ref_exists(repo_root, branch):
             return branch
     return "main"
+
+
+def _ref_exists(repo_root: Path, ref: str) -> bool:
+    """Return True if ``ref`` resolves to a commit in ``repo_root``.
+
+    Uses ``rev-parse --verify <ref>^{commit}`` so a branch name, tag, or SHA
+    all validate, while a path or bogus string does not. Worktrees share the
+    object store, so a feature branch checked out in a *sibling* worktree still
+    resolves from the main checkout — which is exactly what lets a ref-based
+    diff see the branch's changes from any checkout.
+    """
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _linked_branch(snapshot: dict) -> str | None:
+    """Return the most recently linked branch for a task, or None."""
+    branch_links = snapshot.get("branch_links") or []
+    if not branch_links:
+        return None
+    last = branch_links[-1]
+    if isinstance(last, dict):
+        return last.get("branch")
+    return last if isinstance(last, str) else None
 
 
 def _git_diff(repo_root: Path, ref: str) -> str | None:
@@ -618,9 +675,15 @@ def _git_diff(repo_root: Path, ref: str) -> str | None:
 
 
 def _find_commits_by_message(repo_root: Path, short_id: str) -> str | None:
-    """Find git commit range where messages contain short_id."""
+    """Find a git commit range where messages contain short_id.
+
+    Searches ``--all`` refs (not just commits reachable from ``HEAD``) so a
+    ticket whose commits live on an unmerged feature branch — in this checkout
+    or a sibling worktree — is still found. Returns a three-dot range from the
+    oldest matching commit's parent to the newest match.
+    """
     result = subprocess.run(
-        ["git", "log", "--oneline", f"--grep={short_id}", "--format=%H"],
+        ["git", "log", "--all", "--grep", short_id, "--format=%H"],
         cwd=str(repo_root),
         capture_output=True,
         text=True,
@@ -630,17 +693,24 @@ def _find_commits_by_message(repo_root: Path, short_id: str) -> str | None:
     commits = result.stdout.strip().splitlines()
     if not commits:
         return None
-    # Diff from the oldest matching commit's parent to HEAD
+    # Newest match is first (git log is reverse-chronological); oldest is last.
+    newest = commits[0]
     oldest = commits[-1]
-    return f"{oldest}^...HEAD"
+    return f"{oldest}^...{newest}"
 
 
 def _git_diff_by_author(repo_root: Path, author: str, since: str) -> str | None:
-    """Get diff of commits by author since a given ISO timestamp."""
+    """Get diff of commits by author since a given ISO timestamp.
+
+    Searches ``--all`` refs so unmerged feature-branch/worktree commits count,
+    and diffs the resolved commit range directly (parent of the oldest match to
+    the newest match) instead of anchoring on the ambient ``HEAD``.
+    """
     result = subprocess.run(
         [
             "git",
             "log",
+            "--all",
             "--format=%H",
             f"--author={author}",
             f"--since={since}",
@@ -654,8 +724,9 @@ def _git_diff_by_author(repo_root: Path, author: str, since: str) -> str | None:
     commits = result.stdout.strip().splitlines()
     if not commits:
         return None
+    newest = commits[0]
     oldest = commits[-1]
-    return _git_diff(repo_root, f"{oldest}^...HEAD")
+    return _git_diff(repo_root, f"{oldest}^...{newest}")
 
 
 def _get_short_id(snapshot: dict) -> str | None:

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -529,10 +529,13 @@ def resolve_diff(
     if repo_root is None:
         return False, "Not inside a git repository."
 
-    # An explicit --base that doesn't resolve is a caller error worth naming
-    # precisely, rather than burying it in the generic exhausted-all-paths error.
+    # An explicit --base/--head that doesn't resolve is a caller error worth
+    # naming precisely, rather than burying it in the generic exhausted-all-paths
+    # error (or, for head, silently falling through to HEAD and the fallbacks).
     if base is not None and not _ref_exists(repo_root, base):
         return False, f"Base ref '{base}' does not resolve in {repo_root}. Check the ref name."
+    if head is not None and not _ref_exists(repo_root, head):
+        return False, f"Head ref '{head}' does not resolve in {repo_root}. Check the ref name."
 
     base_ref = base if base is not None else _find_base_branch(repo_root)
 

--- a/tests/test_cli/test_review_cmds.py
+++ b/tests/test_cli/test_review_cmds.py
@@ -832,20 +832,17 @@ class TestDiffResolution:
         from lattice.core.review import resolve_diff
 
         # Mock subprocess to return a fake diff
-        with patch(
-            "lattice.core.review._git_diff",
-            return_value="some diff content",
+        with (
+            patch("lattice.core.review._git_diff", return_value="some diff content"),
+            patch("lattice.core.review._find_git_root", return_value=tmp_path),
+            patch("lattice.core.review._ref_exists", return_value=True),
         ):
-            with patch(
-                "lattice.core.review._find_git_root",
-                return_value=tmp_path,
-            ):
-                success, diff = resolve_diff(
-                    tmp_path / ".lattice",
-                    "task_01ABC",
-                    {},
-                    base="main",
-                )
+            success, diff = resolve_diff(
+                tmp_path / ".lattice",
+                "task_01ABC",
+                {},
+                base="main",
+            )
         assert success is True
         assert diff == "some diff content"
 

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -826,6 +826,14 @@ class TestResolveDiffWorktree:
         assert success is False
         assert "no-such-ref" in msg
 
+    def test_bad_head_ref_named_clearly(self, worktree_repo):
+        """An explicit --head that doesn't resolve is named precisely, mirroring
+        --base — a typo'd head shouldn't silently fall through to HEAD."""
+        main, lattice_dir, feature = worktree_repo
+        success, msg = review_mod.resolve_diff(lattice_dir, "task_01", {}, head="no-such-head")
+        assert success is False
+        assert "no-such-head" in msg
+
     def test_non_worktree_head_on_feature_branch(self, tmp_path):
         """Non-worktree case: the feature branch is checked out in the main
         checkout itself (HEAD == feature). Must still resolve."""

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -710,3 +711,149 @@ class TestTripleReviewSpawn:
         # Complex findings route to the needs-human flag, not a status (LAT-232).
         assert "lattice needs-human LAT-42" in prompt
         assert "agent:trident-pane-LAT-42" in prompt
+
+
+# ---------------------------------------------------------------------------
+# resolve_diff against a real git worktree (LAT-253 / ACE-317)
+#
+# These use real git so they bite: they reproduce the worktree-per-ticket model
+# where .lattice/ lives in the main checkout (HEAD == main) while the ticket's
+# code lives on a feature branch in a *sibling* worktree. A resolution that
+# anchors on the ambient HEAD sees an empty diff; a ref-based one sees the real
+# branch changes. On pre-fix code, the --base path accepted that empty diff as
+# success — a PASS on zero lines.
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+@pytest.fixture
+def worktree_repo(tmp_path: Path):
+    """A main checkout (on ``main``) plus a sibling worktree on a feature branch.
+
+    Returns ``(main_checkout, lattice_dir, feature_branch)``. The ticket's change
+    lives only on the feature branch — ``main``'s tree does not contain it.
+    """
+    main = tmp_path / "main"
+    main.mkdir()
+    _git(main, "init", "-b", "main")
+    _git(main, "config", "user.email", "t@t.com")
+    _git(main, "config", "user.name", "Tester")
+    (main / "file.txt").write_text("base\n")
+    _git(main, "add", "-A")
+    _git(main, "commit", "-m", "init")
+
+    feature = "feat/ACE-317-thing"
+    wt = tmp_path / "wt-feature"
+    _git(main, "worktree", "add", "-b", feature, str(wt), "main")
+    (wt / "file.txt").write_text("base\nticket change\n")
+    _git(wt, "add", "-A")
+    _git(wt, "commit", "-m", "ACE-317: the ticket change")
+
+    lattice_dir = main / ".lattice"
+    lattice_dir.mkdir()
+    # Sanity: HEAD-anchored diff from the main checkout sees nothing.
+    assert _git(main, "diff", "main...HEAD") == ""
+    return main, lattice_dir, feature
+
+
+class TestResolveDiffWorktree:
+    def test_linked_branch_resolves_nonempty_from_main_checkout(self, worktree_repo):
+        """The load-bearing case: branch-linked worktree ticket, reviewed from
+        the main checkout whose HEAD is main. Must see the real diff."""
+        main, lattice_dir, feature = worktree_repo
+        snapshot = {"branch_links": [{"branch": feature}], "short_id": "ACE-317"}
+        success, diff = review_mod.resolve_diff(lattice_dir, "task_01", snapshot)
+        assert success is True
+        assert "ticket change" in diff
+
+    def test_explicit_base_main_does_not_return_empty(self, worktree_repo):
+        """Pre-fix trap: ``--base main`` diffed ``main...HEAD`` (empty) and
+        accepted it. Now it must resolve the linked branch's real diff."""
+        main, lattice_dir, feature = worktree_repo
+        snapshot = {"branch_links": [{"branch": feature}], "short_id": "ACE-317"}
+        success, diff = review_mod.resolve_diff(lattice_dir, "task_01", snapshot, base="main")
+        assert success is True
+        assert diff.strip() != ""
+        assert "ticket change" in diff
+
+    def test_no_branch_link_resolves_via_all_history(self, worktree_repo):
+        """No branch-link: the short-id history scan must find the commit on the
+        unmerged feature branch via ``git log --all`` (not reachable from HEAD)."""
+        main, lattice_dir, feature = worktree_repo
+        snapshot = {"short_id": "ACE-317"}  # no branch_links
+        success, diff = review_mod.resolve_diff(lattice_dir, "task_01", snapshot)
+        assert success is True
+        assert "ticket change" in diff
+
+    def test_explicit_head_ref(self, worktree_repo):
+        """An explicit --head names the branch under review directly."""
+        main, lattice_dir, feature = worktree_repo
+        success, diff = review_mod.resolve_diff(lattice_dir, "task_01", {}, head=feature)
+        assert success is True
+        assert "ticket change" in diff
+
+    def test_no_changes_errors_never_passes_empty(self, tmp_path):
+        """A repo with a branch identical to main resolves to an empty diff and
+        must ERROR — never a silent empty success."""
+        main = tmp_path / "main"
+        main.mkdir()
+        _git(main, "init", "-b", "main")
+        _git(main, "config", "user.email", "t@t.com")
+        _git(main, "config", "user.name", "Tester")
+        (main / "f.txt").write_text("x\n")
+        _git(main, "add", "-A")
+        _git(main, "commit", "-m", "init")
+        _git(main, "branch", "feat/empty")  # identical to main
+        lattice_dir = main / ".lattice"
+        lattice_dir.mkdir()
+        snapshot = {"branch_links": [{"branch": "feat/empty"}], "short_id": "NOPE-1"}
+        success, msg = review_mod.resolve_diff(lattice_dir, "task_01", snapshot)
+        assert success is False
+        assert "empty" in msg.lower()
+
+    def test_bad_base_ref_named_clearly(self, worktree_repo):
+        main, lattice_dir, feature = worktree_repo
+        success, msg = review_mod.resolve_diff(lattice_dir, "task_01", {}, base="no-such-ref")
+        assert success is False
+        assert "no-such-ref" in msg
+
+    def test_non_worktree_head_on_feature_branch(self, tmp_path):
+        """Non-worktree case: the feature branch is checked out in the main
+        checkout itself (HEAD == feature). Must still resolve."""
+        main = tmp_path / "main"
+        main.mkdir()
+        _git(main, "init", "-b", "main")
+        _git(main, "config", "user.email", "t@t.com")
+        _git(main, "config", "user.name", "Tester")
+        (main / "f.txt").write_text("base\n")
+        _git(main, "add", "-A")
+        _git(main, "commit", "-m", "init")
+        _git(main, "checkout", "-b", "feat/inline")
+        (main / "f.txt").write_text("base\nmore\n")
+        _git(main, "add", "-A")
+        _git(main, "commit", "-m", "LAT-9: inline change")
+        lattice_dir = main / ".lattice"
+        lattice_dir.mkdir()
+        snapshot = {"branch_links": [{"branch": "feat/inline"}], "short_id": "LAT-9"}
+        success, diff = review_mod.resolve_diff(lattice_dir, "task_01", snapshot)
+        assert success is True
+        assert "more" in diff
+
+    def test_worktree_param_overrides_root(self, worktree_repo):
+        """--worktree points resolution at a specific checkout."""
+        main, lattice_dir, feature = worktree_repo
+        wt = main.parent / "wt-feature"
+        # From the worktree checkout, HEAD is the feature branch, so even the
+        # HEAD candidate resolves.
+        success, diff = review_mod.resolve_diff(lattice_dir, "task_01", {}, worktree=wt)
+        assert success is True
+        assert "ticket change" in diff


### PR DESCRIPTION
## Root cause
`lattice code-review` embedded the **wrong git diff** for tasks whose code lives on a feature branch in a **sibling worktree** — the worktree-per-ticket model Acetate runs. `.lattice/` lives in the main checkout, whose `HEAD` is `main`, so every **HEAD-anchored** path in `core.review.resolve_diff` resolved to an *empty* diff:

- `--base X` → `git diff X...HEAD` (HEAD is `main`) → **empty**, and `""` was accepted as success (`is not None`). The reviewer reviewed **nothing**.
- The short-id / author-since fallbacks used `git log` reachable-from-`HEAD`, so **unmerged** worktree commits were invisible.

Proven with real git: from a main checkout on `main` with a worktree on `feat/ACE-317`, `git diff main...feat/ACE-317` returns the real diff but `git diff main...HEAD` is empty.

In the Acetate overnight run of 2026-07-14→15, **11 of 14** tickets' reviews hit this trap; every delegator fell back to a hand-driven review. A review tool that silently reviews an empty diff can emit a PASS on zero lines.

## Fix
Rework `resolve_diff(lattice_dir, task_id, snapshot, base=None, head=None, worktree=None)`:

1. **Drive off an explicit head ref** — `--head` > last linked branch (if it resolves) > `HEAD` — and diff `base...head` (three-dot, merge-base semantics). This is **ref-based and cwd-independent**: worktrees share the object store, so the branch's changes resolve from the main checkout.
2. **Never accept an empty diff as success.** Both git failure (`None`) and empty output (`""`) fall through to the next candidate. If all are empty/unresolvable, error loudly — refuse to review nothing.
3. **Harden history fallbacks** with `git log --all` so a task with **no branch-link** still finds its commits on any branch/worktree.
4. Add `--head` / `--worktree` to `lattice code-review`; a bad `--base` is now named clearly.

`plan-review` is **unaffected** — it reviews the plan file, not a diff. (Corrects the original ACE-317 assumption.)

## Tests
New real-git worktree tests in `tests/test_core/test_review.py::TestResolveDiffWorktree` reproduce the model. They **bite**: `test_explicit_base_main_does_not_return_empty` and `test_no_changes_errors_never_passes_empty` fail on pre-fix code (empty diff accepted → false PASS) and pass after. Non-worktree case (HEAD on the feature branch in the main checkout) still resolves. Full suite: **1998 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)