### PR TITLE
replay: a legacy empty-list from matches an unset field

### DIFF
--- a/src/lattice/core/tasks.py
+++ b/src/lattice/core/tasks.py
@@ -282,6 +282,20 @@ def _mut_assignment_changed(snap: dict, event: dict) -> None:
     snap["assigned_to"] = data["to"]
 
 
+def _from_matches(recorded, current) -> bool:
+    """Does a field_updated event's recorded ``from`` match the replayed state?
+
+    Legacy allowance: writers before LAT-264's strict replay recorded ``from: []``
+    for list fields that had never been initialized (the write-time snapshot
+    defaulted them to ``[]``; raw replay leaves them absent, i.e. ``None``).
+    115 of the acetate board's 1020 task logs carry that shape, so an unset
+    field and an empty list are accepted as the same starting state.
+    """
+    if recorded == current:
+        return True
+    return recorded == [] and current is None
+
+
 @_register_mutation("field_updated")
 def _mut_field_updated(snap: dict, event: dict) -> None:
     data = event["data"]
@@ -290,7 +304,7 @@ def _mut_field_updated(snap: dict, event: dict) -> None:
     if field.startswith("custom_fields."):
         key = field[len("custom_fields.") :]
         current = (snap.get("custom_fields") or {}).get(key)
-        if "from" in data and data["from"] != current:
+        if "from" in data and not _from_matches(data["from"], current):
             raise ValueError(
                 "field_updated from value does not match authoritative state: "
                 f"expected {current!r}, got {data['from']!r}"
@@ -304,7 +318,7 @@ def _mut_field_updated(snap: dict, event: dict) -> None:
             "Use the dedicated command (e.g., status, assign) instead."
         )
     else:
-        if "from" in data and data["from"] != snap.get(field):
+        if "from" in data and not _from_matches(data["from"], snap.get(field)):
             raise ValueError(
                 "field_updated from value does not match authoritative state: "
                 f"expected {snap.get(field)!r}, got {data['from']!r}"

--- a/tests/test_core/test_tasks.py
+++ b/tests/test_core/test_tasks.py
@@ -343,6 +343,55 @@ class TestFieldUpdated:
         with pytest.raises(ValueError, match="field_updated from value"):
             apply_event_to_snapshot(snap, ev)
 
+    def test_legacy_empty_list_from_matches_unset_field(self) -> None:
+        # Writers before LAT-264's strict replay recorded ``from: []`` for list
+        # fields the snapshot had never initialized (unset -> ``None`` on raw
+        # replay). Such historical logs must still materialize.
+        snap = _make_snapshot()
+        snap.pop("tags", None)  # a task_created that never carried tags
+        ev = {
+            "schema_version": 1,
+            "id": _EV_2,
+            "ts": _TS_2,
+            "type": "field_updated",
+            "task_id": _TASK_ID,
+            "actor": _ACTOR,
+            "data": {"field": "tags", "from": [], "to": ["triage-fold"]},
+        }
+        snap = apply_event_to_snapshot(snap, ev)
+        assert snap["tags"] == ["triage-fold"]
+
+    def test_legacy_empty_list_from_matches_unset_custom_field(self) -> None:
+        snap = _make_snapshot()
+        ev = {
+            "schema_version": 1,
+            "id": _EV_2,
+            "ts": _TS_2,
+            "type": "field_updated",
+            "task_id": _TASK_ID,
+            "actor": _ACTOR,
+            "data": {"field": "custom_fields.watchers", "from": [], "to": ["a"]},
+        }
+        snap = apply_event_to_snapshot(snap, ev)
+        assert snap["custom_fields"]["watchers"] == ["a"]
+
+    def test_empty_list_from_still_rejected_against_real_value(self) -> None:
+        # The allowance is only for unset (None); a populated field keeps the
+        # strict check.
+        snap = _make_snapshot()
+        snap["tags"] = ["existing"]
+        ev = {
+            "schema_version": 1,
+            "id": _EV_2,
+            "ts": _TS_2,
+            "type": "field_updated",
+            "task_id": _TASK_ID,
+            "actor": _ACTOR,
+            "data": {"field": "tags", "from": [], "to": ["new"]},
+        }
+        with pytest.raises(ValueError, match="field_updated from value"):
+            apply_event_to_snapshot(snap, ev)
+
     def test_custom_fields_dot_notation(self) -> None:
         snap = _make_snapshot()
         ev = {


### PR DESCRIPTION
replay: a legacy empty-list `from` matches an unset field

LAT-264 made field_updated replay strict, and 115 of the acetate board's
1020 task logs stopped materializing — every one with the same signature:
`expected None, got []`. Writers before the strict check recorded
`from: []` for list fields the snapshot had never initialized (the
write-time view defaulted them; raw replay leaves them absent). Those
events are historical fact now, so replay accepts that one shape:
a recorded `[]` against an authoritative None. A populated field keeps
the strict check, both for named fields and custom_fields.

Verified against the real board: all 1020 acetate task logs materialize
with this change; 115 failed without it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GR7VwMyYZvHUsmJ79W3M5S
