### PR TITLE
LAT-263: --file on every prose-taking command, documented in SKILL.md

### DIFF
--- a/src/lattice/cli/flag_cmds.py
+++ b/src/lattice/cli/flag_cmds.py
@@ -12,6 +12,7 @@ from lattice.cli.helpers import (
     read_snapshot_or_exit,
     require_actor,
     require_root,
+    resolve_body,
     resolve_task_id,
     validate_actor_format_or_exit,
     write_task_event,
@@ -19,6 +20,12 @@ from lattice.cli.helpers import (
 from lattice.cli.main import cli
 from lattice.core.events import create_event, get_actor_display
 from lattice.core.tasks import apply_event_to_snapshot
+
+_REASON_REQUIRED = (
+    "REASON is required when setting the needs_human flag. "
+    "Say exactly what you need from the human, in one line "
+    "(as an argument, or via --file)."
+)
 
 
 def _notify_c11(snapshot: dict, *, flagged: bool) -> None:
@@ -32,12 +39,20 @@ def _notify_c11(snapshot: dict, *, flagged: bool) -> None:
 @cli.command("needs-human")
 @click.argument("task_id")
 @click.argument("reason", required=False)
+@click.option(
+    "--file",
+    "file_path",
+    default=None,
+    type=click.Path(exists=True),
+    help="Read the reason from a file (safe for long prose — no shell interpolation).",
+)
 @click.option("--clear", "clear_flag", is_flag=True, help="Clear the needs_human flag.")
 @click.option("--note", default=None, help="Resolution note recorded when clearing.")
 @common_options
 def needs_human_cmd(
     task_id: str,
     reason: str | None,
+    file_path: str | None,
     clear_flag: bool,
     note: str | None,
     model: str | None,
@@ -57,6 +72,7 @@ def needs_human_cmd(
 
     \b
         lattice needs-human LAT-42 "Need: which OAuth provider?" --actor agent:claude
+        lattice needs-human LAT-42 --file reason.md --actor agent:claude
         lattice needs-human LAT-42 --clear --note "chose google" --actor human:atin
     """
     is_json = output_json
@@ -73,9 +89,9 @@ def needs_human_cmd(
     display_id = snapshot.get("short_id") or task_id
 
     if clear_flag:
-        if reason is not None:
+        if reason is not None or file_path is not None:
             output_error(
-                "REASON is only for setting the flag. To clear, use "
+                "REASON / --file is only for setting the flag. To clear, use "
                 "--clear (optionally with --note).",
                 "VALIDATION_ERROR",
                 is_json,
@@ -116,13 +132,16 @@ def needs_human_cmd(
             "VALIDATION_ERROR",
             is_json,
         )
-    if not reason or not reason.strip():
-        output_error(
-            "REASON is required when setting the needs_human flag. "
-            "Say exactly what you need from the human, in one line.",
-            "VALIDATION_ERROR",
-            is_json,
-        )
+    reason = resolve_body(
+        reason,
+        file_path,
+        is_json,
+        what="the reason",
+        arg_label="REASON",
+        missing_message=_REASON_REQUIRED,
+    ).strip()
+    if not reason:
+        output_error(_REASON_REQUIRED, "VALIDATION_ERROR", is_json)
     if current:
         flagged_by = get_actor_display(current.get("flagged_by"))
         output_error(

--- a/src/lattice/cli/helpers.py
+++ b/src/lattice/cli/helpers.py
@@ -112,6 +112,48 @@ def output_result(
 
 
 # ---------------------------------------------------------------------------
+# Prose bodies: inline argument or --file
+# ---------------------------------------------------------------------------
+
+
+def resolve_body(
+    text: str | None,
+    file_path: str | None,
+    is_json: bool,
+    *,
+    what: str,
+    arg_label: str,
+    file_label: str = "--file",
+    missing_message: str | None = None,
+) -> str:
+    """Resolve a prose body from an inline argument or a file.
+
+    Exactly one of *text* / *file_path* must be given; both or neither exits
+    through ``output_error(..., "VALIDATION_ERROR", ...)``.
+
+    The file path exists so a long body never has to survive a shell: inside a
+    double-quoted argument, backticks and ``$(...)`` are command substitution.
+    That has silently eaten a clause from one comment and spliced 15 KB of
+    pytest output into another (LAT-263). Reading from a file is byte-exact.
+    """
+    if text is not None and file_path is not None:
+        output_error(
+            f"Provide either {arg_label} or {file_label}, not both.",
+            "VALIDATION_ERROR",
+            is_json,
+        )
+    if text is None and file_path is None:
+        output_error(
+            missing_message or f"Provide {what} as {arg_label} or via {file_label}.",
+            "VALIDATION_ERROR",
+            is_json,
+        )
+    if file_path is not None:
+        return Path(file_path).read_text(encoding="utf-8")
+    return text  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
 # Task ID resolution (short ID -> ULID)
 # ---------------------------------------------------------------------------
 

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -15,6 +15,7 @@ from lattice.cli.helpers import (
     output_result,
     read_snapshot_or_exit,
     require_root,
+    resolve_body,
     resolve_task_id,
     require_actor,
     validate_actor_format_or_exit,
@@ -1142,7 +1143,7 @@ def assign(
     "file_path",
     default=None,
     type=click.Path(exists=True),
-    help="Read comment body from a file.",
+    help="Read comment body from a file (safe for long prose — no shell interpolation).",
 )
 @click.option("--reply-to", default=None, help="Event ID of the comment to reply to.")
 @click.option(
@@ -1168,23 +1169,13 @@ def comment(
     """Add a comment to a task."""
     is_json = output_json
 
-    # Resolve body from text or --file (mutually exclusive, one required)
-    if text is not None and file_path is not None:
-        output_error(
-            "Provide either TEXT or --file, not both.",
-            "VALIDATION_ERROR",
-            is_json,
-        )
-    if text is None and file_path is None:
-        output_error(
-            "Provide comment text as an argument or via --file.",
-            "VALIDATION_ERROR",
-            is_json,
-        )
-    if file_path is not None:
-        from pathlib import Path
-
-        text = Path(file_path).read_text(encoding="utf-8")
+    text = resolve_body(
+        text,
+        file_path,
+        is_json,
+        what="comment text",
+        arg_label="TEXT",
+    )
 
     lattice_dir = require_root(is_json)
     config = load_project_config(lattice_dir)
@@ -1258,13 +1249,21 @@ def comment(
 @cli.command("comment-edit")
 @click.argument("task_id")
 @click.argument("comment_id")
-@click.argument("new_text")
+@click.argument("new_text", required=False, default=None)
+@click.option(
+    "--file",
+    "file_path",
+    default=None,
+    type=click.Path(exists=True),
+    help="Read the new comment body from a file (safe for long prose — no shell interpolation).",
+)
 @click.option("--role", default=None, help="Set or change the comment's role (e.g. review).")
 @common_options
 def comment_edit(
     task_id: str,
     comment_id: str,
-    new_text: str,
+    new_text: str | None,
+    file_path: str | None,
     role: str | None,
     model: str | None,
     session: str | None,
@@ -1276,6 +1275,14 @@ def comment_edit(
 ) -> None:
     """Edit an existing comment on a task."""
     is_json = output_json
+
+    new_text = resolve_body(
+        new_text,
+        file_path,
+        is_json,
+        what="the new comment text",
+        arg_label="NEW_TEXT",
+    )
 
     lattice_dir = require_root(is_json)
     config = load_project_config(lattice_dir)
@@ -1597,11 +1604,19 @@ def _flatten_comments(comments: list[dict]) -> list[dict]:
 
 @cli.command("complete")
 @click.argument("task_id")
-@click.option("--review", "review_text", required=True, help="Review findings text.")
+@click.option("--review", "review_text", default=None, help="Review findings text.")
+@click.option(
+    "--review-file",
+    "review_file",
+    default=None,
+    type=click.Path(exists=True),
+    help="Read review findings from a file (safe for long prose — no shell interpolation).",
+)
 @common_options
 def complete_cmd(
     task_id: str,
-    review_text: str,
+    review_text: str | None,
+    review_file: str | None,
     model: str | None,
     session: str | None,
     output_json: bool,
@@ -1611,6 +1626,9 @@ def complete_cmd(
     provenance_reason: str | None,
 ) -> None:
     """Complete a task with review-to-done ceremony in one command.
+
+    Give the review findings with --review, or --review-file for long prose
+    (a file body is read byte-for-byte, never shell-interpolated).
 
     Emits 4 discrete events (3 if already in review):
     comment_added (role=review), status_changed -> review,
@@ -1632,6 +1650,15 @@ def complete_cmd(
     from lattice.storage.fs import atomic_write, ensure_artifact_dirs
 
     is_json = output_json
+
+    review_text = resolve_body(
+        review_text,
+        review_file,
+        is_json,
+        what="review findings",
+        arg_label="--review",
+        file_label="--review-file",
+    )
 
     lattice_dir = require_root(is_json)
     config = load_project_config(lattice_dir)

--- a/src/lattice/skills/lattice/SKILL.md
+++ b/src/lattice/skills/lattice/SKILL.md
@@ -24,9 +24,14 @@ lattice status <task_id> in_planning --actor agent:claude-cli
 # ... write the plan to .lattice/plans/<task_id>.md ...
 lattice status <task_id> planned --actor agent:claude-cli
 lattice status <task_id> in_progress --actor agent:claude-cli
+
+# 3. Working on a branch or worktree? Link it — BEFORE you reach review.
+lattice branch-link <task_id> <branch> --actor agent:claude-cli
 ```
 
 `lattice next --claim` atomically assigns the highest-priority ready task to you and moves it to `in_progress`. If you already have a task in progress, it returns that one (resume-first logic).
+
+**Link the branch, or review reads the wrong code.** `code-review` resolves its diff from the task's linked branch, then falls back to the HEAD of the checkout holding `.lattice/`. Under one-worktree-per-task that fallback is a *sibling's* branch, so the reviewer silently reviews someone else's diff — this has happened, and the review came back FAIL on an unrelated ticket. `lattice branch-link` is the fix; `code-review --head`/`--worktree` override at review time.
 
 If there's no existing task, create one:
 

--- a/src/lattice/skills/lattice/SKILL.md
+++ b/src/lattice/skills/lattice/SKILL.md
@@ -49,9 +49,12 @@ lattice status <task> review --no-auto-review --actor agent:<id>
 
 ```bash
 lattice complete <task_id> --review "What was done. Key decisions. Test results. What remains." --actor agent:claude-cli
+lattice complete <task_id> --review-file review.md --actor agent:claude-cli   # multi-paragraph review
 ```
 
 The `--review` text is your breadcrumb for every future agent and human who reads this task. Be specific: files changed, approach taken, edge cases considered, anything left undone.
+
+**Long prose goes in a file, not in quotes.** `--review-file` on `complete`; `--file` on `comment`, `comment-edit`, and `needs-human`. Inside a double-quoted shell argument, backticks and `$(...)` are command substitution — that has silently eaten a clause from one comment and spliced 15 KB of pytest output into another. A file is read byte-for-byte.
 
 **Do not use raw `lattice status ... done` to finish work.** The `complete` command exists because completion requires evidence — a review comment and artifact. Skipping this ceremony leaves the task without an audit trail.
 
@@ -95,8 +98,9 @@ lattice complete PROJ-1 --review "Review text" --actor agent:claude-cli
 # Assign
 lattice assign PROJ-1 agent:claude-cli --actor agent:claude-cli
 
-# Comment
+# Comment (--file for anything long — a quoted arg runs backticks/$() as shell)
 lattice comment PROJ-1 "Found root cause" --actor agent:claude-cli
+lattice comment PROJ-1 --file findings.md --actor agent:claude-cli
 
 # Link
 lattice link PROJ-1 blocks PROJ-2 --actor agent:claude-cli

--- a/tests/test_cli/test_complete_cmd.py
+++ b/tests/test_cli/test_complete_cmd.py
@@ -219,11 +219,16 @@ class TestCompleteValidation:
         assert parsed["error"]["code"] == "INVALID_TRANSITION"
 
     def test_fails_without_review_flag(self, invoke, initialized_root, fill_plan) -> None:
+        # --review is no longer required at the Click level (--review-file can
+        # satisfy it, LAT-263); the shared helper enforces exactly-one instead.
         task_id = _create_and_advance_to(invoke, fill_plan, "in_progress")
 
-        r = invoke("complete", task_id, "--actor", _ACTOR)
+        r = invoke("complete", task_id, "--actor", _ACTOR, "--json")
         assert r.exit_code != 0
-        assert "Missing option '--review'" in r.output
+        parsed = json.loads(r.output)
+        assert parsed["error"]["code"] == "VALIDATION_ERROR"
+        assert "--review" in parsed["error"]["message"]
+        assert "--review-file" in parsed["error"]["message"]
 
     def test_empty_review_text_fails(self, invoke, initialized_root, fill_plan) -> None:
         task_id = _create_and_advance_to(invoke, fill_plan, "in_progress")

--- a/tests/test_cli/test_prose_file_args.py
+++ b/tests/test_cli/test_prose_file_args.py
@@ -1,0 +1,259 @@
+"""Prose bodies read from a file, on every command that takes one (LAT-263).
+
+The incident these tests exist for: an agent wrote a long body inline into a
+double-quoted shell argument and the backticks in the text ran as command
+substitution — once silently eating a clause, once running the whole pytest
+suite and splicing ~15 KB of output into the comment. A file is never handed
+to the shell, so the body must arrive byte for byte.
+
+Covered commands: ``comment --file``, ``comment-edit --file``,
+``complete --review-file``, ``needs-human --file``. All four share one
+resolution helper (``lattice.cli.helpers.resolve_body``), so these tests
+assert one behaviour four times on purpose.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+_ACTOR = "human:test"
+
+# Every shell metacharacter that mangles a body when it goes through a
+# double-quoted argument: backticks, $(...) and ${...}. Deliberately no
+# leading/trailing whitespace — comment bodies are stripped on the way in,
+# so the interior is what must survive untouched.
+SHELL_HOSTILE_BODY = """Root cause: `scripts/ci.sh` shells out before quoting.
+
+The old inline path ran `pytest -q` and $(git rev-parse HEAD) instead of
+recording them, and ${HOME} expanded to the operator's home directory.
+Backtick pair two: `make test` — still text, not a command.
+
+Cost: $(1 + 1) engineer-days. Literally that string, never evaluated."""
+
+
+# ---------------------------------------------------------------------------
+# Setup helpers
+# ---------------------------------------------------------------------------
+
+
+def _new_task(invoke, title: str = "Prose task") -> str:
+    r = invoke("create", title, "--actor", _ACTOR, "--json")
+    assert r.exit_code == 0, r.output
+    return json.loads(r.output)["data"]["id"]
+
+
+def _task_in_progress(invoke, fill_plan) -> str:
+    task_id = _new_task(invoke)
+    invoke("status", task_id, "in_planning", "--actor", _ACTOR)
+    fill_plan(task_id, "Prose task")
+    invoke("status", task_id, "planned", "--actor", _ACTOR)
+    invoke("status", task_id, "in_progress", "--actor", _ACTOR)
+    return task_id
+
+
+def _add_comment(invoke, task_id: str, body: str) -> str:
+    r = invoke("comment", task_id, body, "--actor", _ACTOR, "--json")
+    assert r.exit_code == 0, r.output
+    return json.loads(r.output)["data"]["last_event_id"]
+
+
+def _comment_bodies(invoke, task_id: str) -> list[str]:
+    r = invoke("comments", task_id, "--json")
+    assert r.exit_code == 0, r.output
+    return [c["body"] for c in json.loads(r.output)["data"]]
+
+
+def _write(tmp_path, body: str, name: str = "body.md"):
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# The body arrives intact — one test per command
+# ---------------------------------------------------------------------------
+
+
+class TestBodyFromFile:
+    def test_comment(self, invoke, initialized_root, tmp_path) -> None:
+        task_id = _new_task(invoke)
+        r = invoke(
+            "comment",
+            task_id,
+            "--file",
+            _write(tmp_path, "Findings, at length."),
+            "--actor",
+            _ACTOR,
+        )
+        assert r.exit_code == 0, r.output
+        assert _comment_bodies(invoke, task_id) == ["Findings, at length."]
+
+    def test_comment_edit(self, invoke, initialized_root, tmp_path) -> None:
+        task_id = _new_task(invoke)
+        comment_id = _add_comment(invoke, task_id, "original")
+        r = invoke(
+            "comment-edit",
+            task_id,
+            comment_id,
+            "--file",
+            _write(tmp_path, "Revised, at length."),
+            "--actor",
+            _ACTOR,
+        )
+        assert r.exit_code == 0, r.output
+        assert _comment_bodies(invoke, task_id) == ["Revised, at length."]
+
+    def test_complete_review_file(self, invoke, initialized_root, fill_plan, tmp_path) -> None:
+        task_id = _task_in_progress(invoke, fill_plan)
+        r = invoke(
+            "complete",
+            task_id,
+            "--review-file",
+            _write(tmp_path, "Reviewed, at length."),
+            "--actor",
+            _ACTOR,
+            "--json",
+        )
+        assert r.exit_code == 0, r.output
+        assert json.loads(r.output)["data"]["status"] == "done"
+        assert _comment_bodies(invoke, task_id) == ["Reviewed, at length."]
+
+    def test_needs_human(self, invoke, initialized_root, tmp_path) -> None:
+        task_id = _new_task(invoke)
+        r = invoke(
+            "needs-human",
+            task_id,
+            "--file",
+            _write(tmp_path, "Need: which OAuth provider?"),
+            "--actor",
+            _ACTOR,
+            "--json",
+        )
+        assert r.exit_code == 0, r.output
+        flag = json.loads(r.output)["data"]["needs_human"]
+        assert flag["reason"] == "Need: which OAuth provider?"
+
+
+# ---------------------------------------------------------------------------
+# THE REGRESSION THIS TICKET EXISTS FOR
+# ---------------------------------------------------------------------------
+
+
+class TestShellHostileBodyRoundTrip:
+    """A body full of backticks and $(...) must survive --file unchanged.
+
+    This is the whole point of LAT-263. Inline, these characters are command
+    substitution and the shell eats or replaces them before Lattice ever sees
+    the text; via --file the bytes go straight from disk into the event.
+    """
+
+    def test_comment_file_body_with_backticks_round_trips_byte_identically(
+        self, invoke, initialized_root, tmp_path
+    ) -> None:
+        task_id = _new_task(invoke)
+        r = invoke(
+            "comment",
+            task_id,
+            "--file",
+            _write(tmp_path, SHELL_HOSTILE_BODY),
+            "--actor",
+            _ACTOR,
+        )
+        assert r.exit_code == 0, r.output
+
+        stored = _comment_bodies(invoke, task_id)[0]
+        assert stored == SHELL_HOSTILE_BODY
+        # Named explicitly so a future regression names itself:
+        assert "`pytest -q`" in stored
+        assert "$(git rev-parse HEAD)" in stored
+        assert "${HOME}" in stored
+        assert "$(1 + 1)" in stored
+
+    def test_complete_review_file_with_backticks_round_trips_byte_identically(
+        self, invoke, initialized_root, fill_plan, tmp_path
+    ) -> None:
+        task_id = _task_in_progress(invoke, fill_plan)
+        r = invoke(
+            "complete",
+            task_id,
+            "--review-file",
+            _write(tmp_path, SHELL_HOSTILE_BODY),
+            "--actor",
+            _ACTOR,
+        )
+        assert r.exit_code == 0, r.output
+        assert _comment_bodies(invoke, task_id)[0] == SHELL_HOSTILE_BODY
+
+
+# ---------------------------------------------------------------------------
+# Exactly one of inline / file — both or neither is a VALIDATION_ERROR
+# ---------------------------------------------------------------------------
+
+COMMANDS = ["comment", "comment-edit", "complete", "needs-human"]
+
+
+def _case(name: str, invoke, fill_plan) -> tuple[list[str], list[str], str]:
+    """Return (base_args, inline_args, file_flag) for a prose-taking command."""
+    if name == "comment":
+        return ["comment", _new_task(invoke)], ["inline text"], "--file"
+    if name == "comment-edit":
+        task_id = _new_task(invoke)
+        return (
+            ["comment-edit", task_id, _add_comment(invoke, task_id, "original")],
+            ["inline text"],
+            "--file",
+        )
+    if name == "complete":
+        return (
+            ["complete", _task_in_progress(invoke, fill_plan)],
+            ["--review", "inline"],
+            "--review-file",
+        )
+    if name == "needs-human":
+        return ["needs-human", _new_task(invoke)], ["inline reason"], "--file"
+    raise AssertionError(f"unknown command: {name}")
+
+
+def _assert_validation_error_envelope(result) -> str:
+    """Assert the --json error envelope shape and return the message."""
+    assert result.exit_code != 0
+    parsed = json.loads(result.output)
+    assert set(parsed) == {"ok", "error"}
+    assert parsed["ok"] is False
+    assert set(parsed["error"]) == {"code", "message"}
+    assert parsed["error"]["code"] == "VALIDATION_ERROR"
+    assert isinstance(parsed["error"]["message"], str) and parsed["error"]["message"]
+    return parsed["error"]["message"]
+
+
+class TestExactlyOneSource:
+    @pytest.mark.parametrize("name", COMMANDS)
+    def test_both_inline_and_file_rejected(
+        self, name, invoke, initialized_root, fill_plan, tmp_path
+    ) -> None:
+        base, inline, file_flag = _case(name, invoke, fill_plan)
+        result = invoke(
+            *base, *inline, file_flag, _write(tmp_path, "from file"), "--actor", _ACTOR, "--json"
+        )
+        message = _assert_validation_error_envelope(result)
+        assert "not both" in message
+
+    @pytest.mark.parametrize("name", COMMANDS)
+    def test_neither_inline_nor_file_rejected(
+        self, name, invoke, initialized_root, fill_plan
+    ) -> None:
+        base, _inline, _file_flag = _case(name, invoke, fill_plan)
+        result = invoke(*base, "--actor", _ACTOR, "--json")
+        _assert_validation_error_envelope(result)
+
+    @pytest.mark.parametrize("name", COMMANDS)
+    def test_missing_file_is_rejected_by_click(
+        self, name, invoke, initialized_root, fill_plan, tmp_path
+    ) -> None:
+        """click.Path(exists=True) — a typo'd path never becomes an empty body."""
+        base, _inline, file_flag = _case(name, invoke, fill_plan)
+        result = invoke(*base, file_flag, str(tmp_path / "nope.md"), "--actor", _ACTOR)
+        assert result.exit_code != 0
+        assert "does not exist" in result.output


### PR DESCRIPTION
## Why

A long prose body written inline into a double-quoted shell argument gets its backticks and `$(...)` executed as **command substitution**. Twice in one orchestration run (Acetate perf fork, Phase 0) this hit real comments: once silently eating a clause, once running the entire pytest suite and splicing ~15 KB of output into the comment body, requiring the polluted duplicate to be deleted. The natural way to write a long body is the dangerous one.

`lattice comment --file` already existed — but it was **absent from `src/lattice/skills/lattice/SKILL.md`**, the doc agents actually load, which showed only the inline form. Agents learned the footgun and never the escape hatch. That documentation gap was the primary defect.

## What changed

**SKILL.md (the highest-value item).** Two touchpoints, both where agents copy from:

- The `# Comment` example in Core Commands now shows the `--file` form, with the why in the header comment.
- The Closing Ritual gains a `--review-file` line in its code block plus one paragraph: *"**Long prose goes in a file, not in quotes.** `--review-file` on `complete`; `--file` on `comment`, `comment-edit`, and `needs-human`. Inside a double-quoted shell argument, backticks and `$(...)` are command substitution — that has silently eaten a clause from one comment and spliced 15 KB of pytest output into another. A file is read byte-for-byte."*

The incident is stated so the reason survives the next edit. SKILL.md loads into every agent session, so it is +6 lines net, no more.

**Capability**, hoisted into one shared helper (`helpers.resolve_body`) so all four commands are literally the same code path:

| Command | New | Positional/flag |
|---|---|---|
| `complete` | `--review-file` | `--review` drops Click-level `required=True`; the helper enforces exactly-one |
| `comment-edit` | `--file` | `NEW_TEXT` now optional |
| `needs-human` | `--file` | `REASON` now optional |
| `comment` | (already had `--file`) | refactored onto the helper |

Both given or neither given exits through the existing `output_error(..., "VALIDATION_ERROR", is_json)`, so the `--json` envelope shape is unchanged. `click.Path(exists=True)` on every file option — a typo'd path is a Click error, never an empty body.

**Deliberately out of scope:** `attach` (its `SOURCE` argument already accepts a file path; `--inline` is explicitly the short-text path). No schema change, no event-shape change — these are input paths to existing events.

## Tests

`tests/test_cli/test_prose_file_args.py`, 18 tests:

- Body arrives intact from `--file` for each of the four commands.
- Both given → non-zero exit + `VALIDATION_ERROR`; neither given → non-zero exit + `VALIDATION_ERROR`; full `--json` envelope shape asserted (`{ok, error{code, message}}`).
- Missing file → rejected by `click.Path(exists=True)`.
- **The regression the ticket exists for:** a body full of backticks, `$(...)` and `${...}` round-trips **byte-identically** through `--file` (`TestShellHostileBodyRoundTrip`).

`test_complete_cmd.py::test_fails_without_review_flag` updated: it asserted Click's `Missing option '--review'`, which by design is now the helper's `VALIDATION_ERROR` naming both `--review` and `--review-file`.

**Gates:** `uv run pytest` → **2024 passed in ~42s**. `uv run ruff check src/ tests/` → all checks passed. `uv run ruff format` → clean. No schema bump needed, none made.

Verified the tests fail without the fix: with `src/` stashed, 12 of the 18 fail. The 6 that pass are the `comment --file` cases, whose capability already existed — those lock in behaviour rather than prove new behaviour, and the `complete --review-file` backtick round-trip does genuinely fail without this change.

Closes LAT-263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
