### PR TITLE
LAT-254: test(dashboard): JS test harness for lane logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,8 @@ json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n"
 - CLI commands → integration tests (invoke Click, check `.lattice/` state).
 - Core modules → unit tests (pure logic, no filesystem).
 - Storage → tests with real temp directories (`tmp_path` fixture).
+- Dashboard pure JS → `tests/js/` (node:test, zero deps), run automatically through pytest via the bridge test in `tests/test_dashboard/test_js_lane_logic.py` (skipped only when node is absent).
+- New dashboard pure logic goes in a testable static file (e.g. `static/lane-logic.js`), not the inline `index.html` IIFE.
 
 ## Where Things Live
 

--- a/src/lattice/dashboard/static/index.html
+++ b/src/lattice/dashboard/static/index.html
@@ -1574,6 +1574,9 @@ select.form-control{cursor:pointer}
 <script src="/static/cube3d.js" defer></script>
 <link rel="stylesheet" href="/static/cube-v2.css">
 <script src="/static/cube-v2.js" defer></script>
+<!-- Pure lane sort/group logic (see lane-logic.js). Loaded WITHOUT defer so its
+     definitions are global before the main IIFE below runs and calls into them. -->
+<script src="/static/lane-logic.js"></script>
 <script>
 (function(){
 "use strict";
@@ -4068,61 +4071,18 @@ function getLaneColor(status) {
 }
 
 // --- Per-lane organization (sort + group) ---
-// Each lane carries its own mode, stored as dashboard.lane_sort[status]. An absent
-// entry means DEFAULT_LANE_SORT, which reproduces the board's original ULID ordering.
-var DEFAULT_LANE_SORT = "created_asc";
+// The pure lane sort/group logic (constants, comparators, sortLaneItems,
+// groupLaneItems, resolveLaneSort, laneModesFor, isValidLaneMode, and the *_RANK /
+// *_TO_MODE tables) lives in /static/lane-logic.js, loaded as a classic script above
+// so those names are globals here. It is tested under node:test. Only the
+// config/DOM/net-coupled wrappers stay in this IIFE.
 
-var LANE_SORT_MODES = [
-  {value: "created_asc",     label: "Oldest first",      group: "Sort"},
-  {value: "created_desc",    label: "Newest first",      group: "Sort"},
-  {value: "priority",        label: "Priority",          group: "Sort"},
-  {value: "urgency",         label: "Urgency",           group: "Sort"},
-  {value: "updated_desc",    label: "Recently updated",  group: "Sort"},
-  {value: "status_age_desc", label: "Time in status",    group: "Sort"},
-  {value: "complexity_asc",  label: "Quick wins",        group: "Sort"},
-  {value: "group:assignee",  label: "Assignee",          group: "Group"},
-  {value: "group:tag",       label: "Tag",               group: "Group"}
-];
-
-// Done-lane-only modes, kept in sync with the legacy done_display setting.
-var DONE_LANE_MODES = [
-  {value: "group:day", label: "Day completed", group: "Group"},
-  {value: "recent",    label: "Recent 24h",    group: "Group"}
-];
-
-var PRIORITY_RANK   = {critical: 0, high: 1, medium: 2, low: 3};
-var URGENCY_RANK    = {immediate: 0, high: 1, normal: 2, low: 3};
-var COMPLEXITY_RANK = {low: 0, medium: 1, high: 2};
-
-// done_display is the pre-existing setting for the done lane. Map it onto lane modes
-// so an existing config keeps rendering exactly as it did before this feature.
-var DONE_DISPLAY_TO_MODE = {grouped: "group:day", recent: "recent", all: "created_asc"};
-var MODE_TO_DONE_DISPLAY = {"group:day": "grouped", recent: "recent"};
-
-function laneModesFor(status) {
-  return status === "done" ? LANE_SORT_MODES.concat(DONE_LANE_MODES) : LANE_SORT_MODES;
-}
-
-// The server validates lane_sort as a str→str map but does not police the values (a
-// hand-edited config.json can hold anything). Everything downstream indexes lookup
-// tables with this string, so it gets checked against the lane's own mode list here —
-// the single point where a mode enters the app.
-function isValidLaneMode(status, mode) {
-  return laneModesFor(status).some(function(m) { return m.value === mode; });
-}
-
+// Thin wrapper: gathers the dashboard config and delegates the actual decision to the
+// pure resolveLaneSort() in lane-logic.js.
 function getLaneSort(status) {
   var dc = getDashboardConfig();
-  var mode = dc.lane_sort && dc.lane_sort[status];
-  if (mode && isValidLaneMode(status, mode)) return mode;
-  if (status === "done") {
-    var legacy = dc.done_display || (config && config.done_display) || "grouped";
-    var derived = Object.prototype.hasOwnProperty.call(DONE_DISPLAY_TO_MODE, legacy)
-      ? DONE_DISPLAY_TO_MODE[legacy]
-      : null;
-    return derived && isValidLaneMode(status, derived) ? derived : DEFAULT_LANE_SORT;
-  }
-  return DEFAULT_LANE_SORT;
+  var doneDisplay = dc.done_display || (config && config.done_display) || "grouped";
+  return resolveLaneSort(status, dc.lane_sort, doneDisplay);
 }
 
 async function setLaneSort(status, mode) {
@@ -4151,93 +4111,6 @@ async function setLaneSort(status, mode) {
   // won't repair it, because we just adopted the server's config as our own.
   loadDoneDisplaySettings();
   if (currentView === "board") renderBoard();
-}
-
-// Rank-based comparator over an enum field; unset values sort last.
-function _byRank(field, ranks) {
-  return function(a, b) {
-    var ra = ranks[a[field]], rb = ranks[b[field]];
-    if (ra == null) ra = 99;
-    if (rb == null) rb = 99;
-    return ra - rb;
-  };
-}
-
-// Timestamp comparator. If either side is missing the field, compare both by id instead
-// — ULIDs are monotonic in creation time, but they are not lexicographically comparable
-// with ISO timestamps, so the fallback has to apply to both operands or neither.
-function _byTime(field, dir) {
-  return function(a, b) {
-    var va = a[field], vb = b[field];
-    if (!va || !vb) {
-      va = a.id || "";
-      vb = b.id || "";
-    }
-    if (va === vb) return 0;
-    return (va < vb ? -1 : 1) * dir;
-  };
-}
-
-var LANE_COMPARATORS = {
-  created_asc:  _byTime("created_at", 1),
-  created_desc: _byTime("created_at", -1),
-  updated_desc: _byTime("updated_at", -1),
-  // Oldest transition = longest sitting in this lane, so age-descending is timestamp-ascending.
-  status_age_desc: _byTime("last_status_changed_at", 1),
-  priority:     _byRank("priority", PRIORITY_RANK),
-  urgency:      _byRank("urgency", URGENCY_RANK),
-  complexity_asc: _byRank("complexity", COMPLEXITY_RANK)
-};
-
-// Pure: returns a new sorted array. Ties always break on id, so renders are stable.
-function sortLaneItems(items, mode) {
-  // hasOwnProperty, not a truthiness check: LANE_COMPARATORS["constructor"] would
-  // otherwise hand back an inherited function and silently sort nothing.
-  var cmp = Object.prototype.hasOwnProperty.call(LANE_COMPARATORS, mode)
-    ? LANE_COMPARATORS[mode]
-    : LANE_COMPARATORS[DEFAULT_LANE_SORT];
-  return items.slice().sort(function(a, b) {
-    return cmp(a, b) || ((a.id || "") < (b.id || "") ? -1 : (a.id || "") > (b.id || "") ? 1 : 0);
-  });
-}
-
-// Pure: returns [{label, items}] sections. A card belongs to exactly one section — cards
-// are never duplicated, so the lane's header count stays honest. Multi-tag cards group
-// under their alphabetically-first tag.
-function groupLaneItems(items, mode) {
-  var key, emptyLabel;
-  if (mode === "group:assignee") {
-    key = function(t) { return t.assigned_to || ""; };
-    emptyLabel = "Unassigned";
-  } else {
-    key = function(t) {
-      var tags = (t.tags || []).slice().sort();
-      return tags.length ? tags[0] : "";
-    };
-    emptyLabel = "Untagged";
-  }
-
-  // Object.create(null): tags and actor ids are free-form strings, so a task tagged
-  // "constructor" or "__proto__" would otherwise hit an inherited property, skip the
-  // array init, and throw inside renderBoard() — blanking the entire board, not just
-  // this lane.
-  var buckets = Object.create(null);
-  items.forEach(function(t) {
-    var k = key(t);
-    if (!buckets[k]) buckets[k] = [];
-    buckets[k].push(t);
-  });
-
-  // Named sections alphabetically; the empty bucket always sinks to the bottom.
-  var names = Object.keys(buckets).filter(function(k) { return k !== ""; }).sort();
-  if (buckets[""]) names.push("");
-
-  return names.map(function(k) {
-    return {
-      label: k === "" ? emptyLabel : k,
-      items: sortLaneItems(buckets[k], DEFAULT_LANE_SORT)
-    };
-  });
 }
 
 function renderLaneSortSelect(status) {

--- a/src/lattice/dashboard/static/lane-logic.js
+++ b/src/lattice/dashboard/static/lane-logic.js
@@ -1,0 +1,164 @@
+"use strict";
+
+// --- Per-lane organization (sort + group) ---
+// Pure lane sort/group logic for the dashboard board. Extracted from index.html's
+// IIFE so it has a real test home (tests/js/lane-logic.test.js runs under node:test,
+// bridged into pytest). This file is a classic browser script loaded WITHOUT defer
+// before the inline IIFE, so these names are globals by the time the IIFE runs; the
+// CommonJS export guard at the bottom lets node require it. Keep it ES5-flavored (var,
+// function expressions) to match the monolith it came from.
+//
+// Each lane carries its own mode, stored as dashboard.lane_sort[status]. An absent
+// entry means DEFAULT_LANE_SORT, which reproduces the board's original ULID ordering.
+var DEFAULT_LANE_SORT = "created_asc";
+
+var LANE_SORT_MODES = [
+  {value: "created_asc",     label: "Oldest first",      group: "Sort"},
+  {value: "created_desc",    label: "Newest first",      group: "Sort"},
+  {value: "priority",        label: "Priority",          group: "Sort"},
+  {value: "urgency",         label: "Urgency",           group: "Sort"},
+  {value: "updated_desc",    label: "Recently updated",  group: "Sort"},
+  {value: "status_age_desc", label: "Time in status",    group: "Sort"},
+  {value: "complexity_asc",  label: "Quick wins",        group: "Sort"},
+  {value: "group:assignee",  label: "Assignee",          group: "Group"},
+  {value: "group:tag",       label: "Tag",               group: "Group"}
+];
+
+// Done-lane-only modes, kept in sync with the legacy done_display setting.
+var DONE_LANE_MODES = [
+  {value: "group:day", label: "Day completed", group: "Group"},
+  {value: "recent",    label: "Recent 24h",    group: "Group"}
+];
+
+var PRIORITY_RANK   = {critical: 0, high: 1, medium: 2, low: 3};
+var URGENCY_RANK    = {immediate: 0, high: 1, normal: 2, low: 3};
+var COMPLEXITY_RANK = {low: 0, medium: 1, high: 2};
+
+// done_display is the pre-existing setting for the done lane. Map it onto lane modes
+// so an existing config keeps rendering exactly as it did before this feature.
+var DONE_DISPLAY_TO_MODE = {grouped: "group:day", recent: "recent", all: "created_asc"};
+var MODE_TO_DONE_DISPLAY = {"group:day": "grouped", recent: "recent"};
+
+function laneModesFor(status) {
+  return status === "done" ? LANE_SORT_MODES.concat(DONE_LANE_MODES) : LANE_SORT_MODES;
+}
+
+// The server validates lane_sort as a str→str map but does not police the values (a
+// hand-edited config.json can hold anything). Everything downstream indexes lookup
+// tables with this string, so it gets checked against the lane's own mode list here —
+// the single point where a mode enters the app.
+function isValidLaneMode(status, mode) {
+  return laneModesFor(status).some(function(m) { return m.value === mode; });
+}
+
+// Pure: the config-independent core of getLaneSort. Given the raw lane_sort map and the
+// resolved legacy done_display, decide which mode a lane renders in. A valid explicit
+// mode wins; the done lane falls back to deriving from done_display; everything else
+// falls back to the default. The IIFE's getLaneSort is a thin wrapper that gathers the
+// config values and delegates here, keeping the legacy-derivation rules testable without
+// stubbing globals.
+function resolveLaneSort(status, laneSortMap, doneDisplay) {
+  var mode = laneSortMap && laneSortMap[status];
+  if (mode && isValidLaneMode(status, mode)) return mode;
+  if (status === "done") {
+    var legacy = doneDisplay || "grouped";
+    var derived = Object.prototype.hasOwnProperty.call(DONE_DISPLAY_TO_MODE, legacy)
+      ? DONE_DISPLAY_TO_MODE[legacy]
+      : null;
+    return derived && isValidLaneMode(status, derived) ? derived : DEFAULT_LANE_SORT;
+  }
+  return DEFAULT_LANE_SORT;
+}
+
+// Rank-based comparator over an enum field; unset values sort last.
+function _byRank(field, ranks) {
+  return function(a, b) {
+    var ra = ranks[a[field]], rb = ranks[b[field]];
+    if (ra == null) ra = 99;
+    if (rb == null) rb = 99;
+    return ra - rb;
+  };
+}
+
+// Timestamp comparator. If either side is missing the field, compare both by id instead
+// — ULIDs are monotonic in creation time, but they are not lexicographically comparable
+// with ISO timestamps, so the fallback has to apply to both operands or neither.
+function _byTime(field, dir) {
+  return function(a, b) {
+    var va = a[field], vb = b[field];
+    if (!va || !vb) {
+      va = a.id || "";
+      vb = b.id || "";
+    }
+    if (va === vb) return 0;
+    return (va < vb ? -1 : 1) * dir;
+  };
+}
+
+var LANE_COMPARATORS = {
+  created_asc:  _byTime("created_at", 1),
+  created_desc: _byTime("created_at", -1),
+  updated_desc: _byTime("updated_at", -1),
+  // Oldest transition = longest sitting in this lane, so age-descending is timestamp-ascending.
+  status_age_desc: _byTime("last_status_changed_at", 1),
+  priority:     _byRank("priority", PRIORITY_RANK),
+  urgency:      _byRank("urgency", URGENCY_RANK),
+  complexity_asc: _byRank("complexity", COMPLEXITY_RANK)
+};
+
+// Pure: returns a new sorted array. Ties always break on id, so renders are stable.
+function sortLaneItems(items, mode) {
+  // hasOwnProperty, not a truthiness check: LANE_COMPARATORS["constructor"] would
+  // otherwise hand back an inherited function and silently sort nothing.
+  var cmp = Object.prototype.hasOwnProperty.call(LANE_COMPARATORS, mode)
+    ? LANE_COMPARATORS[mode]
+    : LANE_COMPARATORS[DEFAULT_LANE_SORT];
+  return items.slice().sort(function(a, b) {
+    return cmp(a, b) || ((a.id || "") < (b.id || "") ? -1 : (a.id || "") > (b.id || "") ? 1 : 0);
+  });
+}
+
+// Pure: returns [{label, items}] sections. A card belongs to exactly one section — cards
+// are never duplicated, so the lane's header count stays honest. Multi-tag cards group
+// under their alphabetically-first tag.
+function groupLaneItems(items, mode) {
+  var key, emptyLabel;
+  if (mode === "group:assignee") {
+    key = function(t) { return t.assigned_to || ""; };
+    emptyLabel = "Unassigned";
+  } else {
+    key = function(t) {
+      var tags = (t.tags || []).slice().sort();
+      return tags.length ? tags[0] : "";
+    };
+    emptyLabel = "Untagged";
+  }
+
+  // Object.create(null): tags and actor ids are free-form strings, so a task tagged
+  // "constructor" or "__proto__" would otherwise hit an inherited property, skip the
+  // array init, and throw inside renderBoard() — blanking the entire board, not just
+  // this lane.
+  var buckets = Object.create(null);
+  items.forEach(function(t) {
+    var k = key(t);
+    if (!buckets[k]) buckets[k] = [];
+    buckets[k].push(t);
+  });
+
+  // Named sections alphabetically; the empty bucket always sinks to the bottom.
+  var names = Object.keys(buckets).filter(function(k) { return k !== ""; }).sort();
+  if (buckets[""]) names.push("");
+
+  return names.map(function(k) {
+    return {
+      label: k === "" ? emptyLabel : k,
+      items: sortLaneItems(buckets[k], DEFAULT_LANE_SORT)
+    };
+  });
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { DEFAULT_LANE_SORT, LANE_SORT_MODES, DONE_LANE_MODES,
+    laneModesFor, isValidLaneMode, resolveLaneSort, sortLaneItems, groupLaneItems,
+    DONE_DISPLAY_TO_MODE, MODE_TO_DONE_DISPLAY, LANE_COMPARATORS };
+}

--- a/tests/js/lane-logic.test.js
+++ b/tests/js/lane-logic.test.js
@@ -175,6 +175,17 @@ test("sortLaneItems: status_age_desc = timestamp-ascending on last_status_change
   assert.deepStrictEqual(idsOf(sortLaneItems(items, "status_age_desc")), ["a", "b", "c"]);
 });
 
+test("sortLaneItems: updated_desc — newest updated_at first", () => {
+  // Pins the comparator to the real field name: a typo'd field would pass silently
+  // via the id fallback, so ids are chosen to disagree with the expected order.
+  const items = [
+    { id: "a", updated_at: "2026-01-01" },
+    { id: "b", updated_at: "2026-01-03" },
+    { id: "c", updated_at: "2026-01-02" },
+  ];
+  assert.deepStrictEqual(idsOf(sortLaneItems(items, "updated_desc")), ["b", "c", "a"]);
+});
+
 // --- tie-break stability & no mutation ---------------------------------------------
 
 test("sortLaneItems: equal sort keys break on id, deterministic", () => {

--- a/tests/js/lane-logic.test.js
+++ b/tests/js/lane-logic.test.js
@@ -1,0 +1,252 @@
+"use strict";
+
+// Tests for the dashboard's pure lane sort/group logic. Runs under node's built-in
+// test runner — zero npm deps, no package.json. Bridged into pytest via
+// tests/test_dashboard/test_js_lane_logic.py so `uv run pytest` stays the single
+// entrypoint. Run standalone with: node --test tests/js/lane-logic.test.js
+//
+// These cover the regressions PR #33's second commit fixed (prototype-pollution-safe
+// buckets, junk-mode fallback, legacy done_display derivation) plus the surrounding
+// sort/group contract. This is a harness over moved-not-rewritten logic; the
+// non-transitive _byTime missing-field fallback is a documented, accepted tradeoff.
+
+const test = require("node:test");
+const assert = require("node:assert");
+const path = require("node:path");
+
+const lane = require(
+  path.join(__dirname, "..", "..", "src", "lattice", "dashboard", "static", "lane-logic.js")
+);
+const {
+  DEFAULT_LANE_SORT,
+  laneModesFor,
+  isValidLaneMode,
+  resolveLaneSort,
+  sortLaneItems,
+  groupLaneItems,
+} = lane;
+
+// Small helper: pull the flat, ordered list of ids out of grouped sections.
+function idsOf(items) {
+  return items.map(function (t) { return t.id; });
+}
+
+// --- groupLaneItems: prototype-pollution-safe buckets ------------------------------
+
+test("groupLaneItems: tags constructor / __proto__ / untagged → 3 sections, no throw, no loss", () => {
+  const items = [
+    { id: "a", tags: ["constructor"] },
+    { id: "b", tags: ["__proto__"] },
+    { id: "c", tags: [] },
+  ];
+  let sections;
+  assert.doesNotThrow(() => { sections = groupLaneItems(items, "group:tag"); });
+  assert.strictEqual(sections.length, 3);
+
+  // Every card appears exactly once across all sections — no duplication, no loss.
+  const allIds = sections.flatMap((s) => idsOf(s.items)).sort();
+  assert.deepStrictEqual(allIds, ["a", "b", "c"]);
+
+  const labels = sections.map((s) => s.label);
+  assert.ok(labels.includes("constructor"));
+  assert.ok(labels.includes("__proto__"));
+  // Empty bucket labeled "Untagged" and sunk to the bottom.
+  assert.strictEqual(sections[sections.length - 1].label, "Untagged");
+});
+
+test("groupLaneItems: actor id __proto__ groups; empty bucket 'Unassigned' sinks last", () => {
+  const items = [
+    { id: "a", assigned_to: "__proto__" },
+    { id: "b", assigned_to: "constructor" },
+    { id: "c" }, // unassigned
+  ];
+  let sections;
+  assert.doesNotThrow(() => { sections = groupLaneItems(items, "group:assignee"); });
+  assert.strictEqual(sections.length, 3);
+  const labels = sections.map((s) => s.label);
+  assert.ok(labels.includes("__proto__"));
+  assert.ok(labels.includes("constructor"));
+  assert.strictEqual(sections[sections.length - 1].label, "Unassigned");
+});
+
+test("groupLaneItems: multi-tag card appears exactly once, under alphabetically-first tag", () => {
+  const items = [{ id: "a", tags: ["zebra", "apple", "mango"] }];
+  const sections = groupLaneItems(items, "group:tag");
+  const withCard = sections.filter((s) => idsOf(s.items).includes("a"));
+  assert.strictEqual(withCard.length, 1, "card must appear in exactly one section");
+  assert.strictEqual(withCard[0].label, "apple", "grouped under alphabetically-first tag");
+});
+
+test("groupLaneItems: named sections alphabetical, empty bucket always last", () => {
+  const items = [
+    { id: "a", tags: ["mango"] },
+    { id: "b", tags: [] },
+    { id: "c", tags: ["apple"] },
+  ];
+  const sections = groupLaneItems(items, "group:tag");
+  assert.deepStrictEqual(sections.map((s) => s.label), ["apple", "mango", "Untagged"]);
+});
+
+// --- sortLaneItems: junk-mode fallback ---------------------------------------------
+
+test("sortLaneItems: junk mode 'constructor' falls back to default order, never inherited fn", () => {
+  const items = [
+    { id: "b", created_at: "2026-01-02" },
+    { id: "a", created_at: "2026-01-01" },
+  ];
+  const junk = sortLaneItems(items, "constructor");
+  const def = sortLaneItems(items, DEFAULT_LANE_SORT);
+  assert.deepStrictEqual(idsOf(junk), idsOf(def), "junk mode must match default ordering");
+  // created_asc default: oldest (a) first.
+  assert.deepStrictEqual(idsOf(junk), ["a", "b"]);
+});
+
+test("sortLaneItems: junk mode 'hasOwnProperty' also falls back to default", () => {
+  const items = [
+    { id: "b", created_at: "2026-01-02" },
+    { id: "a", created_at: "2026-01-01" },
+  ];
+  const junk = sortLaneItems(items, "hasOwnProperty");
+  assert.deepStrictEqual(idsOf(junk), ["a", "b"]);
+});
+
+// --- rank sorts --------------------------------------------------------------------
+
+test("sortLaneItems: priority — critical first, unset last (rank 99)", () => {
+  const items = [
+    { id: "d" }, // unset priority
+    { id: "c", priority: "low" },
+    { id: "a", priority: "critical" },
+    { id: "b", priority: "high" },
+  ];
+  const out = sortLaneItems(items, "priority");
+  assert.deepStrictEqual(idsOf(out), ["a", "b", "c", "d"]);
+});
+
+test("sortLaneItems: urgency — immediate first, unset last", () => {
+  const items = [
+    { id: "c" }, // unset
+    { id: "a", urgency: "immediate" },
+    { id: "b", urgency: "normal" },
+  ];
+  assert.deepStrictEqual(idsOf(sortLaneItems(items, "urgency")), ["a", "b", "c"]);
+});
+
+test("sortLaneItems: complexity_asc — low first, unset last", () => {
+  const items = [
+    { id: "c" }, // unset
+    { id: "a", complexity: "low" },
+    { id: "b", complexity: "high" },
+  ];
+  assert.deepStrictEqual(idsOf(sortLaneItems(items, "complexity_asc")), ["a", "b", "c"]);
+});
+
+// --- _byTime semantics via modes ---------------------------------------------------
+
+test("sortLaneItems: created_asc vs created_desc direction", () => {
+  const items = [
+    { id: "b", created_at: "2026-01-02" },
+    { id: "a", created_at: "2026-01-01" },
+    { id: "c", created_at: "2026-01-03" },
+  ];
+  assert.deepStrictEqual(idsOf(sortLaneItems(items, "created_asc")), ["a", "b", "c"]);
+  assert.deepStrictEqual(idsOf(sortLaneItems(items, "created_desc")), ["c", "b", "a"]);
+});
+
+test("sortLaneItems: missing-field pair falls back to id-vs-id (never ULID-vs-ISO)", () => {
+  // Neither has created_at → both compared by id. ids chosen so id order is a<b.
+  const items = [
+    { id: "b" },
+    { id: "a" },
+  ];
+  // created_asc: id ascending → a, b.
+  assert.deepStrictEqual(idsOf(sortLaneItems(items, "created_asc")), ["a", "b"]);
+  // created_desc: dir flips the id comparison → b, a.
+  assert.deepStrictEqual(idsOf(sortLaneItems(items, "created_desc")), ["b", "a"]);
+});
+
+test("sortLaneItems: status_age_desc = timestamp-ascending on last_status_changed_at", () => {
+  // Oldest transition (longest sitting) comes first.
+  const items = [
+    { id: "b", last_status_changed_at: "2026-01-02" },
+    { id: "a", last_status_changed_at: "2026-01-01" },
+    { id: "c", last_status_changed_at: "2026-01-03" },
+  ];
+  assert.deepStrictEqual(idsOf(sortLaneItems(items, "status_age_desc")), ["a", "b", "c"]);
+});
+
+// --- tie-break stability & no mutation ---------------------------------------------
+
+test("sortLaneItems: equal sort keys break on id, deterministic", () => {
+  const items = [
+    { id: "c", priority: "high" },
+    { id: "a", priority: "high" },
+    { id: "b", priority: "high" },
+  ];
+  assert.deepStrictEqual(idsOf(sortLaneItems(items, "priority")), ["a", "b", "c"]);
+});
+
+test("sortLaneItems: input array is never mutated", () => {
+  const items = [
+    { id: "b", created_at: "2026-01-02" },
+    { id: "a", created_at: "2026-01-01" },
+  ];
+  const before = idsOf(items);
+  sortLaneItems(items, "created_asc");
+  assert.deepStrictEqual(idsOf(items), before, "original order preserved (slice before sort)");
+});
+
+// --- resolveLaneSort: config-independent core --------------------------------------
+
+test("resolveLaneSort: valid explicit map entry wins", () => {
+  assert.strictEqual(resolveLaneSort("in_progress", { in_progress: "priority" }, null), "priority");
+});
+
+test("resolveLaneSort: junk map entry ignored → default", () => {
+  assert.strictEqual(
+    resolveLaneSort("in_progress", { in_progress: "constructor" }, null),
+    DEFAULT_LANE_SORT
+  );
+});
+
+test("resolveLaneSort: done-lane legacy derivation grouped→group:day, recent→recent, all→created_asc, unknown→default", () => {
+  assert.strictEqual(resolveLaneSort("done", {}, "grouped"), "group:day");
+  assert.strictEqual(resolveLaneSort("done", {}, "recent"), "recent");
+  assert.strictEqual(resolveLaneSort("done", {}, "all"), "created_asc");
+  assert.strictEqual(resolveLaneSort("done", {}, "nonsense"), DEFAULT_LANE_SORT);
+  // Absent done_display defaults to "grouped" → group:day.
+  assert.strictEqual(resolveLaneSort("done", {}, null), "group:day");
+});
+
+test("resolveLaneSort: explicit valid done mode wins over legacy derivation", () => {
+  assert.strictEqual(resolveLaneSort("done", { done: "recent" }, "grouped"), "recent");
+});
+
+test("resolveLaneSort: done-only modes are invalid for non-done lanes → default", () => {
+  assert.strictEqual(
+    resolveLaneSort("in_progress", { in_progress: "group:day" }, null),
+    DEFAULT_LANE_SORT
+  );
+  assert.strictEqual(
+    resolveLaneSort("in_progress", { in_progress: "recent" }, null),
+    DEFAULT_LANE_SORT
+  );
+});
+
+// --- laneModesFor / isValidLaneMode ------------------------------------------------
+
+test("laneModesFor: done includes done-only modes; other statuses exclude them", () => {
+  const doneValues = laneModesFor("done").map((m) => m.value);
+  assert.ok(doneValues.includes("group:day"));
+  assert.ok(doneValues.includes("recent"));
+
+  const otherValues = laneModesFor("in_progress").map((m) => m.value);
+  assert.ok(!otherValues.includes("group:day"));
+  assert.ok(!otherValues.includes("recent"));
+});
+
+test("isValidLaneMode: done-only modes valid only for done lane", () => {
+  assert.strictEqual(isValidLaneMode("done", "group:day"), true);
+  assert.strictEqual(isValidLaneMode("in_progress", "group:day"), false);
+  assert.strictEqual(isValidLaneMode("in_progress", "priority"), true);
+});

--- a/tests/test_dashboard/test_js_lane_logic.py
+++ b/tests/test_dashboard/test_js_lane_logic.py
@@ -45,6 +45,13 @@ MOVED_IDENTIFIERS = [
 ]
 
 
+def _definition_pattern(name: str) -> str:
+    """Match any JS definition form — a `let`/`const` reintroduction inside the IIFE
+    would shadow the global just like `var` or a function declaration."""
+    escaped = re.escape(name)
+    return rf"function\s+{escaped}\s*\(|(?:var|let|const)\s+{escaped}\s*="
+
+
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
 def test_js_lane_logic_node_tests_pass() -> None:
     """Run the node:test suite for lane-logic.js and require it green.
@@ -58,7 +65,7 @@ def test_js_lane_logic_node_tests_pass() -> None:
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
-        timeout=30,
+        timeout=10,
         check=False,
     )
     assert result.returncode == 0, (
@@ -85,7 +92,7 @@ def test_lane_logic_script_tag_present_and_no_inline_shadowing() -> None:
     )
 
     for name in MOVED_IDENTIFIERS:
-        pattern = re.compile(rf"function\s+{re.escape(name)}\s*\(|var\s+{re.escape(name)}\s*=")
+        pattern = re.compile(_definition_pattern(name))
         assert not pattern.search(html), (
             f"'{name}' is still defined inline in index.html — it must live only in "
             f"lane-logic.js, or the browser global is shadowed and the node tests test "
@@ -97,5 +104,5 @@ def test_lane_logic_js_defines_moved_identifiers() -> None:
     """Sanity: the moved identifiers actually live in lane-logic.js now."""
     js = LANE_LOGIC_JS.read_text()
     for name in MOVED_IDENTIFIERS:
-        pattern = re.compile(rf"function\s+{re.escape(name)}\s*\(|var\s+{re.escape(name)}\s*=")
+        pattern = re.compile(_definition_pattern(name))
         assert pattern.search(js), f"'{name}' is not defined in lane-logic.js"

--- a/tests/test_dashboard/test_js_lane_logic.py
+++ b/tests/test_dashboard/test_js_lane_logic.py
@@ -1,0 +1,101 @@
+"""Bridge the dashboard's JS lane-logic tests into pytest, plus a shadowing guard.
+
+The pure lane sort/group logic lives in a static JS file
+(``src/lattice/dashboard/static/lane-logic.js``) and is tested with node's built-in
+test runner (``tests/js/lane-logic.test.js``, zero npm deps). This module makes
+``uv run pytest`` the single test entrypoint by shelling out to node, and adds a guard
+that fails if the extraction ever regresses — a stale inline copy in ``index.html``
+would silently shadow the tested file and make the node tests exercise dead code.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NODE_TEST_FILE = REPO_ROOT / "tests" / "js" / "lane-logic.test.js"
+INDEX_HTML = REPO_ROOT / "src" / "lattice" / "dashboard" / "static" / "index.html"
+LANE_LOGIC_JS = REPO_ROOT / "src" / "lattice" / "dashboard" / "static" / "lane-logic.js"
+
+# Full §1 inventory of identifiers moved out of the IIFE into lane-logic.js. If any of
+# these is defined inline again, the browser's global from lane-logic.js is shadowed and
+# the node tests test dead code.
+MOVED_IDENTIFIERS = [
+    "DEFAULT_LANE_SORT",
+    "LANE_SORT_MODES",
+    "DONE_LANE_MODES",
+    "PRIORITY_RANK",
+    "URGENCY_RANK",
+    "COMPLEXITY_RANK",
+    "DONE_DISPLAY_TO_MODE",
+    "MODE_TO_DONE_DISPLAY",
+    "LANE_COMPARATORS",
+    "laneModesFor",
+    "isValidLaneMode",
+    "resolveLaneSort",
+    "_byRank",
+    "_byTime",
+    "sortLaneItems",
+    "groupLaneItems",
+]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_js_lane_logic_node_tests_pass() -> None:
+    """Run the node:test suite for lane-logic.js and require it green.
+
+    Explicit file path (not ``node --test <dir>``) to sidestep version-sensitive
+    directory discovery. stdout+stderr are surfaced on failure so node assertion
+    output is readable straight from pytest.
+    """
+    result = subprocess.run(
+        ["node", "--test", str(NODE_TEST_FILE)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        "node lane-logic tests failed:\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+
+
+def test_lane_logic_script_tag_present_and_no_inline_shadowing() -> None:
+    """Guard the extraction: script tag wired, and no moved identifier defined inline.
+
+    Fails if ``index.html`` is missing the ``lane-logic.js`` script tag, or if any moved
+    identifier reappears as an inline definition (``function name(`` / ``var name =``) —
+    a partial move that would shadow the tested file while the node tests stay green.
+    """
+    html = INDEX_HTML.read_text()
+
+    assert '<script src="/static/lane-logic.js">' in html, (
+        'index.html is missing the <script src="/static/lane-logic.js"> tag'
+    )
+    # Must load without defer (before the inline IIFE runs).
+    assert '<script src="/static/lane-logic.js" defer>' not in html, (
+        "lane-logic.js must NOT be loaded with defer — it must run before the inline IIFE"
+    )
+
+    for name in MOVED_IDENTIFIERS:
+        pattern = re.compile(rf"function\s+{re.escape(name)}\s*\(|var\s+{re.escape(name)}\s*=")
+        assert not pattern.search(html), (
+            f"'{name}' is still defined inline in index.html — it must live only in "
+            f"lane-logic.js, or the browser global is shadowed and the node tests test "
+            f"dead code."
+        )
+
+
+def test_lane_logic_js_defines_moved_identifiers() -> None:
+    """Sanity: the moved identifiers actually live in lane-logic.js now."""
+    js = LANE_LOGIC_JS.read_text()
+    for name in MOVED_IDENTIFIERS:
+        pattern = re.compile(rf"function\s+{re.escape(name)}\s*\(|var\s+{re.escape(name)}\s*=")
+        assert pattern.search(js), f"'{name}' is not defined in lane-logic.js"


### PR DESCRIPTION
## What

Gives the dashboard's pure lane sort/group logic (added by PR #33) a real test home. Extracts it out of `index.html`'s inline IIFE into a standalone classic static script and tests it under `node:test`, bridged into pytest so `uv run pytest` stays the single entrypoint.

**This is a move + harness, not a rewrite.** No logic behavior changes — the non-transitive `_byTime` missing-field fallback stays exactly as the documented, accepted tradeoff.

## Why

PR #33 added genuine edge-case logic — prototype-pollution-safe buckets (`Object.create(null)`), junk-mode comparator fallback (`hasOwnProperty` vs truthiness), mixed-missing-timestamp comparison, and legacy `done_display` derivation. It was verified once with ad-hoc node assertions during review and left unprotected against regression. `tests/` was pytest-only with no home for JS unit tests.

## Changes

- **`static/lane-logic.js`** (new): moved constants, `LANE_COMPARATORS`, `sortLaneItems`, `groupLaneItems`, `laneModesFor`, `isValidLaneMode`, plus a new pure `resolveLaneSort(status, laneSortMap, doneDisplay)` — the config-independent core of `getLaneSort`. `getLaneSort` in the IIFE becomes a thin wrapper that gathers config and delegates. `"use strict"` first line pins identical semantics in browser + node; CommonJS export guard at bottom.
- **`index.html`**: loads `lane-logic.js` **without `defer`** before the inline IIFE (the IIFE references these names during `renderBoard`/event handling); moved definitions deleted — zero duplicates remain.
- **`tests/js/lane-logic.test.js`** (new): 21 `node:test` cases, zero npm deps.
- **`tests/test_dashboard/test_js_lane_logic.py`** (new): pytest bridge running `node --test` (skipped only when node is absent) + a full-inventory shadowing guard that fails if any moved identifier reappears inline or the script tag goes missing/deferred.
- **`CLAUDE.md`**: two lines documenting the JS test convention.

No server, packaging, or `pyproject` changes — the static route already content-types `.js`.

## Validation

- `uv run pytest` → **2006 passed**; the node bridge test **ran** (not skipped), executing all 21 node:test cases.
- `uv run ruff check src/ tests/` → clean. `uv run ruff format --check` → clean.
- `curl http://localhost:8811/static/lane-logic.js` → **200**, `Content-Type: application/javascript`.
- **Real-browser smoke** (fresh dashboard on port 8811, c11 embedded browser): board renders (5 lanes, 36 cards); pure functions are globals while `getLaneSort` stays IIFE-private (correct wiring, no leak); changing the backlog lane to `created_desc` reorders cards and **survives reload**; done lane renders **day-grouped by default** ("Done Today"); Settings done-display select **stays in sync live** (done lane → `recent` flips the setting to `recent`); no reference errors on any wired path. Shared config mutations made during the smoke were restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)