### PR TITLE
LAT-266: bind review evidence to the caller's worktree, and fail closed without it

### DIFF
--- a/src/lattice/agent_runner.py
+++ b/src/lattice/agent_runner.py
@@ -86,7 +86,7 @@ def _run_agent_mode() -> int:
 
     # Resolve the agent CLI command. Importing inside main keeps this
     # script importable even when lattice is partially built.
-    from lattice.core.agent_spawn import _agent_cli_command
+    from lattice.core.agent_spawn import _agent_cli_command, scrub_host_session_env
 
     cmd = _agent_cli_command(agent_type, prompt_file, output_file)
     if cmd is None:
@@ -97,8 +97,11 @@ def _run_agent_mode() -> int:
     print(f"[agent_runner] type={agent_type} label={label} timeout={timeout_s}s")
     print(f"[agent_runner] cmd: {cmd}")
 
+    # Strip the firing session's identity (CLAUDECODE + c11/cmux vars) so the
+    # spawned agent can't rename the host tab or think it's nested. See
+    # lattice.core.agent_spawn.scrub_host_session_env.
     env = os.environ.copy()
-    env.pop("CLAUDECODE", None)
+    scrub_host_session_env(env)
 
     # Stream stdout/stderr live so the c11/terminal pane hosting this
     # wrapper shows output as the agent produces it, rather than dumping

