### PR TITLE
LAT-268: make failed and abandoned reviews visible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,8 @@ cat .lattice/config.json | python3 -c "import sys,json; d=json.load(sys.stdin); 
 
 **The test:** If the same agent that wrote the code also reviewed it without a fresh context boundary, the review gate is not doing its job. The whole point is independent verification.
 
+**When a review fails.** A review that produces no artifact leaves the task unreviewed, and says so where you will see it: `lattice code-review` / `plan-review` exits non-zero, a comment naming the failure lands on the task's event log, and an *auto-fired* failure also raises `needs-human` — because nobody is reading a detached subprocess's exit code. A review whose process died without recording a result (machine sleep, closed terminal, reaped child) reports as `abandoned` in `lattice review-status`, not as still running. Treat all three the same way: the task has not been reviewed, so re-run the review before moving to `done`.
+
 **Review content validation:** Before trusting a review artifact and moving to `done`, the orchestrator must sanity-check that the content is an actual review — not an error message, stack trace, agent crash output, or empty boilerplate. A valid review references the code (files, sections, or acceptance criteria), contains a verdict (pass/fail), and reads like a human wrote it. If the review content looks like agent failure output, treat it as a failed review and re-run. This is a 5-second gut check, not a deep analysis.
 
 ### Review Verdict Routing
@@ -353,7 +355,7 @@ Max cycles:   3 review->rework transitions, then CLI blocks -> set needs-human f
 
 ### Review Config Reference
 
-Five settings in `.lattice/config.json` control review behavior:
+These settings in `.lattice/config.json` control review behavior:
 
 | Setting | Values | Default | Meaning |
 |---------|--------|---------|---------|
@@ -362,6 +364,9 @@ Five settings in `.lattice/config.json` control review behavior:
 | `plan_approval` | `auto`, `human` | `auto` | After plan-review: `auto` proceeds, `human` sets the `needs-human` flag (task stays in `planned`) for approval |
 | `auto_code_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice code-review` when a task transitions to `review` |
 | `auto_plan_review_on_transition` | `true`, `false` | `true` | Auto-spawn `lattice plan-review` when a task transitions to `planned` |
+| `review_timeout_seconds` | integer | `600` | Wall-clock budget for one review agent |
+| `review_max_diff_lines` | integer | `5000` | Ceiling on diff lines embedded in the prompt |
+| `review_max_diff_chars` | integer | `120000` | Ceiling on diff **characters**. The line cap alone does not bound prompt size — a wide diff (lockfiles, generated code) runs to hundreds of thousands of characters at 5000 lines — and prompt size is the dominant term in review wall-clock. |
 
 **`inline`** — review happens in the same agent session (no subprocess spawned).
 **`single`** — one review agent is spawned; result stored as a `review` or `plan-review` artifact.

--- a/Decisions.md
+++ b/Decisions.md
@@ -832,3 +832,33 @@ Additionally, `lattice advance N` processed multiple tasks in a single context w
 - **Consequence:** Criteria add precise local contracts and evidence navigation
   without creating a criterion database/index/entity, correction event,
   inherited policy, mandatory planning ritual, or new dependency.
+
+---
+
+## 2026-08-14: A failed review reports itself on the task (LAT-268)
+
+- **Decision:** A review that produces no artifact is a failed command. It exits
+  non-zero, records a `comment_added` event on the task it was reviewing, and —
+  when it was auto-fired, so no caller is reading the exit code — sets
+  `needs_human`. The pre-existing `failures.jsonl` line and per-task `.daemon`
+  log remain, as diagnostics rather than as the only signal.
+- **Evidence:** On one board, 49 recorded review failures over three days
+  produced zero signals reachable from `lattice show`, `lattice list`, or an
+  exit status. The failures were real (29 timeouts, 19 exits with code 1) and
+  the tasks sat in `review` looking reviewed. 222 auto-fired reviews on the same
+  board succeeded, which is exactly why the failures went unnoticed.
+- **Abandoned ≠ in flight:** A review whose owning process is gone without
+  writing a terminal status never reaches its own failure handler, so it leaves
+  a record reading `running` forever (24 such records on the same board).
+  `review-status` now checks the holder PID and reports `abandoned`.
+- **Provenance:** The child review process claims `review_state` with
+  `auto_fired` derived from `--triggered-by`, which only the auto-fire path
+  passes. The previous adoption test required the spawning parent to still be
+  alive, which a detached child almost never observes, so every record on every
+  board claimed `auto_fired: false`.
+- **Prompt size:** `review_max_diff_lines` caps hunks, not bytes; 5000 lines of
+  a wide diff measured at 200k–509k characters. `review_max_diff_chars`
+  (default 120000) caps the prompt itself. Measured on this machine: a 14.5k
+  prompt returned in 45s, a 209k prompt in 232s of a 600s budget.
+- **Consequence:** No new files, daemons, or schema versions. The failure paths
+  write to surfaces that already exist and that agents already read.

