### PR TITLE
Pin the model for Lattice-spawned claude reviewers

### DIFF
--- a/src/lattice/core/agent_spawn.py
+++ b/src/lattice/core/agent_spawn.py
@@ -157,6 +157,16 @@ class Backend(ABC):
 # ---------------------------------------------------------------------------
 
 
+#: Model every Lattice-spawned ``claude`` reviewer runs on. Bare ``claude``
+#: inherits the *operator's* configured default, which makes a review fleet
+#: silently as expensive as whatever the human happens to be driving that day —
+#: a nine-agent trident run on a premium default costs real money nobody chose.
+#: Reviews are a fixed, well-understood workload, so they get a fixed model.
+#: ``gemini`` has always been pinned this way (``-m gemini-3-pro-preview``);
+#: this brings ``claude`` in line. Override per-environment when you need to.
+REVIEW_CLAUDE_MODEL: str = os.environ.get("LATTICE_REVIEW_CLAUDE_MODEL", "claude-opus-5")
+
+
 def _agent_cli_command(agent_type: str, prompt_file: str, output_file: str) -> str | None:
     """Return the shell command string that runs the named agent CLI.
 
@@ -167,7 +177,8 @@ def _agent_cli_command(agent_type: str, prompt_file: str, output_file: str) -> s
     if agent_type == "claude":
         return (
             f"env {_HOST_SESSION_ENV_UNSET} "
-            f'claude --dangerously-skip-permissions -p "{instruction}"'
+            f"claude --dangerously-skip-permissions --model {REVIEW_CLAUDE_MODEL} "
+            f'-p "{instruction}"'
         )
     if agent_type == "codex":
         return f'codex exec --full-auto --skip-git-repo-check "{instruction}"'

--- a/src/lattice/integrations/c11.py
+++ b/src/lattice/integrations/c11.py
@@ -35,6 +35,7 @@ from pathlib import Path
 
 from lattice.cli.c11_bridge import _run_c11 as _bridge_run_c11
 from lattice.core.agent_spawn import (
+    REVIEW_CLAUDE_MODEL,
     Backend,
     BackendUnavailableError,
     ProgressCallback,
@@ -232,7 +233,10 @@ def spawn_one_in_current_workspace(
 
     cd_cmd = f"cd {shlex.quote(str(cwd))}"
     instruction = f"Read {shlex.quote(str(prompt_path))} and follow the instructions."
-    claude_cmd = f'claude --dangerously-skip-permissions "{instruction}"'
+    claude_cmd = (
+        f"claude --dangerously-skip-permissions "
+        f'--model {REVIEW_CLAUDE_MODEL} "{instruction}"'
+    )
     line = f"{cd_cmd} && {claude_cmd}"
 
     _bridge_run_c11(

--- a/src/lattice/integrations/c11.py
+++ b/src/lattice/integrations/c11.py
@@ -234,8 +234,7 @@ def spawn_one_in_current_workspace(
     cd_cmd = f"cd {shlex.quote(str(cwd))}"
     instruction = f"Read {shlex.quote(str(prompt_path))} and follow the instructions."
     claude_cmd = (
-        f"claude --dangerously-skip-permissions "
-        f'--model {REVIEW_CLAUDE_MODEL} "{instruction}"'
+        f'claude --dangerously-skip-permissions --model {REVIEW_CLAUDE_MODEL} "{instruction}"'
     )
     line = f"{cd_cmd} && {claude_cmd}"
 


### PR DESCRIPTION
Both review spawn paths ran bare `claude`, so every Lattice-spawned reviewer inherited whatever model the operator had configured as their default. A nine-agent trident plan review therefore costs whatever the human happens to be driving that day, chosen by nobody.

Found while auditing why four Trident panes fired at once on the c11 board: those four runs came to roughly $81 on a premium default.

Reviews are a fixed, well-understood workload, so they get a fixed model. `REVIEW_CLAUDE_MODEL` defaults to `claude-opus-5`, overridable via `LATTICE_REVIEW_CLAUDE_MODEL`. Applied to both paths:

- `core/agent_spawn.py` — the headless single-review path
- `integrations/c11.py` — the trident c11 pane

`gemini` has always been pinned this way (`-m gemini-3-pro-preview`); this brings `claude` in line. `codex` has no model flag in this path and is unchanged.

Full suite: 2189 passed. `ruff check src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)