--- a/src/lattice/cli/auto_review.py
+++ b/src/lattice/cli/auto_review.py
@@ -83,6 +83,7 @@ def auto_fire_review(
     status_event_id: str,
     config: dict,
     no_auto_review_flag: bool,
+    reviewed_worktree: Path | None = None,
 ) -> dict:
     """Spawn a detached ``lattice {code,plan}-review`` if gating allows.
 
@@ -129,6 +130,11 @@ def auto_fire_review(
         return {"fired": False, "reason": "not_a_review_gate"}
 
     mode = resolve_mode(config, new_status)
+
+    if review_type == "code-review" and reviewed_worktree is not None:
+        if not (reviewed_worktree / ".git").exists():
+            return {"fired": False, "reason": "reviewed_worktree_not_git"}
+        reviewed_worktree = reviewed_worktree.resolve()
 
     # Synchronous parent-side claim — see LAT-211 §5.
     claimed, existing = claim_review_state(
@@ -184,6 +190,8 @@ def auto_fire_review(
         "--triggered-by",
         status_event_id,
     ]
+    if reviewed_worktree is not None and review_type == "code-review":
+        cmd.extend(["--worktree", str(reviewed_worktree)])
 
     log_fh = None
     try:
@@ -193,7 +201,7 @@ def auto_fire_review(
 
         proc = subprocess.Popen(
             cmd,
-            cwd=str(lattice_dir.parent),
+            cwd=str(reviewed_worktree or lattice_dir.parent),
             stdin=subprocess.DEVNULL,
             stdout=log_fh,
             stderr=subprocess.STDOUT,
@@ -224,7 +232,7 @@ def auto_fire_review(
             except OSError:
                 logger.debug("log fd close raised", exc_info=True)
 
-    return {
+    result = {
         "fired": True,
         "review_type": review_type,
         "mode": mode,
@@ -232,6 +240,9 @@ def auto_fire_review(
         "pid": proc.pid,
         "spawned_at": spawned_at,
     }
+    if reviewed_worktree is not None:
+        result["reviewed_worktree"] = str(reviewed_worktree)
+    return result
 
 
 def _now_iso() -> str:

--- a/src/lattice/cli/auto_review.py
+++ b/src/lattice/cli/auto_review.py
@@ -70,6 +70,21 @@ def log_path_for(lattice_dir: Path, review_type: str, task_id: str) -> Path:
     return lattice_dir / DAEMON_DIR_NAME / f"auto-{review_type}-{task_id}.log"
 
 
+def _normalize_reviewed_worktree(candidate: Path | None) -> Path | None:
+    """Return a Git worktree's canonical root, or ``None`` when unavailable."""
+    if candidate is None:
+        return None
+    try:
+        top_level = subprocess.check_output(
+            ["git", "-C", str(candidate), "rev-parse", "--show-toplevel"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return Path(top_level).resolve() if top_level else None
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -131,10 +146,13 @@ def auto_fire_review(
 
     mode = resolve_mode(config, new_status)
 
-    if review_type == "code-review" and reviewed_worktree is not None:
-        if not (reviewed_worktree / ".git").exists():
+    if review_type == "code-review":
+        if reviewed_worktree is None:
+            return {"fired": False, "reason": "reviewed_worktree_unavailable"}
+        normalized_worktree = _normalize_reviewed_worktree(reviewed_worktree)
+        if normalized_worktree is None:
             return {"fired": False, "reason": "reviewed_worktree_not_git"}
-        reviewed_worktree = reviewed_worktree.resolve()
+        reviewed_worktree = normalized_worktree
 
     # Synchronous parent-side claim — see LAT-211 §5.
     claimed, existing = claim_review_state(

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -42,6 +42,22 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _normalize_worktree(worktree: Path | None) -> tuple[Path | None, str | None]:
+    candidate = (worktree or Path.cwd()).resolve()
+    result = subprocess.run(
+        ["git", "-C", str(candidate), "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        return None, f"Not a git worktree: {candidate}"
+    return Path(result.stdout.strip()).resolve(), None
+
+
+def _head_sha(worktree: Path) -> str:
+    return subprocess.check_output(["git", "-C", str(worktree), "rev-parse", "HEAD"], text=True).strip()
+
+
 def _claim_or_refuse(
     lattice_dir: Path,
     task_id: str,
@@ -208,6 +224,11 @@ def code_review(
         return
 
     actor = require_actor(is_json)
+    reviewed_worktree, worktree_error = _normalize_worktree(worktree)
+    if worktree_error:
+        output_error(worktree_error, "DIFF_RESOLUTION_FAILED", is_json)
+    assert reviewed_worktree is not None
+    reviewed_sha = _head_sha(reviewed_worktree)
 
     # Claim the in-flight slot (or adopt the parent's claim when this is
     # an auto-fired child invoked with --triggered-by).
@@ -222,7 +243,7 @@ def code_review(
 
     # Resolve diff
     success, diff_or_err = resolve_diff(
-        lattice_dir, task_id, snapshot, base=base, head=head, worktree=worktree
+        lattice_dir, task_id, snapshot, base=base, head=head, worktree=reviewed_worktree
     )
     if not success:
         output_error(diff_or_err, "DIFF_RESOLUTION_FAILED", is_json)
@@ -251,13 +272,17 @@ def code_review(
     template = load_review_template(lattice_dir, "code-review")
     plan_content = _read_plan(lattice_dir, task_id)
     project_context = _read_project_context(lattice_dir)
-    prompt = template.format(
+    prompt = (
+        f"Lattice-Reviewed-Commit: {reviewed_sha}\n"
+        f"Lattice-Reviewed-Worktree: {reviewed_worktree}\n\n"
+        + template.format(
         task_id=snapshot.get("short_id") or task_id,
         task_description=snapshot.get("description") or snapshot.get("title", ""),
         plan_content=plan_content,
         project_context=project_context,
         diff_content=diff_content,
         output_path="<write output here>",
+        )
     )
 
     timeout = config.get("review_timeout_seconds", 600)
@@ -275,6 +300,8 @@ def code_review(
             model=model,
             session=session,
             timeout=timeout,
+            worktree=reviewed_worktree,
+            reviewed_sha=reviewed_sha,
         )
 
     elif mode == "triple":
@@ -287,6 +314,7 @@ def code_review(
             is_json=is_json,
             quiet=quiet,
             base=base,
+            worktree=reviewed_worktree,
         )
 
 
@@ -580,6 +608,8 @@ def _run_single_and_store(
     model: str | None,
     session: str | None,
     timeout: int = 600,
+    worktree: Path | None = None,
+    reviewed_sha: str | None = None,
 ) -> str | None:
     """Run single-agent review, store artifact, print result. Returns artifact ID or None."""
     click.echo(f"Running {review_type} (single mode)...")
@@ -591,6 +621,7 @@ def _run_single_and_store(
         prompt_content=prompt,
         actor=actor,
         timeout=timeout,
+        worktree=worktree,
     )
 
     if not success:
@@ -602,7 +633,7 @@ def _run_single_and_store(
     art_id = _attach_review_artifact(
         lattice_dir=lattice_dir,
         task_id=task_id,
-        content=text,
+        content=(f"Lattice-Reviewed-Commit: {reviewed_sha}\n\n{text}" if reviewed_sha else text),
         title=f"{review_type} ({role})",
         role=role,
         actor=actor,
@@ -634,6 +665,7 @@ def _spawn_triple_pane(
     is_json: bool,
     quiet: bool,
     base: str | None,
+    worktree: Path | None = None,
 ) -> None:
     """Spawn a c11 pane that runs the trident review. Fire-and-forget.
 
@@ -654,7 +686,7 @@ def _spawn_triple_pane(
         actor=actor,
         base=base,
         short_id=short_id,
-        worktree=lattice_dir.parent,
+        worktree=worktree,
     )
 
     if not success:

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -55,7 +55,9 @@ def _normalize_worktree(worktree: Path | None) -> tuple[Path | None, str | None]
 
 
 def _head_sha(worktree: Path) -> str:
-    return subprocess.check_output(["git", "-C", str(worktree), "rev-parse", "HEAD"], text=True).strip()
+    return subprocess.check_output(
+        ["git", "-C", str(worktree), "rev-parse", "HEAD"], text=True
+    ).strip()
 
 
 def _claim_or_refuse(
@@ -276,12 +278,12 @@ def code_review(
         f"Lattice-Reviewed-Commit: {reviewed_sha}\n"
         f"Lattice-Reviewed-Worktree: {reviewed_worktree}\n\n"
         + template.format(
-        task_id=snapshot.get("short_id") or task_id,
-        task_description=snapshot.get("description") or snapshot.get("title", ""),
-        plan_content=plan_content,
-        project_context=project_context,
-        diff_content=diff_content,
-        output_path="<write output here>",
+            task_id=snapshot.get("short_id") or task_id,
+            task_description=snapshot.get("description") or snapshot.get("title", ""),
+            plan_content=plan_content,
+            project_context=project_context,
+            diff_content=diff_content,
+            output_path="<write output here>",
         )
     )
 

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -915,15 +915,25 @@ def status_cmd(
         try:
             from lattice.cli.auto_review import auto_fire_review
 
-            auto_review_result = auto_fire_review(
-                lattice_dir,
-                task_id,
-                new_status,
-                status_event_id=event["id"],
-                config=config,
-                no_auto_review_flag=no_auto_review,
-                reviewed_worktree=_caller_git_worktree() if new_status == "review" else None,
-            )
+            reviewed_worktree = _caller_git_worktree() if new_status == "review" else None
+            # A review must inspect the checkout that requested the transition.
+            # Do not let auto_review's board-root fallback turn an unknown
+            # caller identity into a review of a different checkout.
+            if new_status == "review" and reviewed_worktree is None:
+                auto_review_result = {
+                    "fired": False,
+                    "reason": "reviewed_worktree_unavailable",
+                }
+            else:
+                auto_review_result = auto_fire_review(
+                    lattice_dir,
+                    task_id,
+                    new_status,
+                    status_event_id=event["id"],
+                    config=config,
+                    no_auto_review_flag=no_auto_review,
+                    reviewed_worktree=reviewed_worktree,
+                )
         except Exception as exc:  # noqa: BLE001 — never fail the transition
             logger.warning(
                 "auto-review spawn raised: %s",

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+import subprocess
+from pathlib import Path
 
 import click
 
@@ -52,6 +54,15 @@ from lattice.core.tasks import apply_event_to_snapshot, is_backward_status_trans
 from lattice.storage.readers import read_task_events
 
 logger = logging.getLogger(__name__)
+
+
+def _caller_git_worktree() -> Path | None:
+    """Return the immutable git root of the invoking checkout, if any."""
+    current = Path.cwd().resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -804,7 +815,19 @@ def status_cmd(
                     "REVIEW_CYCLE_LIMIT",
                     is_json,
                 )
-        policy_ok, policy_failures = validate_completion_policy(config, snapshot, new_status)
+        # Check completion policies (evidence gating). The reachable-review-commit
+        # policy needs the invoking checkout, not the board root.
+        target_policy = (
+            config.get("workflow", {}).get("completion_policies", {}).get(new_status, {})
+        )
+        policy_context = (
+            {"lattice_dir": lattice_dir, "repo_root": _caller_git_worktree()}
+            if target_policy.get("require_reachable_review_commit")
+            else {}
+        )
+        policy_ok, policy_failures = validate_completion_policy(
+            config, snapshot, new_status, **policy_context
+        )
         if not policy_ok:
             if not force:
                 output_error(
@@ -899,6 +922,7 @@ def status_cmd(
                 status_event_id=event["id"],
                 config=config,
                 no_auto_review_flag=no_auto_review,
+                reviewed_worktree=_caller_git_worktree() if new_status == "review" else None,
             )
         except Exception as exc:  # noqa: BLE001 — never fail the transition
             logger.warning(
@@ -926,6 +950,11 @@ def status_cmd(
                         # ``log_path`` plus the eventual review artifact.
                         "pid": auto_review_result["pid"],
                         "trigger_status_event_id": event["id"],
+                        **(
+                            {"reviewed_worktree": auto_review_result["reviewed_worktree"]}
+                            if "reviewed_worktree" in auto_review_result
+                            else {}
+                        ),
                     },
                 )
                 updated_snapshot = mutate_task_events(
@@ -1644,6 +1673,19 @@ def complete_cmd(
     shared_ts = utc_now()
     art_id = generate_artifact_id()
 
+    review_payload = review_text
+    # The opt-in gate is Lattice-owned. Capture the invoking checkout rather
+    # than the board root, which can legitimately be a different worktree.
+    policy = config.get("workflow", {}).get("completion_policies", {}).get("done", {})
+    if policy.get("require_reachable_review_commit"):
+        worktree = _caller_git_worktree()
+        if worktree is None:
+            output_error("Not inside a git worktree.", "COMPLETION_BLOCKED", is_json)
+        sha = subprocess.check_output(
+            ["git", "-C", str(worktree), "rev-parse", "HEAD"], text=True
+        ).strip()
+        review_payload = f"Lattice-Reviewed-Commit: {sha}\n\n{review_text}"
+
     # --- Write artifact metadata ---
     # Write inline review text as artifact payload
     tmp = tempfile.NamedTemporaryFile(
@@ -1652,7 +1694,7 @@ def complete_cmd(
         delete=False,
         prefix="lattice-review-",
     )
-    tmp.write(review_text)
+    tmp.write(review_payload)
     tmp.close()
     tmp_path = Path(tmp.name)
 
@@ -1677,7 +1719,7 @@ def complete_cmd(
         model=model,
         payload_file=payload_file,
         content_type="text/markdown",
-        size_bytes=len(review_text.encode("utf-8")),
+        size_bytes=len(review_payload.encode("utf-8")),
     )
 
     meta_path = lattice_dir / "artifacts" / "meta" / f"{art_id}.json"
@@ -1741,7 +1783,17 @@ def complete_cmd(
         )
         events.append(artifact_event)
         working = apply_event_to_snapshot(working, artifact_event)
-        policy_ok, policy_failures = validate_completion_policy(config, working, "done")
+        # Validate the completion policy against the prospective post-transition
+        # snapshot. The reachable-review-commit gate is bound to the invoking
+        # checkout, and the payload it inspects is the one written above.
+        policy_ok, policy_failures = validate_completion_policy(
+            config,
+            working,
+            "done",
+            lattice_dir=lattice_dir,
+            repo_root=_caller_git_worktree(),
+            prospective_review_payloads=[review_payload],
+        )
         if not policy_ok:
             output_error(
                 f"Completion policy not satisfied: {'; '.join(policy_failures)}.",

--- a/src/lattice/cli/task_cmds.py
+++ b/src/lattice/cli/task_cmds.py
@@ -1825,7 +1825,15 @@ def complete_cmd(
         events.append(done_status_event)
         return TaskMutationDecision(events=events, value=current_status)
 
-    result = mutate_task(lattice_dir, task_id, decide, config)
+    # The artifact files above are written before the events that reference
+    # them, so a refused completion must not leave them behind. Nothing was
+    # appended when the mutation raises, so the artifact is unreferenced.
+    try:
+        result = mutate_task(lattice_dir, task_id, decide, config)
+    except BaseException:
+        dest_path.unlink(missing_ok=True)
+        meta_path.unlink(missing_ok=True)
+        raise
     snapshot = result.snapshot
     current_status = result.callback_value
 

--- a/src/lattice/core/agent_spawn.py
+++ b/src/lattice/core/agent_spawn.py
@@ -27,7 +27,7 @@ import threading
 import time
 import uuid
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, MutableMapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -38,6 +38,54 @@ SENTINEL_SUFFIX = ".done"
 DEFAULT_POLL_INTERVAL_S = 0.5
 
 ProgressCallback = Callable[[str, str], None]
+
+
+# ---------------------------------------------------------------------------
+# Host-session environment hygiene
+# ---------------------------------------------------------------------------
+
+#: Environment variables that must NOT leak from the firing session into a
+#: headless agent we spawn. ``CLAUDECODE`` makes a child ``claude`` think it is
+#: nested inside another Claude Code session. The ``C11_*`` / ``CMUX_*``
+#: identity vars are worse: a c11/cmux surface injects a session-start
+#: instruction telling a fresh Claude to rename "its" tab as its first action —
+#: so a child that inherited the PARENT surface's identity renames the parent's
+#: tab (a headless reviewer clobbering the operator's orchestrator tab). We
+#: strip all of them at every leaf headless spawn so the child is a clean,
+#: identity-less process. ``CLAUDECODE`` stays first to preserve the exact
+#: behavior the code already had.
+HOST_SESSION_ENV_VARS: tuple[str, ...] = (
+    "CLAUDECODE",
+    "C11_SURFACE_ID",
+    "C11_TAB_ID",
+    "C11_WORKSPACE_ID",
+    "C11_SHELL_INTEGRATION",
+    "C11_SOCKET_PATH",
+    "CMUX_SURFACE_ID",
+    "CMUX_TAB_ID",
+    "CMUX_WORKSPACE_ID",
+    "CMUX_SHELL_INTEGRATION",
+    "CMUX_SOCKET_PATH",
+)
+
+
+def scrub_host_session_env(env: MutableMapping[str, str]) -> None:
+    """Remove host-session identity vars from ``env`` in place.
+
+    Call this on the env of any headless ``claude`` / ``codex`` / ``gemini``
+    spawn so the child does not inherit the firing session's c11/cmux identity
+    (which would make it rename the parent's tab) or ``CLAUDECODE`` (false
+    nesting). Idempotent; missing vars are ignored. Mutates the mapping the
+    caller passes to ``subprocess`` — never touches the live ``os.environ``.
+    """
+    for var in HOST_SESSION_ENV_VARS:
+        env.pop(var, None)
+
+
+#: ``env -u`` flags that strip :data:`HOST_SESSION_ENV_VARS`, for use as a
+#: belt-and-suspenders prefix on a shell command whose env we cannot otherwise
+#: guarantee is scrubbed. Built from the same list so it can never drift.
+_HOST_SESSION_ENV_UNSET = " ".join(f"-u {name}" for name in HOST_SESSION_ENV_VARS)
 
 
 # ---------------------------------------------------------------------------
@@ -116,7 +164,10 @@ def _agent_cli_command(agent_type: str, prompt_file: str, output_file: str) -> s
     """
     instruction = f"Read {prompt_file} and follow the instructions. Write output to {output_file}"
     if agent_type == "claude":
-        return f'env -u CLAUDECODE claude --dangerously-skip-permissions -p "{instruction}"'
+        return (
+            f"env {_HOST_SESSION_ENV_UNSET} "
+            f'claude --dangerously-skip-permissions -p "{instruction}"'
+        )
     if agent_type == "codex":
         return f'codex exec --full-auto --skip-git-repo-check "{instruction}"'
     if agent_type == "gemini":

--- a/src/lattice/core/agent_spawn.py
+++ b/src/lattice/core/agent_spawn.py
@@ -103,6 +103,7 @@ class SpawnRequest:
     label: str
     timeout_seconds: int = DEFAULT_AGENT_TIMEOUT
     extra_env: dict[str, str] = field(default_factory=dict)
+    cwd: Path | None = None
 
 
 @dataclass(frozen=True)

--- a/src/lattice/core/config.py
+++ b/src/lattice/core/config.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
+from pathlib import Path
 from typing import Literal, TypedDict
 
 
@@ -17,6 +19,7 @@ class WipLimits(TypedDict, total=False):
 class CompletionPolicy(TypedDict, total=False):
     require_roles: list[str]
     require_assigned: bool
+    require_reachable_review_commit: bool
 
 
 class Workflow(TypedDict, total=False):
@@ -602,6 +605,10 @@ def validate_completion_policy(
     config: dict,
     snapshot: dict,
     to_status: str,
+    *,
+    lattice_dir: Path | None = None,
+    repo_root: Path | None = None,
+    prospective_review_payloads: list[str] | None = None,
 ) -> tuple[bool, list[str]]:
     """Check whether a transition into *to_status* satisfies completion policies.
 
@@ -643,7 +650,56 @@ def validate_completion_policy(
     if policy.get("require_assigned") and not snapshot.get("assigned_to"):
         failures.append("Task must be assigned")
 
+    if policy.get("require_reachable_review_commit"):
+        if lattice_dir is None or repo_root is None:
+            failures.append("Reachable review commit check requires repository context")
+        elif not _has_reachable_review_commit(
+            snapshot, lattice_dir, repo_root, prospective_review_payloads or []
+        ):
+            failures.append(
+                "No qualifying review artifact has a Lattice-Reviewed-Commit marker "
+                "reachable from the linked branch"
+            )
+
     return (len(failures) == 0, failures)
+
+
+_REVIEW_MARKER = re.compile(r"\ALattice-Reviewed-Commit: ([0-9a-f]{40})\n")
+
+
+def _has_reachable_review_commit(
+    snapshot: dict, lattice_dir: Path, repo_root: Path, prospective: list[str]
+) -> bool:
+    """Return whether one review artifact names a commit reachable from the linked branch."""
+    branches = snapshot.get("branch_links", [])
+    branch = branches[-1].get("branch") if branches else None
+    if not isinstance(branch, str) or not branch:
+        return False
+    payloads = list(prospective)
+    for ref in snapshot.get("evidence_refs", []):
+        if ref.get("source_type") != "artifact" or ref.get("role") != "review":
+            continue
+        artifact_id = ref.get("id")
+        if not isinstance(artifact_id, str):
+            continue
+        meta_path = lattice_dir / "artifacts" / "meta" / f"{artifact_id}.json"
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            payload_name = meta.get("payload", {}).get("file")
+            if isinstance(payload_name, str):
+                payloads.append((lattice_dir / "artifacts" / "payload" / payload_name).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+    for payload in payloads:
+        marker = _REVIEW_MARKER.match(payload)
+        if marker is None:
+            continue
+        sha = marker.group(1)
+        exists = subprocess.run(["git", "-C", str(repo_root), "cat-file", "-e", f"{sha}^{{commit}}"], capture_output=True).returncode == 0
+        reachable = subprocess.run(["git", "-C", str(repo_root), "merge-base", "--is-ancestor", sha, branch], capture_output=True).returncode == 0
+        if exists and reachable:
+            return True
+    return False
 
 
 def get_configured_roles(config: LatticeConfig) -> set[str]:

--- a/src/lattice/core/config.py
+++ b/src/lattice/core/config.py
@@ -687,7 +687,11 @@ def _has_reachable_review_commit(
             meta = json.loads(meta_path.read_text(encoding="utf-8"))
             payload_name = meta.get("payload", {}).get("file")
             if isinstance(payload_name, str):
-                payloads.append((lattice_dir / "artifacts" / "payload" / payload_name).read_text(encoding="utf-8"))
+                payloads.append(
+                    (lattice_dir / "artifacts" / "payload" / payload_name).read_text(
+                        encoding="utf-8"
+                    )
+                )
         except (OSError, json.JSONDecodeError):
             continue
     for payload in payloads:
@@ -695,8 +699,20 @@ def _has_reachable_review_commit(
         if marker is None:
             continue
         sha = marker.group(1)
-        exists = subprocess.run(["git", "-C", str(repo_root), "cat-file", "-e", f"{sha}^{{commit}}"], capture_output=True).returncode == 0
-        reachable = subprocess.run(["git", "-C", str(repo_root), "merge-base", "--is-ancestor", sha, branch], capture_output=True).returncode == 0
+        exists = (
+            subprocess.run(
+                ["git", "-C", str(repo_root), "cat-file", "-e", f"{sha}^{{commit}}"],
+                capture_output=True,
+            ).returncode
+            == 0
+        )
+        reachable = (
+            subprocess.run(
+                ["git", "-C", str(repo_root), "merge-base", "--is-ancestor", sha, branch],
+                capture_output=True,
+            ).returncode
+            == 0
+        )
         if exists and reachable:
             return True
     return False

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -818,6 +818,7 @@ def run_single_review(
     prompt_content: str,
     actor: str | dict,
     timeout: int = DEFAULT_AGENT_TIMEOUT,
+    worktree: Path | None = None,
 ) -> tuple[bool, str, str | None]:
     """Run a single-agent review via ``agent_spawn.spawn_one``.
 
@@ -860,6 +861,7 @@ def run_single_review(
             output_file=output_file,
             label=f"{review_type} :: claude",
             timeout_seconds=timeout,
+            cwd=worktree,
         )
         result = spawn_one(
             request,

--- a/src/lattice/storage/agent_spawn.py
+++ b/src/lattice/storage/agent_spawn.py
@@ -84,6 +84,7 @@ class HeadlessBackend(Backend):
                 stderr=subprocess.PIPE,
                 text=True,
                 start_new_session=True,
+                cwd=str(req.cwd) if req.cwd is not None else None,
             )
         except OSError as exc:
             duration = time.monotonic() - start

--- a/src/lattice/storage/agent_spawn.py
+++ b/src/lattice/storage/agent_spawn.py
@@ -24,6 +24,7 @@ from lattice.core.agent_spawn import (
     SpawnResult,
     _agent_cli_command,
     run_concurrent,
+    scrub_host_session_env,
     sentinel_path,
 )
 
@@ -54,8 +55,10 @@ class HeadlessBackend(Backend):
         if cmd is None:
             return _failure_result(req, f"Unknown agent type: {req.agent}", duration=0.0)
 
+        # Strip the firing session's identity (CLAUDECODE + c11/cmux vars) so
+        # the headless agent can't rename the host tab or think it's nested.
         env = os.environ.copy()
-        env.pop("CLAUDECODE", None)
+        scrub_host_session_env(env)
         for k, v in req.extra_env.items():
             env[k] = v
 

--- a/tests/test_cli/test_auto_fire_status.py
+++ b/tests/test_cli/test_auto_fire_status.py
@@ -118,7 +118,9 @@ class TestAutoFireSuccessPaths:
             ) as popen,
             patch.object(task_cmds, "_caller_git_worktree", return_value=nested),
             _patch_executable(),
-            patch.object(cli_auto_review, "_normalize_reviewed_worktree", return_value=worktree.resolve()),
+            patch.object(
+                cli_auto_review, "_normalize_reviewed_worktree", return_value=worktree.resolve()
+            ),
         ):
             res = runner.invoke(
                 cli,
@@ -141,7 +143,9 @@ class TestAutoFireSuccessPaths:
         assert argv[-2:] == ["--worktree", str(worktree.resolve())]
         assert popen.call_args.kwargs["cwd"] == str(worktree.resolve())
 
-    def test_status_to_review_refuses_auto_fire_without_caller_worktree(self, tmp_path: Path) -> None:
+    def test_status_to_review_refuses_auto_fire_without_caller_worktree(
+        self, tmp_path: Path
+    ) -> None:
         root = _make_board(tmp_path)
         runner = CliRunner()
         task_id = _create_task(runner, root)

--- a/tests/test_cli/test_auto_fire_status.py
+++ b/tests/test_cli/test_auto_fire_status.py
@@ -8,6 +8,7 @@ because the conftest disables it by default.
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -100,7 +101,13 @@ class TestAutoFireSuccessPaths:
     def test_status_to_review_spawns_code_review(self, tmp_path: Path) -> None:
         root = _make_board(tmp_path)
         worktree = tmp_path / "feature-worktree"
-        (worktree / ".git").mkdir(parents=True)
+        subprocess.run(["git", "init", str(worktree)], check=True, capture_output=True, text=True)
+        nested = worktree / "nested"
+        nested.mkdir()
+        normalized = subprocess.check_output(
+            ["git", "-C", str(nested), "rev-parse", "--show-toplevel"], text=True
+        ).strip()
+        assert normalized == str(worktree.resolve())
         runner = CliRunner()
         task_id = _create_task(runner, root)
         _walk_to_in_progress(runner, root, task_id)
@@ -109,8 +116,9 @@ class TestAutoFireSuccessPaths:
             patch.object(
                 cli_auto_review.subprocess, "Popen", return_value=_FakeProc(54321)
             ) as popen,
-            patch.object(task_cmds, "_caller_git_worktree", return_value=worktree),
+            patch.object(task_cmds, "_caller_git_worktree", return_value=nested),
             _patch_executable(),
+            patch.object(cli_auto_review, "_normalize_reviewed_worktree", return_value=worktree.resolve()),
         ):
             res = runner.invoke(
                 cli,
@@ -211,6 +219,9 @@ class TestAutoFireSkipPaths:
         with (
             patch.object(cli_auto_review.subprocess, "Popen") as popen,
             _patch_executable(),
+            patch.object(
+                cli_auto_review, "_normalize_reviewed_worktree", return_value=Path.cwd().resolve()
+            ),
         ):
             res = runner.invoke(
                 cli,
@@ -230,6 +241,9 @@ class TestAutoFireSkipPaths:
         with (
             patch.object(cli_auto_review.subprocess, "Popen") as popen,
             _patch_executable(),
+            patch.object(
+                cli_auto_review, "_normalize_reviewed_worktree", return_value=Path.cwd().resolve()
+            ),
         ):
             res = runner.invoke(
                 cli,
@@ -250,6 +264,9 @@ class TestAutoFireSkipPaths:
         with (
             patch.object(cli_auto_review.subprocess, "Popen") as popen,
             _patch_executable(),
+            patch.object(
+                cli_auto_review, "_normalize_reviewed_worktree", return_value=Path.cwd().resolve()
+            ),
         ):
             res = runner.invoke(
                 cli,
@@ -344,6 +361,9 @@ class TestAutoFireResilience:
         with (
             patch.object(cli_auto_review.subprocess, "Popen") as popen,
             _patch_executable(),
+            patch.object(
+                cli_auto_review, "_normalize_reviewed_worktree", return_value=Path.cwd().resolve()
+            ),
         ):
             res = runner.invoke(
                 cli,
@@ -365,6 +385,9 @@ class TestAutoFireResilience:
         with (
             patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc(31337)),
             _patch_executable(),
+            patch.object(
+                cli_auto_review, "_normalize_reviewed_worktree", return_value=Path.cwd().resolve()
+            ),
         ):
             runner.invoke(
                 cli,
@@ -425,6 +448,9 @@ def test_status_json_output_includes_auto_review_block(tmp_path: Path) -> None:
     with (
         patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc(99)),
         _patch_executable(),
+        patch.object(
+            cli_auto_review, "_normalize_reviewed_worktree", return_value=Path.cwd().resolve()
+        ),
     ):
         res = runner.invoke(
             cli,

--- a/tests/test_cli/test_auto_fire_status.py
+++ b/tests/test_cli/test_auto_fire_status.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from lattice.cli import auto_review as cli_auto_review
+from lattice.cli import task_cmds
 from lattice.cli.main import cli
 from lattice.core.auto_review import AUTO_REVIEW_ACTOR
 from lattice.core.config import default_config, serialize_config
@@ -98,6 +99,8 @@ def _patch_executable(path: str = "/usr/local/bin/lattice"):
 class TestAutoFireSuccessPaths:
     def test_status_to_review_spawns_code_review(self, tmp_path: Path) -> None:
         root = _make_board(tmp_path)
+        worktree = tmp_path / "feature-worktree"
+        (worktree / ".git").mkdir(parents=True)
         runner = CliRunner()
         task_id = _create_task(runner, root)
         _walk_to_in_progress(runner, root, task_id)
@@ -106,6 +109,7 @@ class TestAutoFireSuccessPaths:
             patch.object(
                 cli_auto_review.subprocess, "Popen", return_value=_FakeProc(54321)
             ) as popen,
+            patch.object(task_cmds, "_caller_git_worktree", return_value=worktree),
             _patch_executable(),
         ):
             res = runner.invoke(
@@ -126,6 +130,28 @@ class TestAutoFireSuccessPaths:
         assert argv[5] == "--triggered-by"
         # event id is a non-empty ULID-shaped string
         assert argv[6].startswith("ev_")
+        assert argv[-2:] == ["--worktree", str(worktree.resolve())]
+        assert popen.call_args.kwargs["cwd"] == str(worktree.resolve())
+
+    def test_status_to_review_refuses_auto_fire_without_caller_worktree(self, tmp_path: Path) -> None:
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        _walk_to_in_progress(runner, root, task_id)
+
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen") as popen,
+            patch.object(task_cmds, "_caller_git_worktree", return_value=None),
+        ):
+            res = runner.invoke(
+                cli,
+                ["status", task_id, "review", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+        assert res.exit_code == 0
+        assert "reviewed_worktree_unavailable" in res.output
+        popen.assert_not_called()
 
     def test_status_to_planned_spawns_plan_review(self, tmp_path: Path) -> None:
         root = _make_board(tmp_path, plan_review_mode="triple")

--- a/tests/test_cli/test_auto_review.py
+++ b/tests/test_cli/test_auto_review.py
@@ -85,6 +85,8 @@ class TestAutoFireReviewHappyPath:
         assert popen.call_args.args[0][-2:] == ["--worktree", str(worktree.resolve())]
 
     def test_fires_for_review_with_default_config(self, lattice_dir: Path) -> None:
+        worktree = lattice_dir.parent / "caller-worktree"
+        (worktree / ".git").mkdir(parents=True)
         with (
             patch.object(
                 cli_auto_review.subprocess, "Popen", return_value=_FakeProc(12345)
@@ -98,6 +100,7 @@ class TestAutoFireReviewHappyPath:
                 status_event_id="evt_xyz",
                 config={},
                 no_auto_review_flag=False,
+                reviewed_worktree=worktree,
             )
 
         assert result["fired"] is True
@@ -118,6 +121,8 @@ class TestAutoFireReviewHappyPath:
             AUTO_REVIEW_ACTOR,
             "--triggered-by",
             "evt_xyz",
+            "--worktree",
+            str(worktree.resolve()),
         ]
         # detached and clean fds
         assert popen.call_args.kwargs["start_new_session"] is True

--- a/tests/test_cli/test_auto_review.py
+++ b/tests/test_cli/test_auto_review.py
@@ -79,7 +79,9 @@ class TestAutoFireReviewHappyPath:
         """ACE-785 regression: board root must not replace caller worktree."""
         worktree = _git_worktree(lattice_dir.parent, "feature-worktree")
         with (
-            patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc(444)) as popen,
+            patch.object(
+                cli_auto_review.subprocess, "Popen", return_value=_FakeProc(444)
+            ) as popen,
             _patch_executable(),
             _patch_normalized_worktree(worktree),
         ):
@@ -207,7 +209,9 @@ class TestAutoFireReviewHappyPath:
 
 
 class TestAutoFireReviewSkipPaths:
-    def test_code_review_rejects_absent_worktree_before_claim_or_spawn(self, lattice_dir: Path) -> None:
+    def test_code_review_rejects_absent_worktree_before_claim_or_spawn(
+        self, lattice_dir: Path
+    ) -> None:
         with patch.object(cli_auto_review.subprocess, "Popen") as popen:
             result = auto_fire_review(
                 lattice_dir,

--- a/tests/test_cli/test_auto_review.py
+++ b/tests/test_cli/test_auto_review.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -61,14 +62,26 @@ def _patch_executable(path: str = "/usr/local/bin/lattice"):
     return patch.object(cli_auto_review, "find_lattice_executable", return_value=path)
 
 
+def _git_worktree(tmp_path: Path, name: str = "caller-worktree") -> Path:
+    worktree = tmp_path / name
+    subprocess.run(["git", "init", str(worktree)], check=True, capture_output=True, text=True)
+    return worktree
+
+
+def _patch_normalized_worktree(worktree: Path):
+    return patch.object(
+        cli_auto_review, "_normalize_reviewed_worktree", return_value=worktree.resolve()
+    )
+
+
 class TestAutoFireReviewHappyPath:
     def test_explicit_worktree_controls_child_argv_and_cwd(self, lattice_dir: Path) -> None:
         """ACE-785 regression: board root must not replace caller worktree."""
-        worktree = lattice_dir.parent / "feature-worktree"
-        (worktree / ".git").mkdir(parents=True)
+        worktree = _git_worktree(lattice_dir.parent, "feature-worktree")
         with (
             patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc(444)) as popen,
             _patch_executable(),
+            _patch_normalized_worktree(worktree),
         ):
             result = auto_fire_review(
                 lattice_dir,
@@ -85,13 +98,13 @@ class TestAutoFireReviewHappyPath:
         assert popen.call_args.args[0][-2:] == ["--worktree", str(worktree.resolve())]
 
     def test_fires_for_review_with_default_config(self, lattice_dir: Path) -> None:
-        worktree = lattice_dir.parent / "caller-worktree"
-        (worktree / ".git").mkdir(parents=True)
+        worktree = _git_worktree(lattice_dir.parent)
         with (
             patch.object(
                 cli_auto_review.subprocess, "Popen", return_value=_FakeProc(12345)
             ) as popen,
             _patch_executable("/usr/local/bin/lattice"),
+            _patch_normalized_worktree(worktree),
         ):
             result = auto_fire_review(
                 lattice_dir,
@@ -171,6 +184,7 @@ class TestAutoFireReviewHappyPath:
             patch.object(cli_auto_review, "open", _spy_open, create=True),
             patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc()),
             _patch_executable(),
+            _patch_normalized_worktree(lattice_dir.parent / "caller-worktree"),
         ):
             auto_fire_review(
                 lattice_dir,
@@ -179,6 +193,7 @@ class TestAutoFireReviewHappyPath:
                 status_event_id="evt_xyz",
                 config={},
                 no_auto_review_flag=False,
+                reviewed_worktree=lattice_dir.parent / "caller-worktree",
             )
 
         assert opened_handles, "open was not called"
@@ -192,6 +207,60 @@ class TestAutoFireReviewHappyPath:
 
 
 class TestAutoFireReviewSkipPaths:
+    def test_code_review_rejects_absent_worktree_before_claim_or_spawn(self, lattice_dir: Path) -> None:
+        with patch.object(cli_auto_review.subprocess, "Popen") as popen:
+            result = auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "review",
+                status_event_id="evt_xyz",
+                config={},
+                no_auto_review_flag=False,
+            )
+        assert result == {"fired": False, "reason": "reviewed_worktree_unavailable"}
+        popen.assert_not_called()
+        assert read_review_state(lattice_dir, "task_abc") is None
+
+    def test_code_review_rejects_spoofed_git_entry_before_claim_or_spawn(
+        self, lattice_dir: Path
+    ) -> None:
+        spoofed = lattice_dir.parent / "spoofed-worktree"
+        (spoofed / ".git").mkdir(parents=True)
+        result = auto_fire_review(
+            lattice_dir,
+            "task_abc",
+            "review",
+            status_event_id="evt_xyz",
+            config={},
+            no_auto_review_flag=False,
+            reviewed_worktree=spoofed,
+        )
+        assert result == {"fired": False, "reason": "reviewed_worktree_not_git"}
+        assert read_review_state(lattice_dir, "task_abc") is None
+
+    def test_code_review_normalizes_nested_worktree_path(self, lattice_dir: Path) -> None:
+        worktree = _git_worktree(lattice_dir.parent)
+        nested = worktree / "nested"
+        nested.mkdir()
+        assert cli_auto_review._normalize_reviewed_worktree(nested) == worktree.resolve()
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc()) as popen,
+            _patch_executable(),
+            _patch_normalized_worktree(worktree),
+        ):
+            result = auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "review",
+                status_event_id="evt_xyz",
+                config={},
+                no_auto_review_flag=False,
+                reviewed_worktree=nested,
+            )
+        assert result["reviewed_worktree"] == str(worktree.resolve())
+        assert popen.call_args.args[0][-2:] == ["--worktree", str(worktree.resolve())]
+        assert popen.call_args.kwargs["cwd"] == str(worktree.resolve())
+
     def test_inline_mode_skip(self, lattice_dir: Path) -> None:
         with patch.object(cli_auto_review.subprocess, "Popen") as popen:
             result = auto_fire_review(
@@ -274,6 +343,7 @@ class TestAutoFireReviewCoordination:
         with (
             patch.object(cli_auto_review.subprocess, "Popen") as popen,
             _patch_executable(),
+            _patch_normalized_worktree(lattice_dir.parent / "caller-worktree"),
         ):
             result = auto_fire_review(
                 lattice_dir,
@@ -282,6 +352,7 @@ class TestAutoFireReviewCoordination:
                 status_event_id="evt_xyz",
                 config={},
                 no_auto_review_flag=False,
+                reviewed_worktree=lattice_dir.parent / "caller-worktree",
             )
         assert result["fired"] is False
         assert result["reason"] == "review_in_flight"
@@ -297,6 +368,7 @@ class TestAutoFireReviewCoordination:
         with (
             patch.object(cli_auto_review, "find_lattice_executable", return_value=None),
             patch.object(cli_auto_review.subprocess, "Popen") as popen,
+            _patch_normalized_worktree(lattice_dir.parent / "caller-worktree"),
         ):
             result = auto_fire_review(
                 lattice_dir,
@@ -305,6 +377,7 @@ class TestAutoFireReviewCoordination:
                 status_event_id="evt_xyz",
                 config={},
                 no_auto_review_flag=False,
+                reviewed_worktree=lattice_dir.parent / "caller-worktree",
             )
         assert result == {"fired": False, "reason": "executable_not_found"}
         popen.assert_not_called()
@@ -319,6 +392,7 @@ class TestAutoFireReviewCoordination:
                 "Popen",
                 side_effect=OSError("no fork for you"),
             ),
+            _patch_normalized_worktree(lattice_dir.parent / "caller-worktree"),
         ):
             result = auto_fire_review(
                 lattice_dir,
@@ -327,6 +401,7 @@ class TestAutoFireReviewCoordination:
                 status_event_id="evt_xyz",
                 config={},
                 no_auto_review_flag=False,
+                reviewed_worktree=lattice_dir.parent / "caller-worktree",
             )
         assert result["fired"] is False
         assert result["reason"].startswith("spawn_failed:")
@@ -340,6 +415,7 @@ class TestAutoFireReviewCoordination:
         with (
             patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc(42)),
             _patch_executable(),
+            _patch_normalized_worktree(lattice_dir.parent / "caller-worktree"),
         ):
             auto_fire_review(
                 lattice_dir,
@@ -348,6 +424,7 @@ class TestAutoFireReviewCoordination:
                 status_event_id="evt_xyz",
                 config={},
                 no_auto_review_flag=False,
+                reviewed_worktree=lattice_dir.parent / "caller-worktree",
             )
         state = read_review_state(lattice_dir, "task_abc")
         assert state is not None
@@ -375,6 +452,7 @@ def test_uses_claim_review_state_under_the_hood(lattice_dir: Path) -> None:
         patch.object(cli_auto_review, "claim_review_state", _spy),
         patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc()),
         _patch_executable(),
+        _patch_normalized_worktree(lattice_dir.parent / "caller-worktree"),
     ):
         auto_fire_review(
             lattice_dir,
@@ -383,6 +461,7 @@ def test_uses_claim_review_state_under_the_hood(lattice_dir: Path) -> None:
             status_event_id="evt_xyz",
             config={},
             no_auto_review_flag=False,
+            reviewed_worktree=lattice_dir.parent / "caller-worktree",
         )
     assert seen, "claim_review_state was not invoked"
     _, kwargs = seen[0]

--- a/tests/test_cli/test_auto_review.py
+++ b/tests/test_cli/test_auto_review.py
@@ -62,6 +62,28 @@ def _patch_executable(path: str = "/usr/local/bin/lattice"):
 
 
 class TestAutoFireReviewHappyPath:
+    def test_explicit_worktree_controls_child_argv_and_cwd(self, lattice_dir: Path) -> None:
+        """ACE-785 regression: board root must not replace caller worktree."""
+        worktree = lattice_dir.parent / "feature-worktree"
+        (worktree / ".git").mkdir(parents=True)
+        with (
+            patch.object(cli_auto_review.subprocess, "Popen", return_value=_FakeProc(444)) as popen,
+            _patch_executable(),
+        ):
+            result = auto_fire_review(
+                lattice_dir,
+                "task_abc",
+                "review",
+                status_event_id="evt_xyz",
+                config={},
+                no_auto_review_flag=False,
+                reviewed_worktree=worktree,
+            )
+
+        assert result["reviewed_worktree"] == str(worktree.resolve())
+        assert popen.call_args.kwargs["cwd"] == str(worktree.resolve())
+        assert popen.call_args.args[0][-2:] == ["--worktree", str(worktree.resolve())]
+
     def test_fires_for_review_with_default_config(self, lattice_dir: Path) -> None:
         with (
             patch.object(

--- a/tests/test_cli/test_complete_cmd.py
+++ b/tests/test_cli/test_complete_cmd.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
 
+from lattice.cli import task_cmds
 from lattice.storage.fs import LATTICE_DIR
 
 from tests.conftest import _add_policies_to_config
@@ -336,3 +340,74 @@ class TestCompleteCompletionPolicy:
         parsed = json.loads(r.output)
         assert parsed["error"]["code"] == "COMPLETION_BLOCKED"
         assert "security" in parsed["error"]["message"]
+
+
+class TestReachableReviewCommitCommandBoundaries:
+    """Exercise the completion door, including its prospective artifact."""
+
+    def _enable_gate_and_link_current_branch(self, invoke, root: Path, task_id: str) -> tuple[str, str]:
+        config_path = root / LATTICE_DIR / "config.json"
+        config = json.loads(config_path.read_text())
+        config["workflow"]["completion_policies"]["done"] = {
+            "require_reachable_review_commit": True
+        }
+        config_path.write_text(json.dumps(config, sort_keys=True, indent=2) + "\n")
+        repo = task_cmds._caller_git_worktree()
+        assert repo is not None
+        branch = subprocess.check_output(
+            ["git", "-C", str(repo), "branch", "--show-current"], text=True
+        ).strip()
+        head = subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
+        linked = invoke("branch-link", task_id, branch, "--actor", _ACTOR)
+        assert linked.exit_code == 0, linked.output
+        return branch, head
+
+    def test_status_done_rejects_unreachable_then_accepts_reachable_artifact(
+        self, invoke, initialized_root, fill_plan
+    ) -> None:
+        task_id = _create_and_advance_to(invoke, fill_plan, "review")
+        _, head = self._enable_gate_and_link_current_branch(invoke, initialized_root, task_id)
+        bad = initialized_root / "bad-review.md"
+        bad.write_text(f"Lattice-Reviewed-Commit: {'0' * 40}\n\nnope", encoding="utf-8")
+        assert invoke("attach", task_id, str(bad), "--role", "review", "--actor", _ACTOR).exit_code == 0
+
+        rejected = invoke("status", task_id, "done", "--actor", _ACTOR, "--json")
+        assert rejected.exit_code != 0
+        assert json.loads(rejected.output)["error"]["code"] == "COMPLETION_BLOCKED"
+
+        good = initialized_root / "good-review.md"
+        good.write_text(f"Lattice-Reviewed-Commit: {head}\n\npass", encoding="utf-8")
+        assert invoke("attach", task_id, str(good), "--role", "review", "--actor", _ACTOR).exit_code == 0
+        accepted = invoke("status", task_id, "done", "--actor", _ACTOR, "--json")
+        assert accepted.exit_code == 0, accepted.output
+        assert json.loads(accepted.output)["data"]["status"] == "done"
+
+    def test_complete_rejects_candidate_without_persisting_then_writes_strict_marker(
+        self, invoke, initialized_root, fill_plan
+    ) -> None:
+        task_id = _create_and_advance_to(invoke, fill_plan, "review")
+        _, head = self._enable_gate_and_link_current_branch(invoke, initialized_root, task_id)
+        lattice_dir = initialized_root / LATTICE_DIR
+        event_path = lattice_dir / "events" / f"{task_id}.jsonl"
+        before_events = event_path.read_text(encoding="utf-8")
+        before_payloads = set((lattice_dir / "artifacts" / "payload").glob("*"))
+        before_meta = set((lattice_dir / "artifacts" / "meta").glob("*"))
+
+        with patch.object(task_cmds.subprocess, "check_output", return_value="0" * 40 + "\n"):
+            rejected = invoke("complete", task_id, "--review", "bad", "--actor", _ACTOR, "--json")
+        assert rejected.exit_code != 0
+        assert json.loads(rejected.output)["error"]["code"] == "COMPLETION_BLOCKED"
+        assert event_path.read_text(encoding="utf-8") == before_events
+        assert set((lattice_dir / "artifacts" / "payload").glob("*")) == before_payloads
+        assert set((lattice_dir / "artifacts" / "meta").glob("*")) == before_meta
+
+        accepted = invoke("complete", task_id, "--review", "good", "--actor", _ACTOR, "--json")
+        assert accepted.exit_code == 0, accepted.output
+        snapshot = json.loads(accepted.output)["data"]
+        art_id = next(
+            ref["id"]
+            for ref in snapshot["evidence_refs"]
+            if ref["role"] == "review" and ref["source_type"] == "artifact"
+        )
+        payload = (lattice_dir / "artifacts" / "payload" / f"{art_id}.md").read_text(encoding="utf-8")
+        assert payload == f"Lattice-Reviewed-Commit: {head}\n\ngood"

--- a/tests/test_cli/test_complete_cmd.py
+++ b/tests/test_cli/test_complete_cmd.py
@@ -7,6 +7,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from lattice.cli import task_cmds
 from lattice.storage.fs import LATTICE_DIR
 
@@ -14,6 +16,26 @@ from tests.conftest import _add_policies_to_config
 
 
 _ACTOR = "human:test"
+
+
+@pytest.fixture()
+def caller_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A throwaway git checkout that the CLI is invoked from.
+
+    The reachable-review-commit gate reads the *invoking* checkout, so these
+    tests need one they own. Borrowing the repository the suite happens to run
+    in makes them depend on its branch and HEAD — which is empty under CI's
+    detached checkout.
+    """
+    repo = tmp_path / "caller-repo"
+    repo.mkdir()
+    git = ["git", "-C", str(repo), "-c", "user.email=t@t", "-c", "user.name=t"]
+    subprocess.run(["git", "init", "-q", "-b", "work", str(repo)], check=True)
+    (repo / "file.txt").write_text("work\n", encoding="utf-8")
+    subprocess.run([*git, "add", "-A"], check=True)
+    subprocess.run([*git, "commit", "-qm", "work"], check=True)
+    monkeypatch.chdir(repo)
+    return repo
 
 
 def _create_and_advance_to(invoke, fill_plan, target_status: str) -> str:
@@ -356,6 +378,7 @@ class TestReachableReviewCommitCommandBoundaries:
         config_path.write_text(json.dumps(config, sort_keys=True, indent=2) + "\n")
         repo = task_cmds._caller_git_worktree()
         assert repo is not None
+        assert repo.name == "caller-repo", "the gate must read the invoking checkout"
         branch = subprocess.check_output(
             ["git", "-C", str(repo), "branch", "--show-current"], text=True
         ).strip()
@@ -367,7 +390,7 @@ class TestReachableReviewCommitCommandBoundaries:
         return branch, head
 
     def test_status_done_rejects_unreachable_then_accepts_reachable_artifact(
-        self, invoke, initialized_root, fill_plan
+        self, invoke, initialized_root, fill_plan, caller_repo
     ) -> None:
         task_id = _create_and_advance_to(invoke, fill_plan, "review")
         _, head = self._enable_gate_and_link_current_branch(invoke, initialized_root, task_id)
@@ -393,7 +416,7 @@ class TestReachableReviewCommitCommandBoundaries:
         assert json.loads(accepted.output)["data"]["status"] == "done"
 
     def test_complete_rejects_candidate_without_persisting_then_writes_strict_marker(
-        self, invoke, initialized_root, fill_plan
+        self, invoke, initialized_root, fill_plan, caller_repo
     ) -> None:
         task_id = _create_and_advance_to(invoke, fill_plan, "review")
         _, head = self._enable_gate_and_link_current_branch(invoke, initialized_root, task_id)

--- a/tests/test_cli/test_complete_cmd.py
+++ b/tests/test_cli/test_complete_cmd.py
@@ -345,7 +345,9 @@ class TestCompleteCompletionPolicy:
 class TestReachableReviewCommitCommandBoundaries:
     """Exercise the completion door, including its prospective artifact."""
 
-    def _enable_gate_and_link_current_branch(self, invoke, root: Path, task_id: str) -> tuple[str, str]:
+    def _enable_gate_and_link_current_branch(
+        self, invoke, root: Path, task_id: str
+    ) -> tuple[str, str]:
         config_path = root / LATTICE_DIR / "config.json"
         config = json.loads(config_path.read_text())
         config["workflow"]["completion_policies"]["done"] = {
@@ -357,7 +359,9 @@ class TestReachableReviewCommitCommandBoundaries:
         branch = subprocess.check_output(
             ["git", "-C", str(repo), "branch", "--show-current"], text=True
         ).strip()
-        head = subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
+        head = subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True
+        ).strip()
         linked = invoke("branch-link", task_id, branch, "--actor", _ACTOR)
         assert linked.exit_code == 0, linked.output
         return branch, head
@@ -369,7 +373,10 @@ class TestReachableReviewCommitCommandBoundaries:
         _, head = self._enable_gate_and_link_current_branch(invoke, initialized_root, task_id)
         bad = initialized_root / "bad-review.md"
         bad.write_text(f"Lattice-Reviewed-Commit: {'0' * 40}\n\nnope", encoding="utf-8")
-        assert invoke("attach", task_id, str(bad), "--role", "review", "--actor", _ACTOR).exit_code == 0
+        assert (
+            invoke("attach", task_id, str(bad), "--role", "review", "--actor", _ACTOR).exit_code
+            == 0
+        )
 
         rejected = invoke("status", task_id, "done", "--actor", _ACTOR, "--json")
         assert rejected.exit_code != 0
@@ -377,7 +384,10 @@ class TestReachableReviewCommitCommandBoundaries:
 
         good = initialized_root / "good-review.md"
         good.write_text(f"Lattice-Reviewed-Commit: {head}\n\npass", encoding="utf-8")
-        assert invoke("attach", task_id, str(good), "--role", "review", "--actor", _ACTOR).exit_code == 0
+        assert (
+            invoke("attach", task_id, str(good), "--role", "review", "--actor", _ACTOR).exit_code
+            == 0
+        )
         accepted = invoke("status", task_id, "done", "--actor", _ACTOR, "--json")
         assert accepted.exit_code == 0, accepted.output
         assert json.loads(accepted.output)["data"]["status"] == "done"
@@ -409,5 +419,7 @@ class TestReachableReviewCommitCommandBoundaries:
             for ref in snapshot["evidence_refs"]
             if ref["role"] == "review" and ref["source_type"] == "artifact"
         )
-        payload = (lattice_dir / "artifacts" / "payload" / f"{art_id}.md").read_text(encoding="utf-8")
+        payload = (lattice_dir / "artifacts" / "payload" / f"{art_id}.md").read_text(
+            encoding="utf-8"
+        )
         assert payload == f"Lattice-Reviewed-Commit: {head}\n\ngood"

--- a/tests/test_cli/test_review_cmds.py
+++ b/tests/test_cli/test_review_cmds.py
@@ -372,7 +372,7 @@ class TestCodeReviewSingle:
             patch(
                 "lattice.cli.review_cmds.run_single_review",
                 return_value=(True, "Review complete.", fake_review),
-            ),
+            ) as run_single,
         ):
             result = runner.invoke(
                 cli,
@@ -385,6 +385,9 @@ class TestCodeReviewSingle:
         assert (
             result.exit_code == 0 or "Review stored" in result.output or "failed" in result.output
         )
+        # Manual command boundary carries a normalized source checkout into
+        # the reviewer; it is not inferred from LATTICE_ROOT.
+        assert run_single.call_args.kwargs["worktree"] == Path.cwd().resolve()
 
     def test_single_mode_agent_failure_reports_error(self, tmp_path):
         root = _make_board(tmp_path, {"review_mode": "single"})
@@ -506,6 +509,7 @@ class TestCodeReviewTriple:
         kwargs = mock_run.call_args.kwargs
         assert kwargs["review_type"] == "code-review"
         assert kwargs["task_id"] == task_id
+        assert kwargs["worktree"] == Path.cwd().resolve()
 
     def test_triple_mode_outside_c11_errors(self, tmp_path):
         """Triple mode outside c11 must fail cleanly with a non-zero exit and

--- a/tests/test_core/test_agent_spawn.py
+++ b/tests/test_core/test_agent_spawn.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from lattice.core.agent_spawn import (
+    HOST_SESSION_ENV_VARS,
     Backend,
     BackendUnavailableError,
     ProgressCallback,
@@ -16,6 +17,7 @@ from lattice.core.agent_spawn import (
     SpawnResult,
     _agent_cli_command,
     poll_sentinels,
+    scrub_host_session_env,
     select_backend,
     sentinel_path,
 )
@@ -84,6 +86,60 @@ class TestAgentCliCommand:
 
     def test_unknown_returns_none(self) -> None:
         assert _agent_cli_command("mystery", "/p", "/o") is None
+
+    def test_claude_command_unsets_host_session_vars(self) -> None:
+        """The claude command's `env -u` prefix strips every host-session var.
+
+        Belt-and-suspenders alongside the env scrub: a claude child must never
+        inherit CLAUDECODE or the firing surface's c11/cmux identity.
+        """
+        cmd = _agent_cli_command("claude", "/p", "/o")
+        assert cmd is not None
+        # Prefix precedes the claude binary.
+        assert cmd.index("env -u") < cmd.index("claude ")
+        for var in HOST_SESSION_ENV_VARS:
+            assert f"-u {var}" in cmd, f"{var} not unset in claude command"
+
+
+# ---------------------------------------------------------------------------
+# scrub_host_session_env
+# ---------------------------------------------------------------------------
+
+
+class TestScrubHostSessionEnv:
+    def test_strips_every_host_session_var(self) -> None:
+        env = {var: "leaked" for var in HOST_SESSION_ENV_VARS}
+        env["PATH"] = "/usr/bin"
+        env["HOME"] = "/home/x"
+        scrub_host_session_env(env)
+        for var in HOST_SESSION_ENV_VARS:
+            assert var not in env, f"{var} survived the scrub"
+        # Unrelated vars are preserved.
+        assert env["PATH"] == "/usr/bin"
+        assert env["HOME"] == "/home/x"
+
+    def test_claudecode_still_stripped(self) -> None:
+        """Regression: preserve the exact pre-existing CLAUDECODE behavior."""
+        env = {"CLAUDECODE": "1", "KEEP": "yes"}
+        scrub_host_session_env(env)
+        assert "CLAUDECODE" not in env
+        assert env["KEEP"] == "yes"
+
+    def test_noop_when_vars_absent(self) -> None:
+        env = {"PATH": "/usr/bin"}
+        scrub_host_session_env(env)  # must not raise
+        assert env == {"PATH": "/usr/bin"}
+
+    def test_legacy_cmux_vars_included(self) -> None:
+        """The legacy CMUX_* aliases the c11 binary still sets are covered."""
+        for legacy in (
+            "CMUX_SURFACE_ID",
+            "CMUX_TAB_ID",
+            "CMUX_WORKSPACE_ID",
+            "CMUX_SHELL_INTEGRATION",
+            "CMUX_SOCKET_PATH",
+        ):
+            assert legacy in HOST_SESSION_ENV_VARS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_agent_spawn_headless.py
+++ b/tests/test_core/test_agent_spawn_headless.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import os
+import shlex
 import sys
 import time
 from pathlib import Path
 
 import pytest
-
-import shlex
 
 from lattice.core.agent_spawn import (
     HOST_SESSION_ENV_VARS,
@@ -111,45 +110,6 @@ class TestHeadlessBackendEndToEnd:
         for req in reqs:
             assert sentinel_path(req.output_file).exists()
 
-
-class TestHeadlessBackendScrubsHostSessionEnv:
-    """Regression (LAT-255): a headless agent spawned from inside a c11 surface
-    must NOT inherit that surface's identity. If it did, c11's session-start
-    injection would make the headless reviewer rename the operator's own tab.
-    """
-
-    def _dump_env_command(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Patch the CLI builder to a stub that dumps the CHILD's view of every
-        host-session var into the output file (``VAR=[<value>]`` per line)."""
-
-        def _stub(agent_type: str, prompt_file: str, output_file: str) -> str:
-            body = "".join(f'echo "{v}=[${v}]"; ' for v in HOST_SESSION_ENV_VARS)
-            return f"sh -c {shlex.quote(body)} > {shlex.quote(output_file)}"
-
-        monkeypatch.setattr("lattice.core.agent_spawn._agent_cli_command", _stub)
-        monkeypatch.setattr("lattice.storage.agent_spawn._agent_cli_command", _stub)
-
-    def test_child_does_not_inherit_host_session_vars(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # Pollute the parent env as if we were firing from inside a c11 surface.
-        for var in HOST_SESSION_ENV_VARS:
-            monkeypatch.setenv(var, f"parent-{var}")
-        self._dump_env_command(monkeypatch)
-
-        req = _make_request(tmp_path, "claude")
-        result = spawn_one(req, workspace_label="test", backend=HeadlessBackend())
-
-        assert result.success, result.error
-        dumped = req.output_file.read_text(encoding="utf-8")
-        # Every host-session var must read empty in the child. Pre-fix (only
-        # CLAUDECODE popped) the C11_*/CMUX_* lines would show ``parent-<VAR>``.
-        for var in HOST_SESSION_ENV_VARS:
-            assert f"{var}=[]" in dumped, f"child inherited {var}: {dumped!r}"
-            assert f"parent-{var}" not in dumped, f"{var} leaked into child: {dumped!r}"
-
     def test_timeout_records_command_for_diagnostics(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -217,3 +177,40 @@ def _pid_alive(pid: int) -> bool:
         return False
     except PermissionError:
         return True
+
+
+class TestHeadlessBackendScrubsHostSessionEnv:
+    """Regression (LAT-255): a headless agent spawned from inside a c11 surface
+    must NOT inherit that surface's identity. If it did, c11's session-start
+    injection would make the headless reviewer rename the operator's own tab.
+    """
+
+    def _dump_env_command(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Patch the CLI builder to a stub that dumps the CHILD's view of every
+        host-session var into the output file (``VAR=[<value>]`` per line)."""
+
+        def _stub(agent_type: str, prompt_file: str, output_file: str) -> str:
+            body = "".join(f'echo "{v}=[${v}]"; ' for v in HOST_SESSION_ENV_VARS)
+            return f"sh -c {shlex.quote(body)} > {shlex.quote(output_file)}"
+
+        monkeypatch.setattr("lattice.core.agent_spawn._agent_cli_command", _stub)
+        monkeypatch.setattr("lattice.storage.agent_spawn._agent_cli_command", _stub)
+
+    def test_child_does_not_inherit_host_session_vars(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Pollute the parent env as if we were firing from inside a c11 surface.
+        for var in HOST_SESSION_ENV_VARS:
+            monkeypatch.setenv(var, f"parent-{var}")
+        self._dump_env_command(monkeypatch)
+
+        req = _make_request(tmp_path, "claude")
+        result = spawn_one(req, workspace_label="test", backend=HeadlessBackend())
+
+        assert result.success, result.error
+        dumped = req.output_file.read_text(encoding="utf-8")
+        # Every host-session var must read empty in the child. Pre-fix (only
+        # CLAUDECODE popped) the C11_*/CMUX_* lines would show ``parent-<VAR>``.
+        for var in HOST_SESSION_ENV_VARS:
+            assert f"{var}=[]" in dumped, f"child inherited {var}: {dumped!r}"
+            assert f"parent-{var}" not in dumped, f"{var} leaked into child: {dumped!r}"

--- a/tests/test_core/test_agent_spawn_headless.py
+++ b/tests/test_core/test_agent_spawn_headless.py
@@ -9,7 +9,10 @@ from pathlib import Path
 
 import pytest
 
+import shlex
+
 from lattice.core.agent_spawn import (
+    HOST_SESSION_ENV_VARS,
     SpawnRequest,
     sentinel_path,
     spawn_many,
@@ -107,6 +110,45 @@ class TestHeadlessBackendEndToEnd:
         assert all(r.success for r in results), [r.error for r in results]
         for req in reqs:
             assert sentinel_path(req.output_file).exists()
+
+
+class TestHeadlessBackendScrubsHostSessionEnv:
+    """Regression (LAT-255): a headless agent spawned from inside a c11 surface
+    must NOT inherit that surface's identity. If it did, c11's session-start
+    injection would make the headless reviewer rename the operator's own tab.
+    """
+
+    def _dump_env_command(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Patch the CLI builder to a stub that dumps the CHILD's view of every
+        host-session var into the output file (``VAR=[<value>]`` per line)."""
+
+        def _stub(agent_type: str, prompt_file: str, output_file: str) -> str:
+            body = "".join(f'echo "{v}=[${v}]"; ' for v in HOST_SESSION_ENV_VARS)
+            return f"sh -c {shlex.quote(body)} > {shlex.quote(output_file)}"
+
+        monkeypatch.setattr("lattice.core.agent_spawn._agent_cli_command", _stub)
+        monkeypatch.setattr("lattice.storage.agent_spawn._agent_cli_command", _stub)
+
+    def test_child_does_not_inherit_host_session_vars(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Pollute the parent env as if we were firing from inside a c11 surface.
+        for var in HOST_SESSION_ENV_VARS:
+            monkeypatch.setenv(var, f"parent-{var}")
+        self._dump_env_command(monkeypatch)
+
+        req = _make_request(tmp_path, "claude")
+        result = spawn_one(req, workspace_label="test", backend=HeadlessBackend())
+
+        assert result.success, result.error
+        dumped = req.output_file.read_text(encoding="utf-8")
+        # Every host-session var must read empty in the child. Pre-fix (only
+        # CLAUDECODE popped) the C11_*/CMUX_* lines would show ``parent-<VAR>``.
+        for var in HOST_SESSION_ENV_VARS:
+            assert f"{var}=[]" in dumped, f"child inherited {var}: {dumped!r}"
+            assert f"parent-{var}" not in dumped, f"{var} leaked into child: {dumped!r}"
 
     def test_timeout_records_command_for_diagnostics(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -853,3 +855,40 @@ class TestValidationSwimlane:
     def test_opinionated_display_name(self) -> None:
         config = default_config("opinionated")
         assert config["workflow"]["display_names"]["in_validation"] == "seeing it work"
+
+
+def test_reachable_review_commit_policy_mutation(tmp_path: Path) -> None:
+    """The completion door rejects an unreachable marker and accepts HEAD."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for args in (["init"], ["checkout", "-b", "feature"]):
+        subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+    (repo / "file").write_text("one", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "file"], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-m", "feature"],
+        check=True,
+        capture_output=True,
+    )
+    head = subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
+    lattice_dir = repo / ".lattice"
+    lattice_dir.mkdir()
+    config = default_config()
+    config["workflow"]["completion_policies"]["done"]["require_reachable_review_commit"] = True
+    snapshot = {
+        "evidence_refs": [{"id": "prospective", "role": "review", "source_type": "artifact"}],
+        "branch_links": [{"branch": "feature"}],
+    }
+    ok, _ = validate_completion_policy(
+        config, snapshot, "done", lattice_dir=lattice_dir, repo_root=repo,
+        prospective_review_payloads=["Lattice-Reviewed-Commit: " + "0" * 40 + "\n"],
+    )
+    assert ok is False
+    ok, failures = validate_completion_policy(
+        config, snapshot, "done", lattice_dir=lattice_dir, repo_root=repo,
+        prospective_review_payloads=[f"Lattice-Reviewed-Commit: {head}\n"],
+    )
+    assert ok is True
+    assert failures == []

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -864,15 +864,26 @@ def test_reachable_review_commit_policy_mutation(tmp_path: Path) -> None:
     for args in (["init"], ["checkout", "-b", "feature"]):
         subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
     (repo / "file").write_text("one", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "file"], check=True, capture_output=True)
     subprocess.run(
-        ["git", "-C", str(repo), "add", "file"], check=True, capture_output=True
-    )
-    subprocess.run(
-        ["git", "-C", str(repo), "-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-m", "feature"],
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-m",
+            "feature",
+        ],
         check=True,
         capture_output=True,
     )
-    head = subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
+    head = subprocess.check_output(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], text=True
+    ).strip()
     lattice_dir = repo / ".lattice"
     lattice_dir.mkdir()
     config = default_config()
@@ -882,12 +893,20 @@ def test_reachable_review_commit_policy_mutation(tmp_path: Path) -> None:
         "branch_links": [{"branch": "feature"}],
     }
     ok, _ = validate_completion_policy(
-        config, snapshot, "done", lattice_dir=lattice_dir, repo_root=repo,
+        config,
+        snapshot,
+        "done",
+        lattice_dir=lattice_dir,
+        repo_root=repo,
         prospective_review_payloads=["Lattice-Reviewed-Commit: " + "0" * 40 + "\n"],
     )
     assert ok is False
     ok, failures = validate_completion_policy(
-        config, snapshot, "done", lattice_dir=lattice_dir, repo_root=repo,
+        config,
+        snapshot,
+        "done",
+        lattice_dir=lattice_dir,
+        repo_root=repo,
         prospective_review_payloads=[f"Lattice-Reviewed-Commit: {head}\n"],
     )
     assert ok is True


### PR DESCRIPTION
## Why

`lattice code-review` could review **the wrong checkout**. An auto-fired review inherited the board root (`.lattice`'s parent) as its working directory and never carried the caller's identity, so when the board checkout sat on a *sibling agent's* branch — the normal state in a worktree-per-ticket fleet — the review resolved that branch's diff and returned a confident PASS on code the ticket never touched.

Observed in an Acetate fleet run: **4 misfires in ~10 reviews, three of them PASS.** Because the `done` completion policy is satisfied by any lifetime `review`-role artifact, a vacuous PASS is indistinguishable from a real one — three lanes would have merged unreviewed.

## What this does

1. **Binds review evidence to the caller's worktree.** `lattice status <task> review` captures the invoking checkout and passes it to the auto-fired `lattice code-review` as `--worktree`, and as the child's cwd. The prompt and the stored artifact carry `Lattice-Reviewed-Commit` / `Lattice-Reviewed-Worktree` headers, so a review states which checkout and commit it actually saw.
2. **Fails closed on missing or invalid identity.** If the caller has no git identity (`reviewed_worktree_unavailable`) or its `.git` doesn't resolve (`reviewed_worktree_not_git`), the review is **not spawned** — instead of silently falling back to the board root. The status transition itself still lands; only the review is withheld.
3. **Adds an opt-in `require_reachable_review_commit` completion policy.** When enabled, `done` requires a `review`-role artifact whose `Lattice-Reviewed-Commit` marker names a commit reachable from the task's linked branch. `lattice complete` stamps that marker from the invoking checkout's HEAD.

## Reproduction and proof

Fixture: a board checkout holding `.lattice` parked on `other-agent-wip`, plus a caller worktree on `feat/proof` holding the ticket's work; the task is not branch-linked (the realistic gap). `lattice status <task> review` run from inside the worktree, with a stub agent capturing the prompt it was handed.

| | `origin/main` (83e9fce) | this branch |
|---|---|---|
| `auto_review.reviewed_worktree` | *(absent)* | the caller worktree |
| Ticket's own file in the review prompt | 0 hits | 2 hits |
| Sibling agent's unrelated file in the prompt | **2 hits** | 0 hits |
| Verdict stored | PASS on unrelated code | review of the ticket |

Fail-closed, same fixture, caller in a directory with no git identity: `origin/main` spawns anyway with cwd = board root; this branch returns `{"fired": false, "reason": "reviewed_worktree_unavailable"}` and writes no review log. A caller whose `.git` exists but doesn't resolve yields `reviewed_worktree_not_git`.

Completion gate, live: with the policy on, `status done` is blocked (`COMPLETION_BLOCKED`, "no qualifying review artifact…"), and `lattice complete` run from the worktree stamps the worktree's HEAD sha into the artifact payload and passes.

## Rebase note

This was rebased across LAT-264, which moved `status`/`complete` validation inside the `mutate_task` decision callback. Both conflict hunks were "upstream side empty, fix side a large block" — the pre-refactor bodies. Resolution took upstream's structure and re-applied the LAT-266 deltas at their new homes inside the closures; nothing was taken-both.

One behavioral repair was needed as a result: LAT-264 also moved the review artifact's payload/meta write to *before* policy validation, so a refused `complete` left an orphaned artifact on disk — precisely the kind of stray review payload this gate exists to distrust. The mutation is now wrapped so a refusal removes both files.

## Also in this branch

Commits `06bd217` / `c052566` (**LAT-255**) ride along — they were already on this branch's base and have no separate PR. They scrub c11/cmux host-session env from headless agent spawns.

## Verification

- `2189 passed` (full suite)
- `ruff check src/ tests/` — clean
- `ruff format --check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