--- a/src/lattice/cli/review_cmds.py
+++ b/src/lattice/cli/review_cmds.py
@@ -23,11 +23,14 @@ from lattice.cli.helpers import (
 )
 from lattice.cli.main import cli
 from lattice.core.review import (
+    DEFAULT_MAX_DIFF_CHARS,
     DEFAULT_MAX_DIFF_LINES,
     cap_diff,
+    cap_diff_chars,
     claim_review_state,
     cleanup_temp_files,
     clear_review_state,
+    is_review_abandoned,
     last_failure_for_task,
     read_review_state,
     run_single_review,
@@ -79,10 +82,14 @@ def _claim_or_refuse(
     — bypassing the live-other-PID refusal that would otherwise fire,
     because the "other" PID is our spawning parent.
 
-    Otherwise call ``claim_review_state(..., auto_fired=False)``: the
-    standard stale-PID reclaim handles the typical case (parent exited
-    before child reached this point), and the live-other-PID refusal
-    handles real contention.
+    Otherwise call ``claim_review_state(...)``: the standard stale-PID
+    reclaim handles the typical case (parent exited before child reached
+    this point), and the live-other-PID refusal handles real contention.
+    ``auto_fired`` carries over from ``--triggered-by``, which only the
+    auto-fire path ever passes — the adoption branch above depends on the
+    parent still being alive, which it usually is not by the time the
+    detached child gets here, so without this the record claimed that no
+    review on the board was ever auto-fired.
 
     Logs the friendly "review already in flight" message and exits 1
     (or returns the structured error for ``--json``) on contention.
@@ -113,7 +120,7 @@ def _claim_or_refuse(
         mode=mode,
         review_type=review_type,
         started_by_pid=os.getpid(),
-        auto_fired=False,
+        auto_fired=triggered_by is not None,
     )
     if claimed:
         return
@@ -270,6 +277,18 @@ def code_review(
             err=True,
         )
 
+    # The line cap does not bound prompt size: 5000 lines of a wide diff runs to
+    # hundreds of thousands of characters, and prompt size is what pushes a
+    # review past its timeout. Cap the characters too.
+    max_diff_chars = config.get("review_max_diff_chars", DEFAULT_MAX_DIFF_CHARS)
+    diff_content, chars_capped, diff_chars = cap_diff_chars(diff_content, max_diff_chars)
+    if chars_capped and not quiet:
+        click.echo(
+            f"Note: diff is {diff_chars} characters — truncated to {max_diff_chars} "
+            f"for review (configurable via review_max_diff_chars).",
+            err=True,
+        )
+
     # Load and fill review template
     template = load_review_template(lattice_dir, "code-review")
     plan_content = _read_plan(lattice_dir, task_id)
@@ -301,9 +320,11 @@ def code_review(
             quiet=quiet,
             model=model,
             session=session,
+            config=config,
             timeout=timeout,
             worktree=reviewed_worktree,
             reviewed_sha=reviewed_sha,
+            auto_fired=triggered_by is not None,
         )
 
     elif mode == "triple":
@@ -434,7 +455,9 @@ def plan_review(
             quiet=quiet,
             model=model,
             session=session,
+            config=config,
             timeout=timeout,
+            auto_fired=triggered_by is not None,
         )
         if art_id and plan_approval == "human":
             _flag_needs_human(lattice_dir, task_id, actor, is_json)
@@ -470,6 +493,7 @@ def _echo_review_failure(
     stderr_tail: str | None = None,
     when: str | None = None,
     source: str | None = None,
+    review_type: str = "code-review",
 ) -> None:
     """Print a clear, diagnosable FAILED report for a review."""
     header = f"Review FAILED for {task_id}"
@@ -485,7 +509,7 @@ def _echo_review_failure(
         click.echo(f"  duration:     {duration}s")
     if stderr_tail:
         click.echo(f"  stderr tail:  {stderr_tail}")
-    click.echo(f"  Re-run with:  lattice code-review {task_id}")
+    click.echo(f"  Re-run with:  lattice {review_type} {task_id}")
 
 
 @cli.command("review-status")
@@ -527,6 +551,7 @@ def review_status(task_id: str, output_json: bool) -> None:
                     stderr_tail=failure.get("stderr_tail"),
                     when=failure.get("timestamp"),
                     source="failures.jsonl",
+                    review_type=failure.get("review_type") or "code-review",
                 )
             else:
                 click.echo(
@@ -549,6 +574,28 @@ def review_status(task_id: str, output_json: bool) -> None:
                 stderr_tail=detail.get("stderr_tail"),
                 when=state.get("finished_at"),
                 source="in-flight review record",
+                review_type=state.get("review_type") or "code-review",
+            )
+        return
+
+    # An in-flight record whose owning process is gone is not in flight — it is
+    # abandoned. Rendering it as "running" is what let 24 killed reviews on one
+    # board read as still-in-progress days after the process died.
+    if is_review_abandoned(state):
+        state = dict(state)
+        state["status"] = "abandoned"
+        if is_json:
+            click.echo(json.dumps({"ok": True, "data": state}, indent=2))
+        else:
+            _echo_review_failure(
+                task_id,
+                error=(
+                    f"review process (pid {state.get('started_by_pid')}) is gone and never "
+                    f"recorded a result — the review was abandoned, not completed"
+                ),
+                when=state.get("started_at"),
+                source="in-flight review record (dead holder pid)",
+                review_type=state.get("review_type") or "code-review",
             )
         return
 
@@ -597,6 +644,87 @@ def review_status(task_id: str, output_json: bool) -> None:
 # ---------------------------------------------------------------------------
 
 
+#: Stable prefix on the comment a failed review leaves on its own task. Kept
+#: greppable so a reader (or a future dashboard lane) can find every review
+#: that never produced a verdict.
+REVIEW_FAILURE_COMMENT_PREFIX = "Automated review failed"
+
+
+def _report_review_failure(
+    lattice_dir: Path,
+    task_id: str,
+    *,
+    review_type: str,
+    message: str,
+    actor: str | dict,
+    config: dict,
+    auto_fired: bool,
+) -> None:
+    """Leave the failure where a human or agent will actually meet it.
+
+    A failed review used to write one line to ``failures.jsonl`` and one line
+    to a per-task ``.daemon`` log — two files nobody opens — while the task
+    itself carried no trace at all and the command still exited 0. The task
+    then sat in ``review`` looking reviewed. This records the failure on the
+    task's own event log, and for an auto-fired review (where by definition no
+    caller is watching the exit code) also raises ``needs_human``.
+
+    Best-effort by construction: reporting a failure must never raise over the
+    top of the failure it is reporting, so every step is guarded.
+    """
+    from lattice.cli.auto_review import log_path_for
+    from lattice.core.events import create_event
+    from lattice.storage.operations import TaskMutationDecision, mutate_task
+
+    log_path = log_path_for(lattice_dir, review_type, task_id)
+    body_lines = [
+        f"{REVIEW_FAILURE_COMMENT_PREFIX}: {review_type} — {message}",
+        "",
+        "No review artifact was produced, so this task has NOT been reviewed.",
+        f"Re-run with: lattice {review_type} {task_id}",
+    ]
+    if auto_fired and log_path.exists():
+        body_lines.append(f"Spawn log: {log_path}")
+    body = "\n".join(body_lines)
+
+    def decide_comment(context):  # noqa: ANN001, ANN202
+        event = create_event(
+            type="comment_added",
+            task_id=task_id,
+            actor=actor,
+            data={"body": body},
+        )
+        return TaskMutationDecision(events=[event])
+
+    try:
+        mutate_task(lattice_dir, task_id, decide_comment, config)
+    except Exception:  # noqa: BLE001 — never mask the review failure
+        click.echo("Warning: could not record the review failure as a comment.", err=True)
+
+    if not auto_fired:
+        return
+
+    def decide_flag(context):  # noqa: ANN001, ANN202
+        snapshot = context.snapshot
+        assert snapshot is not None
+        if snapshot.get("needs_human"):
+            return TaskMutationDecision(events=[])
+        event = create_event(
+            type="needs_human_flagged",
+            task_id=task_id,
+            actor=actor,
+            data={
+                "reason": (f"Auto-fired {review_type} failed ({message}) — task is unreviewed.")
+            },
+        )
+        return TaskMutationDecision(events=[event])
+
+    try:
+        mutate_task(lattice_dir, task_id, decide_flag, config)
+    except Exception:  # noqa: BLE001 — never mask the review failure
+        click.echo("Warning: could not flag the task for human attention.", err=True)
+
+
 def _run_single_and_store(
     *,
     lattice_dir: Path,
@@ -609,9 +737,11 @@ def _run_single_and_store(
     quiet: bool,
     model: str | None,
     session: str | None,
+    config: dict,
     timeout: int = 600,
     worktree: Path | None = None,
     reviewed_sha: str | None = None,
+    auto_fired: bool = False,
 ) -> str | None:
     """Run single-agent review, store artifact, print result. Returns artifact ID or None."""
     click.echo(f"Running {review_type} (single mode)...")
@@ -627,9 +757,19 @@ def _run_single_and_store(
     )
 
     if not success:
-        click.echo(f"Review failed: {message}", err=True)
         cleanup_temp_files(task_id)
-        return None
+        _report_review_failure(
+            lattice_dir,
+            task_id,
+            review_type=review_type,
+            message=message,
+            actor=actor,
+            config=config,
+            auto_fired=auto_fired,
+        )
+        # Exit non-zero: a review that produced no verdict is a failed command,
+        # not a successful one that happened to print a warning.
+        output_error(f"Review failed: {message}", "REVIEW_FAILED", is_json)
 
     assert text is not None
     art_id = _attach_review_artifact(

--- a/src/lattice/core/config.py
+++ b/src/lattice/core/config.py
@@ -173,6 +173,7 @@ class LatticeConfig(TypedDict, total=False):
     plan_approval: Literal["auto", "human"]
     review_timeout_seconds: int
     review_max_diff_lines: int
+    review_max_diff_chars: int
     auto_code_review_on_transition: bool
     auto_plan_review_on_transition: bool
     done_display: Literal["all", "recent", "grouped"]
@@ -431,6 +432,7 @@ def default_config(preset: str = "classic", status_preset: str = "stage11") -> L
         "plan_approval": "auto",
         "review_timeout_seconds": 600,
         "review_max_diff_lines": 5000,
+        "review_max_diff_chars": 120000,
         "auto_code_review_on_transition": True,
         "auto_plan_review_on_transition": True,
         "done_display": "grouped",

--- a/src/lattice/core/review.py
+++ b/src/lattice/core/review.py
@@ -47,6 +47,14 @@ FAILURE_THRESHOLD = 2  # auto-create diagnostic task after this many failures
 #: ``review_max_diff_lines``.
 DEFAULT_MAX_DIFF_LINES = 5000
 
+#: Default ceiling on diff *characters* embedded in a review prompt. The line
+#: cap alone does not bound prompt size — 5000 lines of a wide diff (lockfiles,
+#: minified assets, generated code) measured at ~200k-500k characters in the
+#: field, and prompt size is the dominant term in review wall-clock: a 14.5k
+#: prompt returned in 45s where a 209k prompt took 232s of the 600s budget.
+#: Configurable via ``review_max_diff_chars``; non-positive disables the cap.
+DEFAULT_MAX_DIFF_CHARS = 120_000
+
 REVIEW_STATE_DIR = "review_state"
 TMP_PROMPTS_DIR = "tmp-prompts"
 FAILURES_FILE = "failures.jsonl"
@@ -118,13 +126,13 @@ def cleanup_prompt_dirs(lattice_dir: Path) -> int:
 #      the parent's claim, not contending with a stranger.
 #
 #    * **Normal claim.**  Otherwise (no record, stale parent PID, or no
-#      ``--triggered-by``) the child calls
-#      ``claim_review_state(..., auto_fired=False)``. The standard stale-PID
+#      ``--triggered-by``) the child calls ``claim_review_state`` with
+#      ``auto_fired=(triggered_by is not None)``. The standard stale-PID
 #      reclaim path overwrites the parent's dead record with the child's
-#      live PID. ``auto_fired=False`` here is intentional: ``review_state``
-#      is transient coordination state; the durable "this review was
-#      auto-fired" signal lives in the ``auto_review_spawned`` event in the
-#      task's event log.
+#      live PID, and ``--triggered-by`` — passed only by the auto-fire path —
+#      carries the provenance across the handoff. The durable audit signal
+#      still lives in the ``auto_review_spawned`` event; this keeps the
+#      transient record from contradicting it.
 #
 # 3. **``run_single_review`` / ``run_triple_review``.**  Once inside the
 #    review orchestrator the existing in-place ``write_review_state`` calls
@@ -610,6 +618,54 @@ def cap_diff(diff: str, max_lines: int = DEFAULT_MAX_DIFF_LINES) -> tuple[str, b
         f"review_max_diff_lines.]\n"
     )
     return kept + marker, True, original
+
+
+def cap_diff_chars(diff: str, max_chars: int = DEFAULT_MAX_DIFF_CHARS) -> tuple[str, bool, int]:
+    """Cap a diff to ``max_chars``, truncating with a visible marker if over.
+
+    Returns ``(possibly_truncated_diff, was_capped, original_char_count)``.
+
+    Complements :func:`cap_diff`: a line cap bounds how many hunks the reviewer
+    sees, a character cap bounds how big the prompt actually gets. Only the
+    second one bounds review latency, so both are applied. Truncation happens on
+    a line boundary where one exists inside the budget, so the agent never reads
+    half a diff line. A non-positive ``max_chars`` disables the cap.
+    """
+    original = len(diff)
+    if max_chars <= 0 or original <= max_chars:
+        return diff, False, original
+    kept = diff[:max_chars]
+    boundary = kept.rfind("\n")
+    if boundary > 0:
+        kept = kept[:boundary]
+    omitted = original - len(kept)
+    marker = (
+        f"\n\n[diff truncated by Lattice: showing first {len(kept)} of {original} "
+        f"characters; {omitted} characters omitted. Review the most significant changes "
+        f"above; if the change is genuinely this large, narrow the diff with --base or "
+        f"raise review_max_diff_chars.]\n"
+    )
+    return kept + marker, True, original
+
+
+def is_review_abandoned(state: dict) -> bool:
+    """True when an in-flight review record's owning process is gone.
+
+    A review subprocess that is killed — machine sleep, terminal closed, an
+    orchestrator reaping its children — never reaches its own failure handler,
+    so it writes no terminal ``status`` and no ``failures.jsonl`` line. The
+    record it leaves behind says ``agents[0].status == "running"`` forever, and
+    every reader reports the review as still in flight. Detecting the dead
+    holder PID is what turns that silence back into a signal.
+    """
+    if not isinstance(state, dict):
+        return False
+    if state.get("status") in ("failed", "done", "abandoned"):
+        return False
+    holder = state.get("started_by_pid")
+    if not isinstance(holder, int):
+        return False
+    return not pid_alive(holder)
 
 
 def _find_git_root(lattice_dir: Path) -> Path | None:

--- a/tests/test_cli/test_review_cmds.py
+++ b/tests/test_cli/test_review_cmds.py
@@ -408,8 +408,11 @@ class TestCodeReviewSingle:
                 env={"LATTICE_ROOT": str(root)},
                 catch_exceptions=False,
             )
-        # Agent failure should result in non-zero exit or error message
-        assert result.exit_code != 0 or "failed" in result.output
+        # Agent failure is a failed command: non-zero exit AND a stated reason.
+        # (The `or` this assertion used to allow is exactly how an exit-0
+        # failure path stayed green for two days of silent review failures.)
+        assert result.exit_code != 0
+        assert "failed" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -554,6 +557,8 @@ class TestReviewClaimAndDisplay:
     """Coordination tests for the review_state claim path (LAT-211)."""
 
     def test_review_status_displays_auto_fired_field(self, tmp_path: Path) -> None:
+        import os
+
         from lattice.core.review import write_review_state
 
         root = _make_board(tmp_path)
@@ -566,7 +571,7 @@ class TestReviewClaimAndDisplay:
                 "mode": "triple",
                 "review_type": "code-review",
                 "started_at": "2026-05-06T00:00:00Z",
-                "started_by_pid": 4242,
+                "started_by_pid": os.getpid(),
                 "auto_fired": True,
                 "agents": [],
             },
@@ -580,9 +585,11 @@ class TestReviewClaimAndDisplay:
         assert result.exit_code == 0
         assert "auto_fired:" in result.output
         assert "True" in result.output
-        assert "started_by_pid 4242" in result.output
+        assert f"started_by_pid {os.getpid()}" in result.output
 
     def test_review_status_json_round_trips_new_fields(self, tmp_path: Path) -> None:
+        import os
+
         from lattice.core.review import write_review_state
 
         root = _make_board(tmp_path)
@@ -595,7 +602,7 @@ class TestReviewClaimAndDisplay:
                 "mode": "single",
                 "review_type": "code-review",
                 "started_at": "2026-05-06T00:00:00Z",
-                "started_by_pid": 9999,
+                "started_by_pid": os.getpid(),
                 "auto_fired": False,
                 "agents": [],
             },
@@ -609,7 +616,7 @@ class TestReviewClaimAndDisplay:
         assert result.exit_code == 0
         data = json.loads(result.output)["data"]
         assert data["auto_fired"] is False
-        assert data["started_by_pid"] == 9999
+        assert data["started_by_pid"] == os.getpid()
 
     def test_code_review_refuses_when_live_other_pid_holds(self, tmp_path: Path) -> None:
         import os
@@ -890,3 +897,378 @@ class TestDiffResolution:
             success, msg = resolve_diff(tmp_path / ".lattice", "task_01ABC", {})
         assert success is False
         assert "--base" in msg
+
+
+# ---------------------------------------------------------------------------
+# Tests: a failed review has to be visible (LAT-267)
+# ---------------------------------------------------------------------------
+
+#: A pid above macOS/Linux pid_max — os.kill() on it always raises
+#: ProcessLookupError, so it is a deterministically dead holder.
+DEAD_PID = 4_000_000
+
+
+def _snapshot(root: Path, task_id: str) -> dict:
+    return json.loads((root / LATTICE_DIR / "tasks" / f"{task_id}.json").read_text())
+
+
+def _comment_bodies(root: Path, task_id: str) -> list[str]:
+    path = root / LATTICE_DIR / "events" / f"{task_id}.jsonl"
+    bodies = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        event = json.loads(line)
+        if event.get("type") == "comment_added":
+            bodies.append(event.get("data", {}).get("body", ""))
+    return bodies
+
+
+def _run_failing_code_review(runner: CliRunner, root: Path, task_id: str, *extra: str):
+    with (
+        patch(
+            "lattice.cli.review_cmds.resolve_diff",
+            return_value=(True, "diff --git a/foo.py b/foo.py\n+print('hello')"),
+        ),
+        patch(
+            "lattice.cli.review_cmds.run_single_review",
+            return_value=(False, "Agent 'claude' timed out after 600s", None),
+        ),
+    ):
+        return runner.invoke(
+            cli,
+            ["code-review", task_id, "--mode", "single", "--actor", "agent:test", *extra],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+
+
+class TestFailedReviewIsVisible:
+    def test_failure_exits_non_zero(self, tmp_path):
+        root = _make_board(tmp_path, {"review_mode": "single"})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        result = _run_failing_code_review(runner, root, task_id)
+
+        assert result.exit_code != 0, result.output
+        assert "timed out after 600s" in result.output
+
+    def test_success_still_exits_zero(self, tmp_path):
+        """Positive pair for the exit-code assertion above."""
+        root = _make_board(tmp_path, {"review_mode": "single"})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        with (
+            patch(
+                "lattice.cli.review_cmds.resolve_diff",
+                return_value=(True, "diff --git a/foo.py b/foo.py\n+print('hello')"),
+            ),
+            patch(
+                "lattice.cli.review_cmds.run_single_review",
+                return_value=(True, "Review complete.", "### 1. Verdict\n**PASS**"),
+            ),
+            patch("lattice.cli.review_cmds._attach_review_artifact", return_value="art_fake"),
+        ):
+            result = runner.invoke(
+                cli,
+                ["code-review", task_id, "--mode", "single", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert not any("Automated review failed" in b for b in _comment_bodies(root, task_id))
+
+    def test_failure_comments_on_the_task(self, tmp_path):
+        root = _make_board(tmp_path, {"review_mode": "single"})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        _run_failing_code_review(runner, root, task_id)
+
+        bodies = [b for b in _comment_bodies(root, task_id) if "Automated review failed" in b]
+        assert bodies, (
+            f"no failure comment recorded; comments were {_comment_bodies(root, task_id)}"
+        )
+        assert "timed out after 600s" in bodies[0]
+        assert "has NOT been reviewed" in bodies[0]
+
+    def test_manual_failure_does_not_flag_needs_human(self, tmp_path):
+        """A human/agent running the command sees the non-zero exit directly."""
+        root = _make_board(tmp_path, {"review_mode": "single"})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        _run_failing_code_review(runner, root, task_id)
+
+        assert not _snapshot(root, task_id).get("needs_human")
+
+    def test_auto_fired_failure_flags_needs_human(self, tmp_path):
+        """Nobody is reading an auto-fired review's exit code, so raise the flag."""
+        root = _make_board(tmp_path, {"review_mode": "single"})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        _run_failing_code_review(runner, root, task_id, "--triggered-by", "ev_fake")
+
+        snapshot = _snapshot(root, task_id)
+        flag = snapshot.get("needs_human")
+        assert flag, "auto-fired review failure left no needs_human flag"
+        assert "unreviewed" in flag["reason"]
+
+    def test_plan_review_failure_exits_non_zero_and_comments(self, tmp_path):
+        root = _make_board(tmp_path, {"plan_review_mode": "single"})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        _write_plan(root, task_id, "# Plan\n\nApproach: implement it.\n")
+
+        with patch(
+            "lattice.cli.review_cmds.run_single_review",
+            return_value=(False, "Agent 'claude' timed out after 600s", None),
+        ):
+            result = runner.invoke(
+                cli,
+                ["plan-review", task_id, "--mode", "single", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code != 0, result.output
+        assert any("Automated review failed" in b for b in _comment_bodies(root, task_id))
+
+    def test_failure_json_mode_is_an_error_envelope(self, tmp_path):
+        root = _make_board(tmp_path, {"review_mode": "single"})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        result = _run_failing_code_review(runner, root, task_id, "--json")
+
+        assert result.exit_code != 0
+        payload = json.loads(result.output[result.output.index("{") :])
+        assert payload["ok"] is False
+        assert payload["error"]["code"] == "REVIEW_FAILED"
+
+
+class TestAbandonedReviewIsVisible:
+    def _seed(self, root: Path, task_id: str, pid: int) -> None:
+        from lattice.core.review import write_review_state
+
+        write_review_state(
+            root / LATTICE_DIR,
+            {
+                "task_id": task_id,
+                "mode": "single",
+                "review_type": "code-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "started_by_pid": pid,
+                "auto_fired": True,
+                "agents": [
+                    {"name": "claude", "status": "running", "started_at": "2026-05-06T00:00:00Z"}
+                ],
+            },
+        )
+
+    def test_dead_holder_reports_abandoned(self, tmp_path):
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        self._seed(root, task_id, DEAD_PID)
+
+        result = runner.invoke(
+            cli,
+            ["review-status", task_id],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "abandoned" in result.output
+        assert "running" not in result.output
+
+    def test_live_holder_still_reports_running(self, tmp_path):
+        """Positive pair: the same seed with a live pid is still in flight."""
+        import os
+
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        self._seed(root, task_id, os.getpid())
+
+        result = runner.invoke(
+            cli,
+            ["review-status", task_id],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "running" in result.output
+        assert "abandoned" not in result.output
+
+    def test_dead_holder_reports_abandoned_json(self, tmp_path):
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        self._seed(root, task_id, DEAD_PID)
+
+        result = runner.invoke(
+            cli,
+            ["review-status", task_id, "--json"],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert json.loads(result.output)["data"]["status"] == "abandoned"
+
+
+class TestAutoFiredProvenanceSurvivesTheHandoff:
+    def test_triggered_by_child_claims_as_auto_fired(self, tmp_path):
+        """The detached child usually outlives its parent, so adoption can't carry this."""
+        from lattice.core.review import read_review_state
+
+        root = _make_board(tmp_path, {"review_mode": "single"})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        with (
+            patch(
+                "lattice.cli.review_cmds.resolve_diff",
+                return_value=(True, "diff --git a/x.py b/x.py\n"),
+            ),
+            patch("lattice.cli.review_cmds.run_single_review", return_value=(True, "ok", "PASS")),
+            patch("lattice.cli.review_cmds._attach_review_artifact", return_value="art_fake"),
+        ):
+            runner.invoke(
+                cli,
+                [
+                    "code-review",
+                    task_id,
+                    "--mode",
+                    "single",
+                    "--actor",
+                    "agent:test",
+                    "--triggered-by",
+                    "ev_fake",
+                ],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+
+        # run_single_review is mocked, so the claim record it would have
+        # rewritten (and cleared) is still exactly as the CLI body wrote it.
+        state = read_review_state(root / LATTICE_DIR, task_id)
+        assert state is not None
+        assert state["auto_fired"] is True
+
+    def test_manual_child_claims_as_not_auto_fired(self, tmp_path):
+        from lattice.core.review import read_review_state
+
+        root = _make_board(tmp_path, {"review_mode": "single"})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        with (
+            patch(
+                "lattice.cli.review_cmds.resolve_diff",
+                return_value=(True, "diff --git a/x.py b/x.py\n"),
+            ),
+            patch("lattice.cli.review_cmds.run_single_review", return_value=(True, "ok", "PASS")),
+            patch("lattice.cli.review_cmds._attach_review_artifact", return_value="art_fake"),
+        ):
+            runner.invoke(
+                cli,
+                ["code-review", task_id, "--mode", "single", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+
+        state = read_review_state(root / LATTICE_DIR, task_id)
+        assert state is not None
+        assert state["auto_fired"] is False
+
+
+class TestDiffCharCap:
+    def test_prompt_is_bounded_by_char_cap(self, tmp_path):
+        """5000 lines of a wide diff is still a quarter-million-character prompt."""
+        root = _make_board(tmp_path, {"review_mode": "single", "review_max_diff_chars": 20_000})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        wide_diff = "\n".join(f"+{'x' * 500}" for _ in range(200))  # 100k chars, 200 lines
+        with (
+            patch("lattice.cli.review_cmds.resolve_diff", return_value=(True, wide_diff)),
+            patch(
+                "lattice.cli.review_cmds.run_single_review", return_value=(True, "ok", "PASS")
+            ) as run_single,
+            patch("lattice.cli.review_cmds._attach_review_artifact", return_value="art_fake"),
+        ):
+            result = runner.invoke(
+                cli,
+                ["code-review", task_id, "--mode", "single", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        prompt = run_single.call_args.kwargs["prompt_content"]
+        # The line cap (5000) never fires here — only the char cap can bound this.
+        assert len(prompt) < 25_000, f"prompt was {len(prompt)} chars"
+        assert "diff truncated by Lattice" in prompt
+
+    def test_small_diff_is_not_truncated(self, tmp_path):
+        root = _make_board(tmp_path, {"review_mode": "single"})
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+
+        diff = "diff --git a/foo.py b/foo.py\n+print('hello')"
+        with (
+            patch("lattice.cli.review_cmds.resolve_diff", return_value=(True, diff)),
+            patch(
+                "lattice.cli.review_cmds.run_single_review", return_value=(True, "ok", "PASS")
+            ) as run_single,
+            patch("lattice.cli.review_cmds._attach_review_artifact", return_value="art_fake"),
+        ):
+            runner.invoke(
+                cli,
+                ["code-review", task_id, "--mode", "single", "--actor", "agent:test"],
+                env={"LATTICE_ROOT": str(root)},
+                catch_exceptions=False,
+            )
+
+        prompt = run_single.call_args.kwargs["prompt_content"]
+        assert "diff truncated by Lattice" not in prompt
+        assert "print('hello')" in prompt
+
+
+class TestFailureReportNamesTheRightCommand:
+    def test_plan_review_failure_suggests_plan_review_rerun(self, tmp_path):
+        from lattice.core.review import write_review_state
+
+        root = _make_board(tmp_path)
+        runner = CliRunner()
+        task_id = _create_task(runner, root)
+        write_review_state(
+            root / LATTICE_DIR,
+            {
+                "task_id": task_id,
+                "mode": "single",
+                "review_type": "plan-review",
+                "started_at": "2026-05-06T00:00:00Z",
+                "status": "failed",
+                "error": "timed out after 600s",
+                "agents": [],
+            },
+        )
+
+        result = runner.invoke(
+            cli,
+            ["review-status", task_id],
+            env={"LATTICE_ROOT": str(root)},
+            catch_exceptions=False,
+        )
+
+        assert f"lattice plan-review {task_id}" in result.output
+        assert "lattice code-review" not in result.output

--- a/tests/test_core/test_review.py
+++ b/tests/test_core/test_review.py
@@ -865,3 +865,65 @@ class TestResolveDiffWorktree:
         success, diff = review_mod.resolve_diff(lattice_dir, "task_01", {}, worktree=wt)
         assert success is True
         assert "ticket change" in diff
+
+
+class TestDiffCharCap:
+    def test_under_cap_unchanged(self) -> None:
+        diff = "\n".join(f"line {i}" for i in range(10))
+        capped, was_capped, original = review_mod.cap_diff_chars(diff, max_chars=10_000)
+        assert capped == diff
+        assert was_capped is False
+        assert original == len(diff)
+
+    def test_over_cap_truncates_on_a_line_boundary(self) -> None:
+        diff = "\n".join("x" * 100 for _ in range(100))  # ~10k chars, 100 lines
+        capped, was_capped, original = review_mod.cap_diff_chars(diff, max_chars=1_000)
+        assert was_capped is True
+        assert original == len(diff)
+        assert "diff truncated by Lattice" in capped
+        body = capped.split("\n\n[diff truncated")[0]
+        assert len(body) <= 1_000
+        # No half-line handed to the reviewer.
+        assert all(len(line) == 100 for line in body.splitlines())
+
+    def test_zero_disables_cap(self) -> None:
+        diff = "x" * 5_000
+        capped, was_capped, _ = review_mod.cap_diff_chars(diff, max_chars=0)
+        assert capped == diff
+        assert was_capped is False
+
+    def test_line_cap_alone_does_not_bound_a_wide_diff(self) -> None:
+        """The reason a character cap exists at all."""
+        wide = "\n".join("+" + "x" * 500 for _ in range(5_000))
+        line_capped, was_capped, _ = cap_diff(wide, max_lines=5_000)
+        assert was_capped is False
+        assert len(line_capped) > 2_000_000
+        char_capped, was_capped, _ = review_mod.cap_diff_chars(line_capped, max_chars=120_000)
+        assert was_capped is True
+        assert len(char_capped) < 121_000
+
+
+class TestAbandonedReviewDetection:
+    def test_dead_holder_is_abandoned(self) -> None:
+        state = {
+            "task_id": "task_01",
+            "started_by_pid": 4_000_000,
+            "agents": [{"name": "claude", "status": "running"}],
+        }
+        assert review_mod.is_review_abandoned(state) is True
+
+    def test_live_holder_is_not_abandoned(self) -> None:
+        state = {
+            "task_id": "task_01",
+            "started_by_pid": os.getpid(),
+            "agents": [{"name": "claude", "status": "running"}],
+        }
+        assert review_mod.is_review_abandoned(state) is False
+
+    def test_terminal_status_is_not_abandoned(self) -> None:
+        state = {"task_id": "task_01", "started_by_pid": 4_000_000, "status": "failed"}
+        assert review_mod.is_review_abandoned(state) is False
+
+    def test_record_without_pid_is_not_abandoned(self) -> None:
+        state = {"task_id": "task_01", "agents": [{"name": "claude", "status": "running"}]}
+        assert review_mod.is_review_abandoned(state) is False


### PR DESCRIPTION
## The premise was wrong in an important way

The report was "auto-review is enabled, fires, and has never once succeeded." Measured on the
same board (Marquee, `.lattice/.daemon/`, 283 per-task spawn logs — one per task per gate, each
overwritten per attempt):

| Outcome (last line of each log) | Count |
|---|---|
| **`Review stored as artifact … (role=review)`** | **222** |
| Killed mid-run — last line is `Running … (single mode)…`, no terminal line | 24 |
| `Review failed: Agent 'claude' timed out after 600s` | 20 |
| `Review failed: Agent 'claude': exited with code 1.` | 11 |
| `Error: Could not resolve a non-empty diff` | 6 |

Auto-fire works and produced 222 real review artifacts. `failures.jsonl` is likewise not
unread — `_handle_agent_failure` → `create_failure_diagnostic_task` filed **MRQ-147,
"Investigate claude review failures — failed 40 times"**, flagged `needs-human` and sitting in
that board's queue right now.

**The actual defect is narrower and worse: failure is invisible *on the task that failed*.**
The escalation is a global counter that names no task; the failing task gets no comment, no
flag, and the command exits **0**. So each broken task sat in `review` looking reviewed, and
the one aggregate ticket told nobody which 40 tasks to re-run.

Two more claims from the report also did not survive measurement:

- **Not every failure is a 600s timeout.** 29 timeouts, 19 `exit 1` (durations 1.8s–374s), one
  `exit 143`. A structural single cause was the wrong thing to look for.
- **Prompt size is not the cause of the timeouts.** I ran the real thing: same env-scrubbed
  `claude --dangerously-skip-permissions -p` invocation the harness builds, real capped diff
  from this repo. A **14,495-char prompt returned in 45s**; a **208,983-char prompt in 232s** —
  both `rc=0`, both wrote their output file. Meanwhile the board has 15,485- and
  18,959-char prompts that hit the full 600s. Headless `claude -p` is healthy; a small prompt
  taking 13× its measured cost points at contention (the operator was running 20+ reviewer
  agents in parallel), not at the mechanism.

Prompt size is still real, just as cost rather than cause: **5× wall-clock across that range**,
and `review_max_diff_lines: 5000` does not bound it — 5000 lines of a wide diff measured
205,964 chars here and up to **509,583 chars** in the field, because the cap counts lines and
lockfile/generated lines are enormous.

## Root cause

Three independent silences, one theme — **every failure path writes only to files nobody opens.**

1. **`_run_single_and_store` swallowed the failure.** `click.echo(..., err=True)` then
   `return None`, and the Click command exits **0**. For an auto-fired review that stderr goes
   into `.daemon/auto-{type}-{task}.log`, which is overwritten on the next spawn.
2. **A killed review leaves a record that says `running` forever.** Its process never reaches
   its own failure handler, so no terminal `status`, no `failures.jsonl` line — and
   `review-status` faithfully reports it as in flight. 24 such records on that board, some four
   days old.
3. **`auto_fired` was false on all 52 records.** Not a write-ordering bug: the child claims with
   `auto_fired=False` unless it can adopt the parent's claim, and adoption requires
   `existing["started_by_pid"] == os.getppid()`. The parent `Popen`s with
   `start_new_session=True` and exits immediately, so the detached child essentially never sees
   its parent alive. The branch is unreachable in practice and the record contradicts the
   `auto_review_spawned` event sitting next to it.

## What changed

- **A failed review exits non-zero**, and reports itself on the task: a `comment_added` event
  naming the error, the fact that no artifact exists, and the re-run command.
- **Auto-fired failures also raise `needs_human`.** A manual `lattice code-review` failure does
  not — its caller already sees the exit code. Nobody reads a detached subprocess's.
- **`review-status` reports `abandoned`** when the holder PID is dead and no terminal status was
  written (`is_review_abandoned`), instead of `running`.
- **`auto_fired` derives from `--triggered-by`**, which only the auto-fire path passes, so it
  survives the parent→child handoff.
- **`review_max_diff_chars` (default 120,000)** caps the prompt by characters after the line cap.
- The failure report names the command that failed instead of always saying `lattice code-review`.

No new files, daemons, or schema version. Every signal lands on a surface agents already read.

## Verification

**Tests go red on the current code.** Reverting `src/` and re-running: **19 failed, 86 passed.**
Positive pairs are deliberate and pass both ways — success still exits 0 and leaves no failure
comment; a *live* holder PID still reports `running`; a manual claim is still `auto_fired: false`;
a small diff is still untruncated. Full suite: **2212 passed**, ruff clean.

I also tightened a pre-existing assertion that let this ship:
`assert result.exit_code != 0 or "failed" in result.output` — green on an exit-0 failure.

**Real-artifact smoke test**, not mocks: a fresh board in a real git repo, the worktree's own
`lattice` on `PATH`, `review_timeout_seconds: 1` to force a genuine agent timeout, then
`lattice status <task> review` to let auto-fire spawn the real detached subprocess:

```
NEEDS HUMAN (by agent:lattice-auto-review): Auto-fired code-review failed
  (Agent 'claude' timed out after 1s) — task is unreviewed.
Events: needs_human_flagged / comment_added "Automated review failed: code-review — …"
lattice list --needs-human  →  SMK-1  review  … [needs human: … task is unreviewed.]
review_state: "auto_fired": true
manual `lattice code-review` on the same board  →  EXIT=1, comment, no flag
seeded dead holder PID  →  "the review was abandoned, not completed"
```

## Not addressed

The **contention** behind the 600s timeouts — small prompts taking 13× their isolated cost while
20+ agents ran in parallel — is real and out of scope here. This PR makes it *loud*: those runs
now flag their tasks instead of vanishing. Worth its own ticket once there is signal to work from.
